### PR TITLE
refactor: remove orphaned props from shadows

### DIFF
--- a/packages/styled-docs/pages/stack.mdx
+++ b/packages/styled-docs/pages/stack.mdx
@@ -26,7 +26,7 @@ By default, each item is stacked vertically. Stack clones it's children and pass
 ```jsx noInline
 const Item = (props) => {
   const { colorMode } = useColorMode();
-  const boxShadow = colorMode === 'dark' ? 'dark:1x' : 'light:1x';
+  const boxShadow = `${colorMode}.sm`;
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (
     <Box p="2x" boxShadow={boxShadow} border={1} borderColor={borderColor} {...props} />
@@ -51,7 +51,7 @@ render(<Example />);
 ```jsx noInline
 const Item = (props) => {
   const { colorMode } = useColorMode();
-  const boxShadow = colorMode === 'dark' ? 'dark:1x' : 'light:1x';
+  const boxShadow = `${colorMode}.sm`;
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (
     <Box p="2x" boxShadow={boxShadow} border={1} borderColor={borderColor} {...props} />
@@ -76,7 +76,7 @@ render(<Example />);
 ```jsx noInline
 const Item = (props) => {
   const { colorMode } = useColorMode();
-  const boxShadow = colorMode === 'dark' ? 'dark:1x' : 'light:1x';
+  const boxShadow = `${colorMode}.sm`;
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (
     <Box p="2x" boxShadow={boxShadow} border={1} borderColor={borderColor} {...props} />
@@ -102,7 +102,7 @@ render(<Example />);
 ```jsx noInline
 const Item = (props) => {
   const { colorMode } = useColorMode();
-  const boxShadow = colorMode === 'dark' ? 'dark:1x' : 'light:1x';
+  const boxShadow = `${colorMode}.sm`;
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (
     <Box p="2x" boxShadow={boxShadow} border={1} borderColor={borderColor} {...props} />

--- a/packages/styled-docs/pages/stack.mdx
+++ b/packages/styled-docs/pages/stack.mdx
@@ -26,7 +26,9 @@ By default, each item is stacked vertically. Stack clones it's children and pass
 ```jsx noInline
 const Item = (props) => {
   const { colorMode } = useColorMode();
-  const boxShadow = colorMode === 'dark' ? 'dark:1x' : 'light:1x';
+  const boxShadow = colorMode === 'dark'
+    ? '0 2px 8px 0 rgba(0, 0, 0, 0.48), 0 1px 2px 0 rgba(0, 0, 0, 0.16)'
+    : '0 2px 8px 0 rgba(0, 0, 0, 0.16), 0 1px 2px 0 rgba(0, 0, 0, 0.08)';
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (
     <Box p="2x" boxShadow={boxShadow} border={1} borderColor={borderColor} {...props} />
@@ -51,7 +53,9 @@ render(<Example />);
 ```jsx noInline
 const Item = (props) => {
   const { colorMode } = useColorMode();
-  const boxShadow = colorMode === 'dark' ? 'dark:1x' : 'light:1x';
+  const boxShadow = colorMode === 'dark'
+    ? '0 2px 8px 0 rgba(0, 0, 0, 0.48), 0 1px 2px 0 rgba(0, 0, 0, 0.16)'
+    : '0 2px 8px 0 rgba(0, 0, 0, 0.16), 0 1px 2px 0 rgba(0, 0, 0, 0.08)';
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (
     <Box p="2x" boxShadow={boxShadow} border={1} borderColor={borderColor} {...props} />
@@ -76,7 +80,9 @@ render(<Example />);
 ```jsx noInline
 const Item = (props) => {
   const { colorMode } = useColorMode();
-  const boxShadow = colorMode === 'dark' ? 'dark:1x' : 'light:1x';
+  const boxShadow = colorMode === 'dark'
+    ? '0 2px 8px 0 rgba(0, 0, 0, 0.48), 0 1px 2px 0 rgba(0, 0, 0, 0.16)'
+    : '0 2px 8px 0 rgba(0, 0, 0, 0.16), 0 1px 2px 0 rgba(0, 0, 0, 0.08)';
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (
     <Box p="2x" boxShadow={boxShadow} border={1} borderColor={borderColor} {...props} />
@@ -102,7 +108,9 @@ render(<Example />);
 ```jsx noInline
 const Item = (props) => {
   const { colorMode } = useColorMode();
-  const boxShadow = colorMode === 'dark' ? 'dark:1x' : 'light:1x';
+  const boxShadow = colorMode === 'dark'
+    ? '0 2px 8px 0 rgba(0, 0, 0, 0.48), 0 1px 2px 0 rgba(0, 0, 0, 0.16)'
+    : '0 2px 8px 0 rgba(0, 0, 0, 0.16), 0 1px 2px 0 rgba(0, 0, 0, 0.08)';
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (
     <Box p="2x" boxShadow={boxShadow} border={1} borderColor={borderColor} {...props} />

--- a/packages/styled-theme/src/base.js
+++ b/packages/styled-theme/src/base.js
@@ -241,12 +241,16 @@ const shadows = {
   /**
    * offset-x | offset-y | blur-radius | spread-radius | color
    */
-  'dark:1x': '0 2px 8px 0 rgba(0, 0, 0, 0.48), 0 1px 2px 0 rgba(0, 0, 0, 0.16)',
-  'dark:2x': '0 4px 16px 0 rgba(0, 0, 0, 0.48), 0 2px 4px 0 rgba(0, 0, 0, 0.16)',
-  'dark:4x': '0 8px 32px 0 rgba(0, 0, 0, 0.48), 0 4px 8px 0 rgba(0, 0, 0, 0.16)',
-  'light:1x': '0 2px 8px 0 rgba(0, 0, 0, 0.16), 0 1px 2px 0 rgba(0, 0, 0, 0.08)',
-  'light:2x': '0 4px 16px 0 rgba(0, 0, 0, 0.16), 0 2px 4px 0 rgba(0, 0, 0, 0.08)',
-  'light:4x': '0 8px 32px 0 rgba(0, 0, 0, 0.16), 0 4px 8px 0 rgba(0, 0, 0, 0.08)',
+  dark: {
+    sm: '0 2px 8px 0 rgba(0, 0, 0, 0.48), 0 1px 2px 0 rgba(0, 0, 0, 0.16)',
+    md: '0 4px 16px 0 rgba(0, 0, 0, 0.48), 0 2px 4px 0 rgba(0, 0, 0, 0.16)',
+    lg: '0 8px 32px 0 rgba(0, 0, 0, 0.48), 0 4px 8px 0 rgba(0, 0, 0, 0.16)',
+  },
+  light: {
+    sm: '0 2px 8px 0 rgba(0, 0, 0, 0.16), 0 1px 2px 0 rgba(0, 0, 0, 0.08)',
+    md: '0 4px 16px 0 rgba(0, 0, 0, 0.16), 0 2px 4px 0 rgba(0, 0, 0, 0.08)',
+    lg: '0 8px 32px 0 rgba(0, 0, 0, 0.16), 0 4px 8px 0 rgba(0, 0, 0, 0.08)',
+  },
 };
 
 const zIndices = {

--- a/packages/styled-theme/src/base.js
+++ b/packages/styled-theme/src/base.js
@@ -237,16 +237,6 @@ const radii = {
 
 const shadows = {
   none: 'none',
-
-  /**
-   * offset-x | offset-y | blur-radius | spread-radius | color
-   */
-  'dark:1x': '0 2px 8px 0 rgba(0, 0, 0, 0.48), 0 1px 2px 0 rgba(0, 0, 0, 0.16)',
-  'dark:2x': '0 4px 16px 0 rgba(0, 0, 0, 0.48), 0 2px 4px 0 rgba(0, 0, 0, 0.16)',
-  'dark:4x': '0 8px 32px 0 rgba(0, 0, 0, 0.48), 0 4px 8px 0 rgba(0, 0, 0, 0.16)',
-  'light:1x': '0 2px 8px 0 rgba(0, 0, 0, 0.16), 0 1px 2px 0 rgba(0, 0, 0, 0.08)',
-  'light:2x': '0 4px 16px 0 rgba(0, 0, 0, 0.16), 0 2px 4px 0 rgba(0, 0, 0, 0.08)',
-  'light:4x': '0 8px 32px 0 rgba(0, 0, 0, 0.16), 0 4px 8px 0 rgba(0, 0, 0, 0.08)',
 };
 
 const zIndices = {


### PR DESCRIPTION
Since there is no good naming system for shadows and the usage is pretty low, I plan to remove it from `styled-theme` to get rid of light/dark color system dependency. The implementation of shadows will be made within the component level when necessary (e.g., drawer, modal).