### PR TITLE
fix: side header component zindex

### DIFF
--- a/packages/styled-docs/components/Header.jsx
+++ b/packages/styled-docs/components/Header.jsx
@@ -21,7 +21,7 @@ const Header = React.forwardRef((props, ref) => {
       top={0}
       height="4rem"
       width="100%"
-      zIndex="2"
+      zIndex="fixed"
       backgroundColor={backgroundColor}
       borderBottom={1}
       borderBottomColor={borderColor}

--- a/packages/styled-docs/components/Header.jsx
+++ b/packages/styled-docs/components/Header.jsx
@@ -21,6 +21,7 @@ const Header = React.forwardRef((props, ref) => {
       top={0}
       height="4rem"
       width="100%"
+      zIndex="2"
       backgroundColor={backgroundColor}
       borderBottom={1}
       borderBottomColor={borderColor}

--- a/packages/styled-docs/pages/_app.js
+++ b/packages/styled-docs/pages/_app.js
@@ -22,7 +22,7 @@ const Layout = ({ children }) => {
 
   return (
     <Box color={fontColor}>
-      <Header zIndex="1" />
+      <Header />
       <SideNav
         display={['none', null, 'block']}
         maxWidth="20rem"


### PR DESCRIPTION
Fix site header covered by the copy button.
![Screen Shot 2020-02-13 at 11 00 43 AM](https://user-images.githubusercontent.com/20294934/74397635-17b04680-4e50-11ea-8caf-1d7295fe3257.png)
