### PR TITLE
Update docs and API for SVGIcon

### DIFF
--- a/packages/react-styled-core/src/SVGIcon/index.js
+++ b/packages/react-styled-core/src/SVGIcon/index.js
@@ -4,7 +4,6 @@ import { forwardRef } from "react";
 import Box from '../Box';
 
 const SVGIconBase = styled(Box)`
-  fill: currentColor;
   flex-shrink: 0;
   backface-visibility: hidden;
   &:not(:root) {
@@ -17,7 +16,6 @@ const SVGIcon = forwardRef(
     {
       children,
       size = '1em',
-      name,
       color = 'currentColor',
       role = 'presentation',
       focusable = false,
@@ -28,6 +26,7 @@ const SVGIcon = forwardRef(
   ) => {
     return (
       <SVGIconBase
+        aria-hidden={true}
         ref={ref}
         as="svg"
         size={size}

--- a/packages/styled-docs/components/HomeIcon.jsx
+++ b/packages/styled-docs/components/HomeIcon.jsx
@@ -3,10 +3,12 @@ import { SVGIcon } from '@trendmicro/react-styled-core';
 const HomeIcon = (props) => (
   <SVGIcon
     fontSize="1.5rem"
-    mx="1rem"
+    mx=".75rem"
     {...props}
   >
-    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+    <g fill="currentColor">
+      <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+    </g>
   </SVGIcon>
 );
 

--- a/packages/styled-docs/pages/svgicon.mdx
+++ b/packages/styled-docs/pages/svgicon.mdx
@@ -6,7 +6,6 @@ If you need a custom SVG icon, you can use the `<SVGIcon>` component to extend t
 
 * It comes with built-in accessibility.
 * SVG elements should be scaled for a 24x24px viewport.
-* By default, the component inherits the current color.
 
 ## Import
 
@@ -18,14 +17,18 @@ import { SVGIcon } from '@trendmicro/react-styled-core';
 
 ## Usage
 
+You can use the current text color by adding the `fill=currentColor` attribute to the `<path>` or `<g>` element. This means that the fill color of the SVG will be inherited from the color value of its parent.
+
 ```jsx readonly
 const HomeIcon = props => (
   <SVGIcon
     fontSize="1.5rem"
-    mx="1rem"
+    mx=".75rem"
     {...props}
   >
-    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+    <g fill="currentColor">
+      <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+    </g>
   </SVGIcon>
 );
 ```

--- a/packages/styled-docs/pages/svgicon.mdx
+++ b/packages/styled-docs/pages/svgicon.mdx
@@ -17,7 +17,7 @@ import { SVGIcon } from '@trendmicro/react-styled-core';
 
 ## Usage
 
-You can use the current text color by adding the `fill=currentColor` attribute to the `<path>` or `<g>` element. This means that the fill color of the SVG will be inherited from the color value of its parent.
+You can use the current text color by adding the `fill="currentColor"` attribute to the `<path>` or `<g>` element. This means that the fill color of the SVG will be inherited from the color value of its parent.
 
 ```jsx readonly
 const HomeIcon = props => (


### PR DESCRIPTION
#### What's Changed
Use the current text color by adding the `fill="currentColor"` attribute to the `<path>` or `<g>` element. This means that the fill color of the SVG will be inherited from the color value of its parent.
