### PR TITLE
feat: add initial standalone badge

### DIFF
--- a/packages/react-styled-core/src/Badge/index.js
+++ b/packages/react-styled-core/src/Badge/index.js
@@ -3,8 +3,8 @@ import Box from '../Box';
 import { forwardRef } from 'react';
 
 const Badge = forwardRef(
-  ({ variantColor = 'gray', variant = 'gray', ...props }, ref) => {
-    const badgeStyleProps = useBadgeStyle({ color: variantColor, variant });
+  ({ variant = 'gray', ...props }, ref) => {
+    const badgeStyleProps = useBadgeStyle({ variant });
 
     return (
       <Box

--- a/packages/react-styled-core/src/Badge/index.js
+++ b/packages/react-styled-core/src/Badge/index.js
@@ -3,8 +3,8 @@ import useBadgeStyle from './styles';
 import Box from '../Box';
 
 const Badge = forwardRef(
-  ({ variant = 'gray', ...props }, ref) => {
-    const badgeStyleProps = useBadgeStyle({ variant });
+  ({ variantColor = 'gray', ...props }, ref) => {
+    const badgeStyleProps = useBadgeStyle({ color: variantColor });
 
     return (
       <Box

--- a/packages/react-styled-core/src/Badge/index.js
+++ b/packages/react-styled-core/src/Badge/index.js
@@ -1,6 +1,6 @@
+import React, { forwardRef } from 'react';
 import useBadgeStyle from './styles';
 import Box from '../Box';
-import { forwardRef } from 'react';
 
 const Badge = forwardRef(
   ({ variant = 'gray', ...props }, ref) => {

--- a/packages/react-styled-core/src/Badge/index.js
+++ b/packages/react-styled-core/src/Badge/index.js
@@ -1,0 +1,29 @@
+import useBadgeStyle from './styles';
+import Box from '../Box';
+import { forwardRef } from 'react';
+
+const Badge = forwardRef(
+  ({ variantColor = 'gray', variant = 'gray', ...props }, ref) => {
+    const badgeStyleProps = useBadgeStyle({ color: variantColor, variant });
+
+    return (
+      <Box
+        ref={ref}
+        display="inline-block"
+        px="0.3rem"
+        textTransform="uppercase"
+        fontSize="xs"
+        borderRadius="sm"
+        fontWeight="bold"
+        whiteSpace="nowrap"
+        verticalAlign="middle"
+        {...badgeStyleProps}
+        {...props}
+      />
+    );
+  },
+);
+
+Badge.displayName = 'Badge';
+
+export default Badge;

--- a/packages/react-styled-core/src/Badge/styles.js
+++ b/packages/react-styled-core/src/Badge/styles.js
@@ -1,0 +1,124 @@
+import useColorMode from '../useColorMode';
+import useTheme from '../useTheme';
+
+const grayStyle = ({ colorMode }) => {
+  const style = {
+    light: {
+      bg: 'gray.60',
+      color: '#fff',
+      borderRadius: '0.75rem', //12px
+      minWidth: '1.125rem', //18px
+      height: '1.125rem',
+      textAlign: 'center',
+      lineHeight: '1.125rem',
+    },
+    dark: {
+      bg: 'gray.60',
+      color: '#fff',
+      borderRadius: '0.75rem', //12px
+      minWidth: '1.125rem', //18px
+      height: '1.125rem',
+      textAlign: 'center',
+      lineHeight: '1.125rem',
+    },
+  };
+  return style[colorMode];
+};
+
+const redStyle = ({ colorMode }) => {
+  const style = {
+    light: {
+      bg: 'red.60',
+      color: '#fff',
+      borderRadius: '0.75rem', //12px
+      minWidth: '1.125rem', //18px
+      height: '1.125rem',
+      textAlign: 'center',
+      lineHeight: '1.125rem',
+    },
+    dark: {
+      bg: 'red.60',
+      color: '#fff',
+      borderRadius: '0.75rem', //12px
+      minWidth: '1.125rem', //18px
+      height: '1.125rem',
+      textAlign: 'center',
+      lineHeight: '1.125rem',
+    },
+  };
+  return style[colorMode];
+};
+
+const greenStyle = ({ colorMode }) => {
+  const style = {
+    light: {
+      bg: 'green.60',
+      color: '#fff',
+      borderRadius: '0.75rem', //12px
+      minWidth: '1.125rem', //18px
+      height: '1.125rem',
+      textAlign: 'center',
+      lineHeight: '1.125rem',
+    },
+    dark: {
+      bg: 'green.60',
+      color: '#fff',
+      borderRadius: '0.75rem', //12px
+      minWidth: '1.125rem', //18px
+      height: '1.125rem',
+      textAlign: 'center',
+      lineHeight: '1.125rem',
+    },
+  };
+  return style[colorMode];
+};
+
+const blueStyle = ({ colorMode }) => {
+  const style = {
+    light: {
+      bg: 'blue.60',
+      color: '#fff',
+      borderRadius: '0.75rem', //12px
+      minWidth: '1.125rem', //18px
+      height: '1.125rem',
+      textAlign: 'center',
+      lineHeight: '1.125rem',
+    },
+    dark: {
+      bg: 'blue.60',
+      color: '#fff',
+      borderRadius: '0.75rem', //12px
+      minWidth: '1.125rem', //18px
+      height: '1.125rem',
+      textAlign: 'center',
+      lineHeight: '1.125rem',
+    },
+  };
+  return style[colorMode];
+};
+
+const variantProps = props => {
+  const { variant, colorMode } = props;
+  switch (variant) {
+    case 'gray':
+      return grayStyle(props);
+    case 'red':
+      return redStyle(props);
+    case 'green':
+      return greenStyle(props);
+    case 'blue':
+      return blueStyle(props);
+    default:
+      return {};
+  }
+};
+
+const useBadgeStyle = props => {
+  const theme = useTheme();
+  const { colorMode } = useColorMode();
+  const _props = { ...props, theme, colorMode };
+
+  return variantProps(_props);
+};
+
+export default useBadgeStyle;

--- a/packages/react-styled-core/src/Badge/styles.js
+++ b/packages/react-styled-core/src/Badge/styles.js
@@ -98,18 +98,18 @@ const blueStyle = ({ colorMode }) => {
 };
 
 const variantProps = props => {
-  const { variant, colorMode } = props;
+  const { variant } = props;
   switch (variant) {
-    case 'gray':
-      return grayStyle(props);
-    case 'red':
-      return redStyle(props);
-    case 'green':
-      return greenStyle(props);
-    case 'blue':
-      return blueStyle(props);
-    default:
-      return {};
+  case 'gray':
+    return grayStyle(props);
+  case 'red':
+    return redStyle(props);
+  case 'green':
+    return greenStyle(props);
+  case 'blue':
+    return blueStyle(props);
+  default:
+    return {};
   }
 };
 

--- a/packages/react-styled-core/src/Badge/styles.js
+++ b/packages/react-styled-core/src/Badge/styles.js
@@ -1,34 +1,12 @@
 import useColorMode from '../useColorMode';
 import useTheme from '../useTheme';
 
-const grayStyle = ({ colorMode }) => {
-  const style = {
-    light: {
-      bg: 'gray.60',
-      color: '#fff',
-      borderRadius: '0.75rem', //12px
-      minWidth: '1.125rem', //18px
-      height: '1.125rem',
-      textAlign: 'center',
-      lineHeight: '1.125rem',
-    },
-    dark: {
-      bg: 'gray.60',
-      color: '#fff',
-      borderRadius: '0.75rem', //12px
-      minWidth: '1.125rem', //18px
-      height: '1.125rem',
-      textAlign: 'center',
-      lineHeight: '1.125rem',
-    },
-  };
-  return style[colorMode];
-};
+const get = (color, hue) => `${color}.${hue}`;
 
-const redStyle = ({ colorMode }) => {
-  const style = {
+const badgeStyle = ({ color }) => {
+  return {
     light: {
-      bg: 'red.60',
+      bg: get(color, 60),
       color: '#fff',
       borderRadius: '0.75rem', //12px
       minWidth: '1.125rem', //18px
@@ -37,7 +15,7 @@ const redStyle = ({ colorMode }) => {
       lineHeight: '1.125rem',
     },
     dark: {
-      bg: 'red.60',
+      bg: get(color, 60),
       color: '#fff',
       borderRadius: '0.75rem', //12px
       minWidth: '1.125rem', //18px
@@ -46,71 +24,11 @@ const redStyle = ({ colorMode }) => {
       lineHeight: '1.125rem',
     },
   };
-  return style[colorMode];
-};
-
-const greenStyle = ({ colorMode }) => {
-  const style = {
-    light: {
-      bg: 'green.60',
-      color: '#fff',
-      borderRadius: '0.75rem', //12px
-      minWidth: '1.125rem', //18px
-      height: '1.125rem',
-      textAlign: 'center',
-      lineHeight: '1.125rem',
-    },
-    dark: {
-      bg: 'green.60',
-      color: '#fff',
-      borderRadius: '0.75rem', //12px
-      minWidth: '1.125rem', //18px
-      height: '1.125rem',
-      textAlign: 'center',
-      lineHeight: '1.125rem',
-    },
-  };
-  return style[colorMode];
-};
-
-const blueStyle = ({ colorMode }) => {
-  const style = {
-    light: {
-      bg: 'blue.60',
-      color: '#fff',
-      borderRadius: '0.75rem', //12px
-      minWidth: '1.125rem', //18px
-      height: '1.125rem',
-      textAlign: 'center',
-      lineHeight: '1.125rem',
-    },
-    dark: {
-      bg: 'blue.60',
-      color: '#fff',
-      borderRadius: '0.75rem', //12px
-      minWidth: '1.125rem', //18px
-      height: '1.125rem',
-      textAlign: 'center',
-      lineHeight: '1.125rem',
-    },
-  };
-  return style[colorMode];
 };
 
 const variantProps = props => {
-  const { variant } = props;
-  switch (variant) {
-  case 'gray':
-    return grayStyle(props);
-  case 'red':
-    return redStyle(props);
-  case 'green':
-    return greenStyle(props);
-  case 'blue':
-    return blueStyle(props);
-  default:
-    return {};
-  }
+  const { colorMode } = props;
+  return badgeStyle(props)[colorMode];
 };
 
 const useBadgeStyle = props => {

--- a/packages/react-styled-core/src/index.js
+++ b/packages/react-styled-core/src/index.js
@@ -1,3 +1,4 @@
+import Badge from './Badge';
 import Box from './Box';
 import Button from './Button';
 import Collapse from './Collapse';
@@ -18,6 +19,7 @@ import useTheme from './useTheme';
 import withTheme from './withTheme';
 
 export {
+  Badge,
   Box,
   Button,
   Collapse,

--- a/packages/styled-docs/pages/badge.mdx
+++ b/packages/styled-docs/pages/badge.mdx
@@ -18,9 +18,11 @@ import { Badge } from '@trendmicro/react-styled-core';
 
 ### Badge Color
 
-Pass the `variantColor` prop to customize the color of the Badge. `variantColor`
-can be any **color key with key 50** that exists in the `theme.colors`. (Ex: green.50 exists then can use variantColor="green" prop)
-[Learn more about theming](./theming).
+* Pass the `variantColor` prop to customize the color of the Badge. `variantColor`
+can be any **color key with key 50** that exists in the `theme.colors`.
+  > Thats mean the `green.50` exists in the `theme.colors` then can use variantColor="green".
+
+* [Learn more about theming](./theme).
 
 ```jsx
 <div>

--- a/packages/styled-docs/pages/badge.mdx
+++ b/packages/styled-docs/pages/badge.mdx
@@ -1,0 +1,68 @@
+# Badge
+
+Badges are used to highlight an item's status for quick recognition.
+
+## Import
+
+```js
+import { Badge } from "@chakra-ui/core";
+```
+
+## Usage
+
+```jsx
+<Badge>1</Badge>
+```
+
+### Badge Color
+
+Pass the `variantColor` prop to customize the color of the Badge. `variantColor`
+can be any **color key** that exists in the `theme.colors`.
+[Learn more about theming](./theming).
+
+```jsx
+<div>
+  <Badge>1</Badge>
+  <Badge variant="green">2</Badge>
+  <Badge variant="red">3</Badge>
+  <Badge variant="blue">4</Badge>
+</div>
+```
+
+### Badge Variants
+
+Pass the variant prop and set to either `subtle`, `solid`, or `outline` to get a
+different style.
+
+```jsx
+<div>
+  <Badge variant="gray">
+    1
+  </Badge>
+  <Badge variant="red">
+    2
+  </Badge>
+  <Badge variant="green">
+    3
+  </Badge>
+</div>
+```
+
+You can also change the size of the badge by passing `fontSize` prop.
+
+```jsx
+<Text fontSize="xl" fontWeight="bold">
+  Trend Micro Frontend
+  <Badge ml="1" fontSize="0.8em" variant="green">
+    New
+  </Badge>
+</Text>
+```
+
+## Props
+
+The Badge component composes `Box` component so you can pass props for `Box`.
+
+| Name           | Type                         | Default  | Description                                                            |
+| -------------- | ---------------------------- | -------- | ---------------------------------------------------------------------- |
+| `variant`      | `gray`, `red`, `green`, `blue` | `gray` | The style variant of the badge                                         |

--- a/packages/styled-docs/pages/badge.mdx
+++ b/packages/styled-docs/pages/badge.mdx
@@ -5,7 +5,9 @@ Badges are used to highlight an item's status for quick recognition.
 ## Import
 
 ```js
-import { Badge } from "@chakra-ui/core";
+import Badge from '@trendmicro/react-styled-core/Collapse';
+// or
+import { Badge } from '@trendmicro/react-styled-core';
 ```
 
 ## Usage

--- a/packages/styled-docs/pages/badge.mdx
+++ b/packages/styled-docs/pages/badge.mdx
@@ -5,7 +5,7 @@ Badges are used to highlight an item's status for quick recognition.
 ## Import
 
 ```js
-import Badge from '@trendmicro/react-styled-core/Collapse';
+import Badge from '@trendmicro/react-styled-core/Badge';
 // or
 import { Badge } from '@trendmicro/react-styled-core';
 ```

--- a/packages/styled-docs/pages/badge.mdx
+++ b/packages/styled-docs/pages/badge.mdx
@@ -19,7 +19,7 @@ import { Badge } from '@trendmicro/react-styled-core';
 ### Badge Color
 
 * Pass the `variantColor` prop to customize the color of the Badge. `variantColor`
-can be any **color key with key 50** that exists in the `theme.colors`.
+can be any **color key with key 60** that exists in the `theme.colors`.
   > Thats mean the `green.50` exists in the `theme.colors` then can use variantColor="green".
 
 * [Learn more about theming](./theme).

--- a/packages/styled-docs/pages/badge.mdx
+++ b/packages/styled-docs/pages/badge.mdx
@@ -11,7 +11,7 @@ import { Badge } from "@chakra-ui/core";
 ## Usage
 
 ```jsx
-<Badge>1</Badge>
+<Badge>100</Badge>
 ```
 
 ### Badge Color
@@ -23,28 +23,13 @@ can be any **color key** that exists in the `theme.colors`.
 ```jsx
 <div>
   <Badge>1</Badge>
-  <Badge variant="green">2</Badge>
-  <Badge variant="red">3</Badge>
-  <Badge variant="blue">4</Badge>
-</div>
-```
-
-### Badge Variants
-
-Pass the variant prop and set to either `subtle`, `solid`, or `outline` to get a
-different style.
-
-```jsx
-<div>
-  <Badge variant="gray">
-    1
-  </Badge>
-  <Badge variant="red">
-    2
-  </Badge>
-  <Badge variant="green">
-    3
-  </Badge>
+  <Badge variantColor="green">2</Badge>
+  <Badge variantColor="red">3</Badge>
+  <Badge variantColor="blue">4</Badge>
+  <Badge variantColor="magenta">5</Badge>
+  <Badge variantColor="purple">6</Badge>
+  <Badge variantColor="teal">7</Badge>
+  <Badge variantColor="cyan">8</Badge>
 </div>
 ```
 
@@ -53,7 +38,7 @@ You can also change the size of the badge by passing `fontSize` prop.
 ```jsx
 <Text fontSize="xl" fontWeight="bold">
   Trend Micro Frontend
-  <Badge ml="1" fontSize="0.8em" variant="green">
+  <Badge ml="1" fontSize="0.8em" variantColor="green">
     New
   </Badge>
 </Text>
@@ -65,4 +50,4 @@ The Badge component composes `Box` component so you can pass props for `Box`.
 
 | Name           | Type                         | Default  | Description                                                            |
 | -------------- | ---------------------------- | -------- | ---------------------------------------------------------------------- |
-| `variant`      | `gray`, `red`, `green`, `blue` | `gray` | The style variant of the badge                                         |
+| `variantColor`      | string | `gray` | The color scheme to use for the badge. Must be a key in theme.colors                                         |

--- a/packages/styled-docs/pages/badge.mdx
+++ b/packages/styled-docs/pages/badge.mdx
@@ -19,7 +19,7 @@ import { Badge } from '@trendmicro/react-styled-core';
 ### Badge Color
 
 Pass the `variantColor` prop to customize the color of the Badge. `variantColor`
-can be any **color key** that exists in the `theme.colors`.
+can be any **color key with key 50** that exists in the `theme.colors`. (Ex: green.50 exists then can use variantColor="green" prop)
 [Learn more about theming](./theming).
 
 ```jsx


### PR DESCRIPTION
如同今天跟 @joshuatai 等人開會結論

會請Designer將 Badge display: absolute的使用情境列出

這個就先做 Standalone
![螢幕快照 2020-02-07 上午11 04 24](https://user-images.githubusercontent.com/8485590/73997559-cc062480-4999-11ea-8567-d2ece9898e7d.png)
