### PR TITLE
refactor: wrap children with a context provider in CheckboxGroup component

### DIFF
--- a/packages/react-styled-core/src/Checkbox/index.js
+++ b/packages/react-styled-core/src/Checkbox/index.js
@@ -1,3 +1,4 @@
+import chainedFunction from 'chained-function';
 import React, { forwardRef } from 'react';
 import Box from '../Box';
 import ControlBox from '../ControlBox';
@@ -5,6 +6,7 @@ import Icon from '../Icon';
 import useColorMode from '../useColorMode';
 import VisuallyHidden from '../VisuallyHidden';
 import checkboxStyles from './styles';
+import { useGroupContext } from '../GroupContext';
 
 const Checkbox = forwardRef(
   (
@@ -34,10 +36,31 @@ const Checkbox = forwardRef(
     ref,
   ) => {
     const { colorMode } = useColorMode();
-    const styleProps = checkboxStyles({ color: variantColor, size, colorMode, indeterminate });
-    const opacity = readOnly || disabled ? 0.32 : 1;
+    const {
+      disabled: disabledFromParent,
+      size: sizeFromParent,
+      value: valueFromParent,
+      variantColor: variantColorFromParent,
+      onChange: onChangeFromParent
+    } = useGroupContext();
     const _defaultChecked = defaultChecked ? undefined : checked;
-    const _checked = readOnly ? Boolean(checked) : _defaultChecked;
+    let _checked = readOnly ? Boolean(checked) : _defaultChecked;
+    if (valueFromParent !== undefined) {
+      _checked = valueFromParent.includes(value);
+    }
+    const _disabled = disabledFromParent || disabled;
+    const _size = sizeFromParent || size;
+    const _variantColor = variantColorFromParent || variantColor;
+    const _onChange = chainedFunction(
+      onChange,
+      onChangeFromParent,
+    );
+    const styleProps = checkboxStyles({
+      color: _variantColor,
+      size: _size,
+      colorMode,
+      indeterminate
+    });
 
     return (
       <Box
@@ -45,7 +68,7 @@ const Checkbox = forwardRef(
         display="inline-flex"
         verticalAlign="top"
         alignItems="center"
-        cursor={disabled || readOnly ? 'not-allowed' : 'pointer'}
+        cursor={_disabled || readOnly ? 'not-allowed' : 'pointer'}
         {...rest}
       >
         <VisuallyHidden
@@ -56,11 +79,11 @@ const Checkbox = forwardRef(
           name={name}
           value={value}
           defaultChecked={readOnly ? undefined : defaultChecked}
-          onChange={readOnly ? undefined : onChange}
+          onChange={readOnly ? undefined : _onChange}
           onBlur={onBlur}
           onFocus={onFocus}
           checked={_checked}
-          disabled={disabled}
+          disabled={_disabled}
           readOnly={readOnly}
           data-indeterminate={indeterminate}
         />
@@ -77,7 +100,7 @@ const Checkbox = forwardRef(
             ml="2x"
             fontSize={size}
             userSelect="none"
-            opacity={opacity}
+            opacity={readOnly || _disabled ? 0.32 : 1}
           >
             {children}
           </Box>

--- a/packages/react-styled-core/src/CheckboxGroup/index.js
+++ b/packages/react-styled-core/src/CheckboxGroup/index.js
@@ -1,32 +1,18 @@
-import React, {
-  Children,
-  cloneElement,
-  useState,
-  useRef,
-  isValidElement,
-} from 'react';
-import { useId } from '../utils/autoId';
-import Box from '../Box';
+import React, { useState, useRef } from 'react';
+import GroupContext from '../GroupContext';
 
 const CheckboxGroup = ({
-  onChange,
-  name,
-  value: valueProp,
-  defaultValue,
-
-  size,
-  spacing,
-  variantColor,
-  disabled,
-  inline,
-
   children,
-  ...rest
+  defaultValue,
+  disabled,
+  size,
+  value: valueProp,
+  variantColor,
+  onChange,
 }) => {
-  const [values, setValues] = useState(defaultValue || []);
   const { current: isControlled } = useRef(valueProp != null);
+  const [values, setValues] = useState(defaultValue || []);
   const _values = isControlled ? valueProp : values;
-
   const _onChange = event => {
     const { checked, value } = event.target;
     let newValues;
@@ -35,45 +21,21 @@ const CheckboxGroup = ({
     } else {
       newValues = _values.filter(val => val !== value);
     }
-
     !isControlled && setValues(newValues);
     onChange && onChange(newValues);
   };
-
-  // If no name is passed, we'll generate a random, unique name
-  const fallbackName = `checkbox-${useId()}`;
-  const _name = name || fallbackName;
-
-  const clones = Children.map(children, (child, index) => {
-    if (!isValidElement(child)) {
-      return null;
-    }
-
-    const isLastCheckbox = (children.length === index + 1);
-    const defaultSpacing = spacing || (inline ? '6x' : '1x');
-    const spacingProps = inline ? { mr: defaultSpacing } : { mb: defaultSpacing };
-
-    return (
-      <Box
-        display={inline ? 'inline-block' : 'block'}
-        {...(!isLastCheckbox && spacingProps)}
-      >
-        {cloneElement(child, {
-          size: size,
-          variantColor: variantColor,
-          name: `${_name}-${index}`,
-          onChange: _onChange,
-          checked: _values.includes(child.props.value),
-          disabled: disabled,
-        })}
-      </Box>
-    );
-  });
+  const state = {
+    disabled: disabled,
+    onChange: _onChange,
+    size: size,
+    value: _values,
+    variantColor: variantColor,
+  };
 
   return (
-    <Box role="group" {...rest}>
-      {clones}
-    </Box>
+    <GroupContext.Provider value={state}>
+      { children }
+    </GroupContext.Provider>
   );
 };
 

--- a/packages/styled-docs/pages/checkboxgroup.mdx
+++ b/packages/styled-docs/pages/checkboxgroup.mdx
@@ -26,7 +26,7 @@ import { CheckboxGroup } from '@trendmicro/react-styled-core';
 Make a set of checkboxes appear horizontal stacked rather than vertically, by adding `direction="row"` to the `Stack` component.
 
 ```jsx
-<CheckboxGroup inline defaultValue={["apple", "papaya"]}>
+<CheckboxGroup defaultValue={["apple", "papaya"]}>
   <Stack direction="row" spacing="6x">
     <Checkbox value="apple">Apple</Checkbox>
     <Checkbox value="orange">Orange</Checkbox>

--- a/packages/styled-docs/pages/checkboxgroup.mdx
+++ b/packages/styled-docs/pages/checkboxgroup.mdx
@@ -13,21 +13,25 @@ import { CheckboxGroup } from '@trendmicro/react-styled-core';
 
 ```jsx
 <CheckboxGroup defaultValue={["apple", "papaya"]}>
-  <Checkbox value="apple">Apple</Checkbox>
-  <Checkbox value="orange">Orange</Checkbox>
-  <Checkbox value="papaya">Papaya</Checkbox>
+  <Stack spacing="1x">
+    <Checkbox value="apple">Apple</Checkbox>
+    <Checkbox value="orange">Orange</Checkbox>
+    <Checkbox value="papaya">Papaya</Checkbox>
+  </Stack>
 </CheckboxGroup>
 ```
 
 ### Group orientation
 
-Make a set of radios appear horizontal stacked rather than vertically, by adding `inline` to the `CheckboxGroup` component.
+Make a set of checkboxes appear horizontal stacked rather than vertically, by adding `direction="row"` to the `Stack` component.
 
 ```jsx
 <CheckboxGroup inline defaultValue={["apple", "papaya"]}>
-  <Checkbox value="apple">Apple</Checkbox>
-  <Checkbox value="orange">Orange</Checkbox>
-  <Checkbox value="papaya">Papaya</Checkbox>
+  <Stack direction="row" spacing="6x">
+    <Checkbox value="apple">Apple</Checkbox>
+    <Checkbox value="orange">Orange</Checkbox>
+    <Checkbox value="papaya">Papaya</Checkbox>
+  </Stack>
 </CheckboxGroup>
 ```
 
@@ -37,9 +41,11 @@ Use the `variantColor` prop to change the color scheme of the Radio. `variantCol
 
 ```jsx
 <CheckboxGroup variantColor="green" defaultValue={["apple", "papaya"]}>
-  <Checkbox value="apple">Apple</Checkbox>
-  <Checkbox value="orange">Orange</Checkbox>
-  <Checkbox value="papaya">Papaya</Checkbox>
+  <Stack direction="row" spacing="6x">
+    <Checkbox value="apple">Apple</Checkbox>
+    <Checkbox value="orange">Orange</Checkbox>
+    <Checkbox value="papaya">Papaya</Checkbox>
+  </Stack>
 </CheckboxGroup>
 ```
 
@@ -48,21 +54,27 @@ Use the `variantColor` prop to change the color scheme of the Radio. `variantCol
 Use the `size` prop to change the size of the Radio. You can set the value to `sm`, `md`, or `lg`.
 
 ```jsx
-<Stack direction="column" spacing="1rem">
-  <CheckboxGroup inline spacing="2x" size="sm">
-    <Checkbox value="apple">Apple</Checkbox>
-    <Checkbox value="orange">Orange</Checkbox>
-    <Checkbox value="papaya">Papaya</Checkbox>
+<Stack direction="column" spacing="1x" shouldWrapChildren>
+  <CheckboxGroup size="sm">
+    <Stack direction="row" spacing="6x">
+      <Checkbox value="apple">Apple</Checkbox>
+      <Checkbox value="orange">Orange</Checkbox>
+      <Checkbox value="papaya">Papaya</Checkbox>
+    </Stack>
   </CheckboxGroup>
-  <CheckboxGroup inline spacing="2x" size="md">
-    <Checkbox value="apple">Apple</Checkbox>
-    <Checkbox value="orange">Orange</Checkbox>
-    <Checkbox value="papaya">Papaya</Checkbox>
+  <CheckboxGroup size="md">
+    <Stack direction="row" spacing="6x">
+      <Checkbox value="apple">Apple</Checkbox>
+      <Checkbox value="orange">Orange</Checkbox>
+      <Checkbox value="papaya">Papaya</Checkbox>
+    </Stack>
   </CheckboxGroup>
-  <CheckboxGroup inline spacing="2x" size="lg">
-    <Checkbox value="apple">Apple</Checkbox>
-    <Checkbox value="orange">Orange</Checkbox>
-    <Checkbox value="papaya">Papaya</Checkbox>
+  <CheckboxGroup size="lg">
+    <Stack direction="row" spacing="6x">
+      <Checkbox value="apple">Apple</Checkbox>
+      <Checkbox value="orange">Orange</Checkbox>
+      <Checkbox value="papaya">Papaya</Checkbox>
+    </Stack>
   </CheckboxGroup>
 </Stack>
 ```
@@ -70,9 +82,11 @@ Use the `size` prop to change the size of the Radio. You can set the value to `s
 ### States
 ```jsx
 <CheckboxGroup disabled>
-  <Checkbox value="apple">Apple</Checkbox>
-  <Checkbox value="orange">Orange</Checkbox>
-  <Checkbox value="papaya">Papaya</Checkbox>
+  <Stack direction="row" spacing="6x">
+    <Checkbox value="apple">Apple</Checkbox>
+    <Checkbox value="orange">Orange</Checkbox>
+    <Checkbox value="papaya">Papaya</Checkbox>
+  </Stack>
 </CheckboxGroup>
 ```
 
@@ -80,13 +94,10 @@ Use the `size` prop to change the size of the Radio. You can set the value to `s
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| name | `string` | | The name of the checkbox group. This prop is passed to each checbox. |
 | value | `Array<Checkbox["value"]>` | | The value of the checkbox group. |
 | disabled | `boolean` | false | If `true`, all checkboxes will be disabled. |
-| inline | `boolean` | false | If `true`, the checkboxes will aligned horizontally. |
 | variantColor | `string` | | The color of the radio when it's checked. This should be one of the color keys in the theme (e.g."green", "red"). |
 | size | `sm`, `md`, `lg` | `md` | The size (width and height) of the radio. |
-| spacing | `string` or `number` | `1x` | The space between each checkbox. |
 | defaultValue | `Array<Checkbox["value"]>` | | The initial value of the checkbox group. |
 | children | `React.ReactNode` | | The content of the checkbox group. Must be the `Checkbox` component. |
 | onChange | `function` | | The callback fired when any children Checkbox is checked or unchecked. |

--- a/packages/styled-docs/pages/radiogroup.mdx
+++ b/packages/styled-docs/pages/radiogroup.mdx
@@ -58,23 +58,23 @@ Use the `variantColor` prop to change the color scheme of the Radio. `variantCol
 Use the `size` prop to change the size of the Radio. You can set the value to `sm`, `md`, or `lg`.
 
 ```jsx
-<Stack direction="column" spacing="1rem">
+<Stack direction="column" spacing="1x" shouldWrapChildren>
   <RadioGroup size="sm">
-    <Stack direction="row" spacing="2x">
+    <Stack direction="row" spacing="6x">
       <Radio value="1">Radio 1</Radio>
       <Radio value="2">Radio 2</Radio>
       <Radio value="3">Radio 3</Radio>
     </Stack>
   </RadioGroup>
   <RadioGroup size="md">
-    <Stack direction="row" spacing="2x">
+    <Stack direction="row" spacing="6x">
       <Radio value="1">Radio 1</Radio>
       <Radio value="2">Radio 2</Radio>
       <Radio value="3">Radio 3</Radio>
     </Stack>
   </RadioGroup>
   <RadioGroup size="lg">
-    <Stack direction="row" spacing="2x">
+    <Stack direction="row" spacing="6x">
       <Radio value="1">Radio 1</Radio>
       <Radio value="2">Radio 2</Radio>
       <Radio value="3">Radio 3</Radio>
@@ -86,7 +86,7 @@ Use the `size` prop to change the size of the Radio. You can set the value to `s
 ### States
 ```jsx
 <RadioGroup defaultValue="1" disabled>
-  <Stack direction="row" spacing="2x">
+  <Stack direction="row" spacing="6x">
     <Radio value="1">Radio 1</Radio>
     <Radio value="2">Radio 2</Radio>
     <Radio value="3">Radio 3</Radio>


### PR DESCRIPTION
Remove `inline` and `spacing` props for CheckboxGroup. We use context to share state.

![image](https://user-images.githubusercontent.com/24446505/76392569-cb9fe580-63ac-11ea-83a2-99d3c58e19f7.png)
