### PR TITLE
feat: SVGIcon component

### DIFF
--- a/packages/react-styled-core/src/SVGIcon/index.js
+++ b/packages/react-styled-core/src/SVGIcon/index.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { forwardRef } from "react";
+import Box from '../Box';
+
+const SVGIconBase = styled(Box)`
+  fill: currentColor;
+  flex-shrink: 0;
+  backface-visibility: hidden;
+  &:not(:root) {
+    overflow: hidden;
+  }
+`;
+
+const SVGIcon = forwardRef(
+  (
+    {
+      children,
+      size = '1em',
+      name,
+      color = 'currentColor',
+      role = 'presentation',
+      focusable = false,
+      viewBox = '0 0 24 24',
+      ...rest
+    },
+    ref,
+  ) => {
+    return (
+      <SVGIconBase
+        ref={ref}
+        as="svg"
+        size={size}
+        color={color}
+        display="inline-block"
+        verticalAlign="middle"
+        viewBox={viewBox}
+        focusable={focusable}
+        role={role}
+        {...rest}
+      >
+        {children}
+      </SVGIconBase>
+    );
+  },
+);
+
+SVGIcon.displayName = 'SVGIcon';
+
+export default SVGIcon;

--- a/packages/react-styled-core/src/index.js
+++ b/packages/react-styled-core/src/index.js
@@ -7,6 +7,7 @@ import Heading from './Heading';
 import Image from './Image';
 import Link from './Link';
 import PseudoBox from './PseudoBox';
+import SVGIcon from './SVGIcon';
 import Text from './Text';
 import ThemeProvider from './ThemeProvider';
 import theme from './theme';
@@ -24,6 +25,7 @@ export {
   Image,
   Link,
   PseudoBox,
+  SVGIcon,
   Text,
   ThemeProvider,
   theme,

--- a/packages/styled-docs/components/HomeIcon.jsx
+++ b/packages/styled-docs/components/HomeIcon.jsx
@@ -1,0 +1,13 @@
+import { SVGIcon } from '@trendmicro/react-styled-core';
+
+const HomeIcon = (props) => (
+  <SVGIcon
+    fontSize="1.5rem"
+    mx="1rem"
+    {...props}
+  >
+    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+  </SVGIcon>
+);
+
+export default HomeIcon;

--- a/packages/styled-docs/pages/box.mdx
+++ b/packages/styled-docs/pages/box.mdx
@@ -1,5 +1,3 @@
-import { Box } from '@trendmicro/react-styled-core';
-
 # Box
 
 The Box component serves as a wrapper component for most of the CSS utility needs.

--- a/packages/styled-docs/pages/link.mdx
+++ b/packages/styled-docs/pages/link.mdx
@@ -1,5 +1,3 @@
-import { Link } from '@trendmicro/react-styled-core';
-
 # Link
 
 Links are accessible elements used primarily for navigation. This component is styled to resemble a hyperlink and semantically renders an `<a />`.

--- a/packages/styled-docs/pages/pseudobox.mdx
+++ b/packages/styled-docs/pages/pseudobox.mdx
@@ -1,5 +1,3 @@
-import { PseudoBox } from '@trendmicro/react-styled-core';
-
 # PesudoBox
 
 ## Import

--- a/packages/styled-docs/pages/svgicon.mdx
+++ b/packages/styled-docs/pages/svgicon.mdx
@@ -1,0 +1,65 @@
+import HomeIcon from '../components/HomeIcon';
+
+# SVGIcon
+
+If you need a custom SVG icon, you can use the `<SVGIcon>` component to extend the native `<svg>` element:
+
+* It comes with built-in accessibility.
+* SVG elements should be scaled for a 24x24px viewport.
+* By default, the component inherits the current color.
+
+## Import
+
+```js
+import SVGIcon from '@trendmicro/react-styled-core/SVGIcon';
+// or
+import { SVGIcon } from '@trendmicro/react-styled-core';
+```
+
+## Usage
+
+```jsx readonly
+const HomeIcon = props => (
+  <SVGIcon
+    fontSize="1.5rem"
+    mx="1rem"
+    {...props}
+  >
+    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+  </SVGIcon>
+);
+```
+
+### Color
+
+<HomeIcon color="gray.50" />
+<HomeIcon color="red.50" />
+<HomeIcon color="green.50" />
+<HomeIcon color="blue.50" />
+
+```jsx readonly
+<HomeIcon color="gray.50" />
+<HomeIcon color="red.50" />
+<HomeIcon color="green.50" />
+<HomeIcon color="blue.50" />
+```
+
+### Size
+
+<HomeIcon fontSize="xs" />
+<HomeIcon fontSize="sm" />
+<HomeIcon fontSize="lg" />
+<HomeIcon fontSize="xl" />
+<HomeIcon fontSize="2xl" />
+<HomeIcon fontSize="3xl" />
+<HomeIcon fontSize="4xl" />
+
+```jsx readonly
+<HomeIcon fontSize="xs" />
+<HomeIcon fontSize="sm" />
+<HomeIcon fontSize="lg" />
+<HomeIcon fontSize="xl" />
+<HomeIcon fontSize="2xl" />
+<HomeIcon fontSize="3xl" />
+<HomeIcon fontSize="4xl" />
+```

--- a/packages/styled-docs/shared/components.js
+++ b/packages/styled-docs/shared/components.js
@@ -28,6 +28,7 @@ const components = [
   'Radio',
   'RadioGroup',
   'Select',
+  'SVGIcon',
   'Switch',
   'Tag',
   'Text',


### PR DESCRIPTION
# SVGIcon

If you need a custom SVG icon, you can use the `<SVGIcon>` component to extend the native `<svg>` element:

* It comes with built-in accessibility.
* SVG elements should be scaled for a 24x24px viewport.
* By default, the component inherits the current color.

## Import

```js
import SVGIcon from '@trendmicro/react-styled-core/SVGIcon';
// or
import { SVGIcon } from '@trendmicro/react-styled-core';
```

## Usage

```jsx
const ArrowUpIcon = props => (
  <SVGIcon {...props}>
    <path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z" />
  </SVGIcon>
);
```

### Color

```jsx
<ArrowUpIcon color="gray.50" />
<ArrowUpIcon color="whiteAlpha.primary" />
<ArrowUpIcon color="blackAlpha.primary" />
```

### Font size

```jsx
<ArrowUpIcon fontSize="md" />
<ArrowUpIcon fontSize="lg" />
```