### PR TITLE
improvement: remove variant from Link and update docs

### DIFF
--- a/packages/react-styled-core/src/Link/index.js
+++ b/packages/react-styled-core/src/Link/index.js
@@ -16,7 +16,6 @@ const baseStyleProps = (colorMode) => {
     textDecoration: 'none',
     _disabled: {
       color: disabledColor,
-      textDecoration: textDecoration,
       cursor: 'not-allowed',
     },
     _visited: {

--- a/packages/react-styled-core/src/Link/index.js
+++ b/packages/react-styled-core/src/Link/index.js
@@ -3,18 +3,17 @@ import PropTypes from 'prop-types';
 import PseudoBox from '../PseudoBox';
 import useColorMode from '../useColorMode';
 
-const baseStyleProps = (colorMode, variant) => {
+const baseStyleProps = (colorMode) => {
   const color = { light: 'blue.60', dark: 'blue.40' }[colorMode];
   const hoverColor = { light: 'blue.50', dark: 'blue.40' }[colorMode];
   const visitedColor = { light: 'purple.60', dark: 'purple.50' }[colorMode];
   const disabledColor = { light: 'blackAlpha.disabled', dark: 'whiteAlpha.disabled' }[colorMode];
-  const textDecoration = variant === 'underline' ? 'underline' : 'none';
 
   return {
-    color: color,
+    color,
     cursor: 'pointer',
-    textDecoration: textDecoration,
     outline: 'none',
+    textDecoration: 'none',
     _disabled: {
       color: disabledColor,
       textDecoration: textDecoration,
@@ -43,7 +42,7 @@ const Link = forwardRef(({ disabled, onClick, ...props }, ref) => {
       ref={ref}
       aria-disabled={disabled}
       onClick={disabled ? event => event.preventDefault() : onClick}
-      {...baseStyleProps(colorMode, props.variant)}
+      {...baseStyleProps(colorMode)}
       {...props}
     />
   );
@@ -52,8 +51,9 @@ const Link = forwardRef(({ disabled, onClick, ...props }, ref) => {
 Link.propTypes = {
   variant: PropTypes.string,
   disabled: PropTypes.bool,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
 };
 
 Link.displayName = 'Link';
+
 export default Link;

--- a/packages/styled-docs/pages/link.mdx
+++ b/packages/styled-docs/pages/link.mdx
@@ -1,6 +1,6 @@
 # Link
 
-Links are accessible elements used primarily for navigation. This component is styled to resemble a hyperlink and semantically renders an `<a />`.
+Links are accessible elements used primarily for navigation. This component is styled to resemble a hyperlink and semantically renders an `<a>`.
 
 ## Import
 
@@ -12,37 +12,53 @@ import { Link } from '@trendmicro/react-styled-core';
 
 ## Usage
 
-### Link with `href` attribute
-
 ```jsx
-<Link
-  fontSize="sm"
-  href="https://github.com/trendmicro-frontend"
->
-  Trend Micro Frontend
-</Link>
+<Stack direction="column" spacing=".5rem">
+  <Link href="https://github.com/trendmicro-frontend" fontSize="xs" lineHeight="xs">
+    Trend Micro Frontend
+  </Link>
+  <Link href="https://github.com/trendmicro-frontend" fontSize="sm" lineHeight="sm">
+    Trend Micro Frontend
+  </Link>
+  <Link href="https://github.com/trendmicro-frontend" fontSize="md" lineHeigh="md">
+    Trend Micro Frontend
+  </Link>
+  <Link href="https://github.com/trendmicro-frontend" fontSize="lg" lineHeight="lg">
+    Trend Micro Frontend
+  </Link>
+  <Link href="https://github.com/trendmicro-frontend" fontSize="xl" lineHeight="xl">
+    Trend Micro Frontend
+  </Link>
+</Stack>
 ```
 
 ### Link without `href` attribute
 
 ```jsx
-<Link
-  fontSize="sm"
-  onClick={() => {
-    console.log('clicked');
-  }}
->
-  Click Me
-</Link>
+function Example() {
+  const [value, setValue] = React.useState(0);
+
+  return (
+    <>
+      <Link
+        onClick={() => {
+          setValue(value => value + 1);
+        }}
+      >
+        Click Me
+      </Link>
+      <Box>Count: {value}</Box>
+    </>
+  );
+}
 ```
 
-### Variant: underline
+### An underlined link
 
 ```jsx
 <Link
-  fontSize="sm"
   href="https://github.com/trendmicro-frontend"
-  variant="underline"
+  textDecoration="underline"
 >
   Trend Micro Frontend
 </Link>
@@ -52,7 +68,6 @@ import { Link } from '@trendmicro/react-styled-core';
 
 ```jsx
 <Link
-  fontSize="sm"
   href="https://github.com/trendmicro-frontend"
   disabled
 >
@@ -64,7 +79,6 @@ import { Link } from '@trendmicro/react-styled-core';
 
 ```jsx
 <Link
-  fontSize="sm"
   href="https://github.com/trendmicro-frontend"
   target="_blank"
   rel="noopener noreferrer"
@@ -73,7 +87,7 @@ import { Link } from '@trendmicro/react-styled-core';
 </Link>
 ```
 
-You can also create a `<ExternalLink />` component for convenience of use:
+You can also create a `<ExternalLink>` component for convenience of use:
 
 ```jsx noInline
 const ExternalLink = React.forwardRef((props, ref) => (
@@ -96,8 +110,7 @@ render(
 
 The link component composes the [PseudoBox](./PseudoBox) component.
 
-| Name          | Type                              | Default | Description                                                                    |
-| :------------- | :--------------------------------- | :------- | :-------------------------------------------------------------------------------|
-| variant       | `none`, `underline`               | `none`  | The variant of the link style to use.                                          |
-| disabled      | `boolean`                         |         | If `true`, the link will be disabled.                                          |
-| onClick       | `function`                        |         | Function called when the link is clicked.                                      |
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| disabled | `boolean` | | If `true`, the link will be disabled. |
+| onClick | `function` | | Function called when the link is clicked. |


### PR DESCRIPTION
This PR removed `variant="underline"` from Link component since there is no strong demand so far and the `underline` style can be decorated using the `textDecoration` prop:

```jsx
<Link textDecoration="underline" />
```