### PR TITLE
feat: Space component

### DIFF
--- a/packages/react-styled-core/src/Space/index.js
+++ b/packages/react-styled-core/src/Space/index.js
@@ -1,0 +1,14 @@
+import React, { forwardRef } from 'react';
+import Box from '../Box';
+
+const Space = forwardRef((props, ref) => (
+  <Box
+    ref={ref}
+    display="inline-block"
+    {...props}
+  />
+));
+
+Space.displayName = 'Space';
+
+export default Space;

--- a/packages/react-styled-core/src/index.js
+++ b/packages/react-styled-core/src/index.js
@@ -10,6 +10,7 @@ import Icon from './Icon';
 import Image from './Image';
 import Link from './Link';
 import PseudoBox from './PseudoBox';
+import Space from './Space';
 import Stack from './Stack';
 import SVGIcon from './SVGIcon';
 import Text from './Text';
@@ -32,6 +33,7 @@ export {
   Image,
   Link,
   PseudoBox,
+  Space,
   Stack,
   SVGIcon,
   Text,

--- a/packages/styled-docs/components/TMIcon.jsx
+++ b/packages/styled-docs/components/TMIcon.jsx
@@ -1,5 +1,5 @@
 import { keyframes } from '@emotion/core';
-import { Box, useColorMode } from '@trendmicro/react-styled-core';
+import { Box } from '@trendmicro/react-styled-core';
 import cx from 'classnames';
 import React from 'react';
 

--- a/packages/styled-docs/components/TMIcon.jsx
+++ b/packages/styled-docs/components/TMIcon.jsx
@@ -25,25 +25,20 @@ const TMIcon = React.forwardRef(({
   spin,
   spinReverse,
   fontSize = 'md',
+  lineHeight = 'md',
   className,
   name,
   ...props
 }, ref) => {
-  const { colorMode } = useColorMode();
-  const color = {
-    light: '#666666',
-    dark: '#bbbbbb',
-  }[colorMode];
-
   return (
     <Box
       ref={ref}
       as="i"
       name={name}
       className={cx(className, 'tmicon', { [`tmicon-${name}`]: !!name })}
-      color={color}
       display="inline-block"
       fontSize={fontSize}
+      lineHeight={lineHeight}
       verticalAlign="top"
       animation={
         (spin && `${spinKeyframes} 2s infinite linear`) ||

--- a/packages/styled-docs/pages/space.mdx
+++ b/packages/styled-docs/pages/space.mdx
@@ -1,6 +1,6 @@
 # Space
 
-Space is [Box](./box) with `display="inline-block"`. You can specify either `width` or `height` to add space between elements.
+Space is [Box](./box) with `display="inline-block"`. You can specify either `width` or `height` to add space between two elements.
 
 ## Import
 

--- a/packages/styled-docs/pages/space.mdx
+++ b/packages/styled-docs/pages/space.mdx
@@ -12,7 +12,7 @@ import { Space } from '@trendmicro/react-styled-core';
 
 ## Usage
 
-### Horizontal space
+### Horizontal spacing
 
 ```jsx
 <Stack direction="row">
@@ -22,7 +22,7 @@ import { Space } from '@trendmicro/react-styled-core';
 </Stack>
 ```
 
-### Vertical space
+### Vertical spacing
 
 ```jsx
 <Stack direction="column">

--- a/packages/styled-docs/pages/space.mdx
+++ b/packages/styled-docs/pages/space.mdx
@@ -1,0 +1,33 @@
+# Space
+
+Space is [Box](./box) with `display="inline-block"`. You can specify either `width` or `height` to add space between elements.
+
+## Import
+
+```js
+import Space from '@trendmicro/react-styled-core/Space';
+// or
+import { Space } from '@trendmicro/react-styled-core';
+```
+
+## Usage
+
+### Horizontal space
+
+```jsx
+<Stack direction="row">
+  <TMIcon name="add" />
+  <Space width=".5rem" />
+  <Text>New</Text>
+</Stack>
+```
+
+### Vertical space
+
+```jsx
+<Stack direction="column">
+  <TMIcon name="add" />
+  <Space height=".5rem" />
+  <Text>New</Text>
+</Stack>
+```

--- a/packages/styled-docs/shared/components.js
+++ b/packages/styled-docs/shared/components.js
@@ -28,6 +28,7 @@ const components = [
   'Radio',
   'RadioGroup',
   'Select',
+  'Space',
   'Stack',
   'SVGIcon',
   'Switch',


### PR DESCRIPTION
A semantic component for spacing

# Space

Space is [Box](./box) with `display="inline-block"`. You can specify either `width` or `height` to add space between elements.

## Import

```js
import Space from '@trendmicro/react-styled-core/Space';
// or
import { Space } from '@trendmicro/react-styled-core';
```

## Usage

### Horizontal spacing

![image](https://user-images.githubusercontent.com/447801/74127773-8b670f00-4c16-11ea-9bfa-311b6f2c6db2.png)

```jsx
<Stack direction="row">
  <TMIcon name="add" />
  <Space width=".5rem" />
  <Text>New</Text>
</Stack>
```

### Vertical spacing

![image](https://user-images.githubusercontent.com/447801/74127821-a20d6600-4c16-11ea-8968-c099c43d5c43.png)

```jsx
<Stack direction="column">
  <TMIcon name="add" />
  <Space height=".5rem" />
  <Text>New</Text>
</Stack>
```
