### PR TITLE
feat: add FlatButton component

### DIFF
--- a/packages/react-styled-core/src/Button/styles.js
+++ b/packages/react-styled-core/src/Button/styles.js
@@ -8,7 +8,7 @@ const secondaryVariantProps = ({ color, colorMode, theme: { colors } }) => {
   const outerBorderColor = colors['blue:60'];
   const style = {
     borderColor: 'gray:60',
-    color: isDarkMode ? 'rgba(255, 255, 255, 0.92)' : 'rgba(0, 0, 0, 0.92)',
+    color: isDarkMode ? 'white:primary' : 'black:primary',
     _focus: {
       borderColor: outerBorderColor,
       boxShadow: `inset 0 0 0 1px ${outerBorderColor}`,
@@ -29,7 +29,7 @@ const secondaryVariantProps = ({ color, colorMode, theme: { colors } }) => {
     },
     _disabled: {
       borderColor: 'gray:60',
-      color: isDarkMode ? 'white' : 'black',
+      color: isDarkMode ? 'white:emphasis' : 'black',
       cursor: 'not-allowed',
       opacity: 0.28,
     },
@@ -54,7 +54,7 @@ const fillColorVariantProps = ({ color, theme: { colors } }) => {
   const style = {
     bg: `${color}:60`,
     borderColor: 'transparent',
-    color: 'white',
+    color: 'white:emphasis',
     _focus: {
       ':not(:active)': {
         borderColor: outerBorderColor,
@@ -99,17 +99,17 @@ const fillColorVariantProps = ({ color, theme: { colors } }) => {
 
 const sizes = {
   lg: {
-    minHeight: '2.5rem', // 40px
+    minHeight: '10x', // 40px
     fontSize: 'md',
     lineHeight: 'md',
   },
   md: {
-    minHeight: '2rem', //32px
+    minHeight: '8x', //32px
     fontSize: 'sm',
     lineHeight: 'sm',
   },
   sm: {
-    minHeight: '1.5rem', //24px
+    minHeight: '6x', //24px
     fontSize: 'sm',
     lineHeight: 'sm',
   },
@@ -123,7 +123,7 @@ const selectedProps = {
   _selected: {
     bg: 'blue:60',
     borderColor: 'blue:60',
-    color: 'white',
+    color: 'white:emphasis',
     '& > :first-of-type': {
       top: 0,
       bottom: 0,

--- a/packages/react-styled-core/src/FlatButton/index.js
+++ b/packages/react-styled-core/src/FlatButton/index.js
@@ -1,0 +1,44 @@
+import React, { forwardRef } from 'react';
+import useButtonStyle from './styles';
+import ButtonBase from '../ButtonBase';
+
+const FlatButton = forwardRef(
+  (
+    {
+      as: Comp = 'button',
+      borderRadius = 'sm',
+      children,
+      px = '3x',
+      size = 'md',
+      type = 'button',
+      variant = 'solid',
+      variantColor,
+      ...rest
+    },
+    ref,
+  ) => {
+    const buttonStyleProps = useButtonStyle({
+      color: variantColor,
+      size,
+      variant,
+    });
+
+    return (
+      <ButtonBase
+        ref={ref}
+        as={Comp}
+        type={type}
+        borderRadius={borderRadius}
+        px={px}
+        {...buttonStyleProps}
+        {...rest}
+      >
+        { children }
+      </ButtonBase>
+    );
+  },
+);
+
+FlatButton.displayName = 'FlatButton';
+
+export default FlatButton;

--- a/packages/react-styled-core/src/FlatButton/styles.js
+++ b/packages/react-styled-core/src/FlatButton/styles.js
@@ -1,0 +1,125 @@
+import { addOpacity } from '../theme/colors-utils';
+import useColorMode from '../useColorMode';
+import useTheme from '../useTheme';
+
+// Solid Button
+const solidVariantProps = ({ color = 'gray', theme: { colors } }) => {
+  const outerBorderColor = colors['blue:60'];
+  const _color = colors[color] || color;
+  const styles = {
+    bg: color,
+    borderColor: 'transparent',
+    color: 'white',
+    _focus: {
+      borderColor: outerBorderColor,
+      boxShadow: `inset 0 0 0 1px ${outerBorderColor}`,
+    },
+    _hover: {
+      bg: addOpacity(_color, 0.60),
+    },
+    _active: {
+      bg: addOpacity(_color, 0.60),
+    },
+    _disabled: {
+      bg: 'gray:60',
+      cursor: 'not-allowed',
+      opacity: 0.28,
+    },
+  };
+
+  return styles;
+};
+
+// Outline Button
+const outlineVariantProps = ({ color = 'gray', theme: { colors } }) => {
+  const outerBorderColor = colors['blue:60'];
+  const _color = colors[color] ? addOpacity(colors[color], 0.92) : addOpacity(color, 0.92);
+  const styles = {
+    borderColor: _color,
+    color: _color,
+    _focus: {
+      borderColor: outerBorderColor,
+      boxShadow: `inset 0 0 0 1px ${outerBorderColor}`,
+    },
+    _hover: {
+      bg: addOpacity('black', 0.12),
+    },
+    _active: {
+      bg: addOpacity('black', 0.12),
+    },
+    _disabled: {
+      borderColor: 'gray:60',
+      color: 'white',
+      cursor: 'not-allowed',
+      opacity: 0.28,
+    },
+  };
+
+  return styles;
+};
+
+////////////////////////////////////////////////////////////
+
+const sizes = {
+  lg: {
+    minHeight: '2.5rem', // 40px
+    fontSize: 'md',
+    lineHeight: 'md',
+  },
+  md: {
+    minHeight: '2rem', //32px
+    fontSize: 'sm',
+    lineHeight: 'sm',
+  },
+  sm: {
+    minHeight: '1.5rem', //24px
+    fontSize: 'sm',
+    lineHeight: 'sm',
+  },
+};
+
+const sizeProps = ({ size }) => sizes[size];
+
+////////////////////////////////////////////////////////////
+
+const variantProps = props => {
+  const variant = props.variant;
+
+  switch (variant) {
+  case 'solid':
+    return solidVariantProps(props);
+  case 'outline':
+    return outlineVariantProps(props);
+  default:
+    return {};
+  }
+};
+
+////////////////////////////////////////////////////////////
+
+const baseProps = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  transition: 'all 250ms',
+  appearance: 'none',
+  userSelect: 'none',
+  verticalAlign: 'middle',
+  whiteSpace: 'nowrap',
+  border: 1,
+};
+
+////////////////////////////////////////////////////////////
+
+const useButtonStyle = props => {
+  const { colorMode } = useColorMode();
+  const theme = useTheme();
+  const _props = { ...props, colorMode, theme };
+  return {
+    ...baseProps,
+    ...sizeProps(_props),
+    ...variantProps(_props),
+  };
+};
+
+export default useButtonStyle;

--- a/packages/react-styled-core/src/FlatButton/styles.js
+++ b/packages/react-styled-core/src/FlatButton/styles.js
@@ -9,7 +9,7 @@ const solidVariantProps = ({ color = 'gray', theme: { colors } }) => {
   const styles = {
     bg: color,
     borderColor: 'transparent',
-    color: 'white',
+    color: 'white:emphasis',
     _focus: {
       borderColor: outerBorderColor,
       boxShadow: `inset 0 0 0 1px ${outerBorderColor}`,
@@ -49,7 +49,7 @@ const outlineVariantProps = ({ color = 'gray', theme: { colors } }) => {
     },
     _disabled: {
       borderColor: 'gray:60',
-      color: 'white',
+      color: 'white:emphasis',
       cursor: 'not-allowed',
       opacity: 0.28,
     },
@@ -62,17 +62,17 @@ const outlineVariantProps = ({ color = 'gray', theme: { colors } }) => {
 
 const sizes = {
   lg: {
-    minHeight: '2.5rem', // 40px
+    minHeight: '10x', // 40px
     fontSize: 'md',
     lineHeight: 'md',
   },
   md: {
-    minHeight: '2rem', //32px
+    minHeight: '8x', //32px
     fontSize: 'sm',
     lineHeight: 'sm',
   },
   sm: {
-    minHeight: '1.5rem', //24px
+    minHeight: '6x', //24px
     fontSize: 'sm',
     lineHeight: 'sm',
   },

--- a/packages/react-styled-core/src/index.js
+++ b/packages/react-styled-core/src/index.js
@@ -11,6 +11,7 @@ import ControlBox from './ControlBox';
 import CSSBaseline from './CSSBaseline';
 import DarkMode from './DarkMode';
 import Fade from './Fade';
+import FlatButton from './FlatButton';
 import Flex from './Flex';
 import Grid from './Grid';
 import Heading from './Heading';
@@ -48,6 +49,7 @@ export {
   CSSBaseline,
   DarkMode,
   Fade,
+  FlatButton,
   Flex,
   Grid,
   Heading,

--- a/packages/styled-docs/pages/button.mdx
+++ b/packages/styled-docs/pages/button.mdx
@@ -198,7 +198,7 @@ In case you need to customize the button, pass style props to the [ButtonBase](.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| disabled | `boolean` | false | If `true`, the button will be disabled. |
-| selected | `boolean` | false | If `true`, the button will be selected. |
+| disabled | `boolean` | | If `true`, the button will be disabled. |
+| selected | `boolean` | | If `true`, the button will be selected. |
 | size | `string` | `md` | The size of the button. One of: `sm`, `md`, `lg` |
 | variant | `string` | `default` | The variant of the button style to use. One of: `emphasis`, `primary`, `default`, `secondary`, `ghost` |

--- a/packages/styled-docs/pages/flatbutton.mdx
+++ b/packages/styled-docs/pages/flatbutton.mdx
@@ -1,0 +1,88 @@
+# FlatButton
+
+## Import
+
+```js
+import FlatButton from '@trendmicro/react-styled-core/FlatButton';
+// or
+import { FlatButton } from '@trendmicro/react-styled-core';
+```
+
+## Usage
+
+```jsx
+<FlatButton>Flat Button</FlatButton>
+```
+
+### Variants
+
+Use the `variant` prop to change the visual style of the Button. You can set the value to `solid`, `outline`.
+
+```jsx
+<Stack direction="row" spacing="2x">
+  <FlatButton variant="solid">Solid Button</FlatButton>
+  <FlatButton variant="outline">Outline Button</FlatButton>
+</Stack>
+```
+
+### Colors
+
+Use the `variantColor` prop to change the color scheme of the Button. `variantColor` can be any color key that exist in the `them.color`.
+
+```jsx
+<Stack spacing="4x">
+  <Stack direction="row" spacing="2x">
+    <FlatButton variantColor="green">Button</FlatButton>
+    <FlatButton variantColor="green:40">Button</FlatButton>
+  </Stack>
+  <Stack direction="row" spacing="2x">
+    <FlatButton variant="outline" variantColor="green">Button</FlatButton>
+    <FlatButton variant="outline" variantColor="green:40">Button</FlatButton>
+  </Stack>
+</Stack>
+```
+
+### Sizes
+
+Use the `size` prop to change the size of the `Button`. You can set the value to `sm`, `md`, or `lg`.
+
+```jsx
+<Stack spacing="4x">
+  <Stack direction="row" spacing="2x" alignItems="center">
+    <FlatButton size="sm">Small</FlatButton>
+    <FlatButton size="md">Medium</FlatButton>
+    <FlatButton size="lg">Large</FlatButton>
+  </Stack>
+  <Stack direction="row" spacing="2x" alignItems="center">
+    <FlatButton variant="outline" size="sm">Small</FlatButton>
+    <FlatButton variant="outline" size="md">Medium</FlatButton>
+    <FlatButton variant="outline" size="lg">Large</FlatButton>
+  </Stack>
+</Stack>
+```
+
+### States
+
+```jsx
+<Stack spacing="4x">
+  <Stack direction="row" spacing="2x">
+    <FlatButton>Normal</FlatButton>
+    <FlatButton disabled>Disabled</FlatButton>
+  </Stack>
+  <Stack direction="row" spacing="2x">
+    <FlatButton variant="outline">Normal</FlatButton>
+    <FlatButton variant="outline" disabled>Disabled</FlatButton>
+  </Stack>
+</Stack>
+```
+
+## Props
+
+`FlatButton` composes the [`ButtonBase`](./buttonbase) component. You can override the default styles with style props.
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| disabled | `boolean` | false | If `true`, the button will be disabled. |
+| size | `string` | `md` | The size of the button. One of: `sm`, `md`, `lg` |
+| variant | `string` | `solid` | The variant of the button style to use. One of: `solid`, `outline` |
+| variantColor | `string` | `gray` | The color of the button. It must be a color key defined in `theme.colors`. |

--- a/packages/styled-docs/pages/flatbutton.mdx
+++ b/packages/styled-docs/pages/flatbutton.mdx
@@ -82,7 +82,7 @@ Use the `size` prop to change the size of the `Button`. You can set the value to
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| disabled | `boolean` | false | If `true`, the button will be disabled. |
+| disabled | `boolean` | | If `true`, the button will be disabled. |
 | size | `string` | `md` | The size of the button. One of: `sm`, `md`, `lg` |
 | variant | `string` | `solid` | The variant of the button style to use. One of: `solid`, `outline` |
 | variantColor | `string` | `gray` | The color of the button. It must be a color key defined in `theme.colors`. |

--- a/packages/styled-docs/shared/components.js
+++ b/packages/styled-docs/shared/components.js
@@ -14,6 +14,7 @@ const components = [
   //'Drawer',
   //'Editable',
   'Fade',
+  'FlatButton',
   'Flex',
   //'FormGroup',
   'Grid',


### PR DESCRIPTION
這個component和Button component很像，但沒在zeplin裡定義....所以outline button我是參考Notification裡的Action button style。

# FlatButton
![image](https://user-images.githubusercontent.com/24446505/77384059-6fcb5880-6dbf-11ea-87c9-a79c2170088f.png)
![image](https://user-images.githubusercontent.com/24446505/77384068-73f77600-6dbf-11ea-8d7c-496ff9d7d5d9.png)
![image](https://user-images.githubusercontent.com/24446505/77384084-7954c080-6dbf-11ea-84fb-602550dd0999.png)
![image](https://user-images.githubusercontent.com/24446505/77384093-7c4fb100-6dbf-11ea-8412-a6374e4e21fc.png)
![image](https://user-images.githubusercontent.com/24446505/77384102-81146500-6dbf-11ea-83f2-97085e9f5f14.png)
![image](https://user-images.githubusercontent.com/24446505/77384112-85d91900-6dbf-11ea-87dc-0dcaf3904225.png)


## Import

```js
import FlatButton from '@trendmicro/react-styled-core/FlatButton';
// or
import { FlatButton } from '@trendmicro/react-styled-core';
```

## Usage

```jsx
<FlatButton>Flat Button</FlatButton>
```

### Variants

Use the `variant` prop to change the visual style of the Button. You can set the value to `solid`, `outline`.

```jsx
<Stack direction="row" spacing="2x">
  <FlatButton variant="solid">Solid Button</FlatButton>
  <FlatButton variant="outline">Outline Button</FlatButton>
</Stack>
```

### Colors

Use the `variantColor` prop to change the color scheme of the Button. `variantColor` can be any color key that exist in the `them.color`.

```jsx
<Stack spacing="4x">
  <Stack direction="row" spacing="2x">
    <FlatButton variantColor="green">Button</FlatButton>
    <FlatButton variantColor="green:40">Button</FlatButton>
  </Stack>
  <Stack direction="row" spacing="2x">
    <FlatButton variant="outline" variantColor="green">Button</FlatButton>
    <FlatButton variant="outline" variantColor="green:40">Button</FlatButton>
  </Stack>
</Stack>
```

### Sizes

Use the `size` prop to change the size of the `Button`. You can set the value to `sm`, `md`, or `lg`.

```jsx
<Stack spacing="4x">
  <Stack direction="row" spacing="2x" alignItems="center">
    <FlatButton size="sm">Small</FlatButton>
    <FlatButton size="md">Medium</FlatButton>
    <FlatButton size="lg">Large</FlatButton>
  </Stack>
  <Stack direction="row" spacing="2x" alignItems="center">
    <FlatButton variant="outline" size="sm">Small</FlatButton>
    <FlatButton variant="outline" size="md">Medium</FlatButton>
    <FlatButton variant="outline" size="lg">Large</FlatButton>
  </Stack>
</Stack>
```

### States

```jsx
<Stack spacing="4x">
  <Stack direction="row" spacing="2x">
    <FlatButton>Normal</FlatButton>
    <FlatButton disabled>Disabled</FlatButton>
  </Stack>
  <Stack direction="row" spacing="2x">
    <FlatButton variant="outline">Normal</FlatButton>
    <FlatButton variant="outline" disabled>Disabled</FlatButton>
  </Stack>
</Stack>
```

## Props

`FlatButton` composes the [`ButtonBase`](./buttonbase) component. You can override the default styles with style props.

| Name | Type | Default | Description |
| :--- | :--- | :------ | :---------- |
| disabled | `boolean` | false | If `true`, the button will be disabled. |
| size | `string` | `md` | The size of the button. One of: `sm`, `md`, `lg` |
| variant | `string` | `solid` | The variant of the button style to use. One of: `solid`, `outline` |
| variantColor | `string` | `gray` | The color of the button. It must be a color key defined in `theme.colors`. |
