### PR TITLE
fix: fix incorrect anchor pseudo-classes order

### DIFF
--- a/packages/react-styled-core/package.json
+++ b/packages/react-styled-core/package.json
@@ -39,8 +39,8 @@
     "@emotion/styled": "10.x",
     "emotion-theming": "10.x",
     "prop-types": "^15.6.0",
-    "react": ">= 16.8",
-    "react-dom": ">= 16.8"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "author": "Cheton Wu <cheton_wu@trendmicro.com>",
   "homepage": "https://github.com/trendmicro-frontend/styled-ui",

--- a/packages/react-styled-core/src/PseudoBox/index.js
+++ b/packages/react-styled-core/src/PseudoBox/index.js
@@ -96,6 +96,9 @@ const PseudoBox = styled(Box)(
 
     return css({
       // pseudo-classes
+      // XXX:
+      //    a:hover MUST come after a:link and a:visited in the CSS definition in order to be effective.
+      //    a:active MUST come after a:hover in the CSS definition in order to be effective.
       [focus]: _focus,
       [checked]: _checked,
       [visited]: _visited,

--- a/packages/react-styled-core/src/PseudoBox/index.js
+++ b/packages/react-styled-core/src/PseudoBox/index.js
@@ -100,10 +100,10 @@ const PseudoBox = styled(Box)(
       //    a:hover MUST come after a:link and a:visited in the CSS definition in order to be effective.
       //    a:active MUST come after a:hover in the CSS definition in order to be effective.
       [focus]: _focus,
-      [checked]: _checked,
       [visited]: _visited,
       [hover]: _hover,
       [active]: _active,
+      [checked]: _checked,
       [selected]: _selected,
       [disabled]: _disabled,
       [empty]: _empty,

--- a/packages/react-styled-core/src/PseudoBox/index.js
+++ b/packages/react-styled-core/src/PseudoBox/index.js
@@ -87,6 +87,10 @@ const PseudoBox = styled(Box)(
     __firstLine,
     __placeholder,
     __selection,
+    
+    cursor,
+    outline,
+    textDecoration,
   }) => {
     let rest = null;
 
@@ -124,6 +128,10 @@ const PseudoBox = styled(Box)(
       [firstLine]: __firstLine,
       [placeholder]: __placeholder,
       [selection]: __selection,
+      
+      cursor,
+      outline,
+      textDecoration,
 
       ...rest
     });

--- a/packages/react-styled-core/src/PseudoBox/index.js
+++ b/packages/react-styled-core/src/PseudoBox/index.js
@@ -87,10 +87,6 @@ const PseudoBox = styled(Box)(
     __firstLine,
     __placeholder,
     __selection,
-    
-    cursor,
-    outline,
-    textDecoration,
   }) => {
     let rest = null;
 
@@ -128,10 +124,6 @@ const PseudoBox = styled(Box)(
       [firstLine]: __firstLine,
       [placeholder]: __placeholder,
       [selection]: __selection,
-      
-      cursor,
-      outline,
-      textDecoration,
 
       ...rest
     });

--- a/packages/react-styled-core/src/PseudoBox/index.js
+++ b/packages/react-styled-core/src/PseudoBox/index.js
@@ -96,11 +96,11 @@ const PseudoBox = styled(Box)(
 
     return css({
       // pseudo-classes
-      [hover]: _hover,
       [focus]: _focus,
-      [active]: _active,
       [checked]: _checked,
       [visited]: _visited,
+      [hover]: _hover,
+      [active]: _active,
       [selected]: _selected,
       [disabled]: _disabled,
       [empty]: _empty,

--- a/packages/styled-docs/package.json
+++ b/packages/styled-docs/package.json
@@ -31,8 +31,8 @@
     "next-compose-plugins": "^2.2.0",
     "prism-react-renderer": "^1.0.2",
     "prop-types": "^15.6.0",
-    "react": "16.12.0",
-    "react-dom": "16.12.0",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
     "react-live": "^2.2.2",
     "remark-emoji": "^2.0.2",
     "remark-images": "^1.0.0"


### PR DESCRIPTION
## Explanation
>  a:hover MUST come after a:link and a:visited in the CSS definition in order to be effective.
>  a:active MUST come after a:hover in the CSS definition in order to be effective.
>
References: [css pseudo classes](https://www.w3schools.com/css/css_pseudo_classes.asp)

## TL;DR
The `ci` builds of this PR failed since the inconsistent version of `react` and `react-dom`.
The commits `13cd224` and `2527e8c` are trying to fix this issue. 