### PR TITLE
docs: update Input and InputGroup examples

### DIFF
--- a/packages/react-styled-core/src/Input/styles.js
+++ b/packages/react-styled-core/src/Input/styles.js
@@ -107,7 +107,7 @@ const getFilledStyle = ({
 }) => {
   const backgroundColor = {
     dark: 'gray:80',
-    light: 'gray:20',
+    light: 'gray:10',
   }[colorMode];
 
   return {

--- a/packages/react-styled-core/src/InputGroupAddon/styles.js
+++ b/packages/react-styled-core/src/InputGroupAddon/styles.js
@@ -53,7 +53,7 @@ const getFilledStyle = ({
 }) => {
   const backgroundColor = {
     dark: 'gray:80',
-    light: 'gray:20',
+    light: 'gray:10',
   }[colorMode];
 
   return {

--- a/packages/react-styled-core/src/InputLabel/index.js
+++ b/packages/react-styled-core/src/InputLabel/index.js
@@ -36,7 +36,6 @@ const InputLabel = forwardRef((
   return (
     <Box
       ref={ref}
-      mb="1x"
       {...colorProps}
       {...sizeProps}
       {...rest}

--- a/packages/react-styled-core/src/InputLabel/index.js
+++ b/packages/react-styled-core/src/InputLabel/index.js
@@ -1,0 +1,46 @@
+import React, { forwardRef } from 'react';
+import Box from '../Box';
+import useColorMode from '../useColorMode';
+
+const InputLabel = forwardRef((
+  {
+    size = 'md',
+    ...rest
+  },
+  ref,
+) => {
+  const { colorMode } = useColorMode();
+  const colorProps = {
+    dark: {
+      color: 'white:secondary',
+    },
+    light: {
+      color: 'black:secondary',
+    },
+  }[colorMode];
+  const sizeProps = {
+    'sm': {
+      fontSize: 'sm',
+    },
+    'md': {
+      fontSize: 'sm',
+    },
+    'lg': {
+      fontSize: 'md',
+    },
+  }[size];
+
+  return (
+    <Box
+      ref={ref}
+      mb="1x"
+      {...colorProps}
+      {...sizeProps}
+      {...rest}
+    />
+  );
+});
+
+InputLabel.displayName = 'InputLabel';
+
+export default InputLabel;

--- a/packages/react-styled-core/src/InputLabel/index.js
+++ b/packages/react-styled-core/src/InputLabel/index.js
@@ -21,12 +21,15 @@ const InputLabel = forwardRef((
   const sizeProps = {
     'sm': {
       fontSize: 'sm',
+      lineHeight: 'sm',
     },
     'md': {
       fontSize: 'sm',
+      lineHeight: 'sm',
     },
     'lg': {
       fontSize: 'md',
+      lineHeight: 'md',
     },
   }[size];
 

--- a/packages/react-styled-core/src/index.js
+++ b/packages/react-styled-core/src/index.js
@@ -22,6 +22,7 @@ import InputGroup from './InputGroup';
 import InputGroupAddon from './InputGroupAddon';
 import InputGroupAppend from './InputGroupAppend';
 import InputGroupPrepend from './InputGroupPrepend';
+import InputLabel from './InputLabel';
 import LightMode from './LightMode';
 import Link from './Link';
 import PseudoBox from './PseudoBox';
@@ -65,6 +66,7 @@ export {
   InputGroupAddon,
   InputGroupAppend,
   InputGroupPrepend,
+  InputLabel,
   LightMode,
   Link,
   PseudoBox,

--- a/packages/react-styled-core/src/index.js
+++ b/packages/react-styled-core/src/index.js
@@ -37,6 +37,7 @@ import Tooltip from './Tooltip';
 import theme from './theme';
 import useColorMode from './useColorMode';
 import useClipboard from './useClipboard';
+import useDisclosure from './useDisclosure';
 import useTheme from './useTheme';
 import VisuallyHidden from './VisuallyHidden';
 import withTheme from './withTheme';
@@ -81,6 +82,7 @@ export {
   theme,
   useColorMode,
   useClipboard,
+  useDisclosure,
   useTheme,
   VisuallyHidden,
   withTheme,

--- a/packages/styled-docs/pages/input.mdx
+++ b/packages/styled-docs/pages/input.mdx
@@ -4,16 +4,29 @@ Input component is a component that is used to get user input in a text field.
 
 ## Import
 
+### Default imports
+
 ```js
 import Input from '@trendmicro/react-styled-core/Input';
-// or
-import { Input } from '@trendmicro/react-styled-core';
+import InputLabel from '@trendmicro/react-styled-core/InputLabel';
+```
+
+### Named imports
+
+```js
+import {
+  Input,
+  InputLabel,
+} from '@trendmicro/react-styled-core';
 ```
 
 ## Usage
 
 ```jsx
-<Input placeholder="Basic example" />
+<>
+  <InputLabel>Label:</InputLabel>
+  <Input placeholder="Basic example" />
+</>
 ```
 
 ### Sizes
@@ -22,9 +35,18 @@ Use the `size` prop to change the size of the `Input`. You can set the value to 
 
 ```jsx
 <Stack direction="column" spacing="4x">
-  <Input size="sm" placeholder="Small size (24px)" />
-  <Input size="md" placeholder="Default size (32px)" />
-  <Input size="lg" placeholder="Large size (40px)" />
+  <Box>
+    <InputLabel size="sm">Label:</InputLabel>
+    <Input size="sm" placeholder="Small size (24px)" />
+  </Box>
+  <Box>
+    <InputLabel size="md">Label:</InputLabel>
+    <Input size="md" placeholder="Default size (32px)" />
+  </Box>
+  <Box>
+    <InputLabel size="lg">Label:</InputLabel>
+    <Input size="lg" placeholder="Large size (40px)" />
+  </Box>
 </Stack>
 ```
 
@@ -208,7 +230,9 @@ render(<Example />);
 
 ## Props
 
-`Input` composes the [`PseudoBox`](./pseudobox) component. You can override the default styles with style props.
+### Input
+
+`Input` composes the [`PseudoBox`](./pseudobox) component.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
@@ -217,3 +241,11 @@ render(<Example />);
 | `disabled` | `boolean` | false | If `true`, the input will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
 | `readOnly` | `boolean` | | If `true`, prevents the value of the input from being edited. |
 | `aria-invalid` | `boolean` | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |
+
+### InputLabel
+
+`InputLabel` composes the [`Box`](./box) component.
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| `size` | `string` | 'md' | One of: 'sm', 'md', 'lg' |

--- a/packages/styled-docs/pages/input.mdx
+++ b/packages/styled-docs/pages/input.mdx
@@ -24,7 +24,7 @@ import {
 
 ```jsx
 <>
-  <InputLabel>Label:</InputLabel>
+  <InputLabel mb="1x">Label:</InputLabel>
   <Input placeholder="Basic example" />
 </>
 ```
@@ -36,15 +36,15 @@ Use the `size` prop to change the size of the `Input`. You can set the value to 
 ```jsx
 <Stack direction="column" spacing="4x">
   <Box>
-    <InputLabel size="sm">Label:</InputLabel>
+    <InputLabel mb="1x" size="sm">Label:</InputLabel>
     <Input size="sm" placeholder="Small size (24px)" />
   </Box>
   <Box>
-    <InputLabel size="md">Label:</InputLabel>
+    <InputLabel mb="1x" size="md">Label:</InputLabel>
     <Input size="md" placeholder="Default size (32px)" />
   </Box>
   <Box>
-    <InputLabel size="lg">Label:</InputLabel>
+    <InputLabel mb="1x" size="lg">Label:</InputLabel>
     <Input size="lg" placeholder="Large size (40px)" />
   </Box>
 </Stack>

--- a/packages/styled-docs/pages/inputgroup.mdx
+++ b/packages/styled-docs/pages/inputgroup.mdx
@@ -218,14 +218,14 @@ While multiple `<Input />`s are supported visually, validation styles are only a
   </InputGroup>
   <InputGroup>
     <Input />
-    <InputGroupAppend ml={0}>
+    <InputGroupAppend>
       <Button variant="secondary">
         Action
       </Button>
     </InputGroupAppend>
   </InputGroup>
   <InputGroup>
-    <InputGroupPrepend mr={0}>
+    <InputGroupPrepend>
       <Button variant="secondary">
         Host name
         <Space width="1x" />

--- a/packages/styled-docs/pages/inputgroup.mdx
+++ b/packages/styled-docs/pages/inputgroup.mdx
@@ -241,31 +241,6 @@ While multiple `<Input />`s are supported visually, validation styles are only a
 </Stack>
 ```
 
-### Checkbox and radio add-ons
-
-Place any checkbox or radio option within an input group's add-on instead of text.
-
-```jsx
-<Stack direction="column" spacing="4x">
-  <InputGroup>
-    <InputGroupPrepend>
-      <InputGroupAddon variant="filled">
-        <Checkbox />
-      </InputGroupAddon>
-    </InputGroupPrepend>
-    <Input placeholder="Text input with checkbox" />
-  </InputGroup>
-  <InputGroup>
-    <InputGroupPrepend>
-      <InputGroupAddon variant="filled">
-        <Radio />
-      </InputGroupAddon>
-    </InputGroupPrepend>
-    <Input placeholder="Text input with radio button" />
-  </InputGroup>
-</Stack>
-```
-
 ## Props
 
 ### InputGroup

--- a/packages/styled-docs/pages/inputgroup.mdx
+++ b/packages/styled-docs/pages/inputgroup.mdx
@@ -209,34 +209,46 @@ While multiple `<Input />`s are supported visually, validation styles are only a
 ```jsx
 <Stack direction="column" spacing="4x">
   <InputGroup>
-    <InputGroupPrepend mr={0}>
-      <Button>Button</Button>
-    </InputGroupPrepend>
-    <Input />
-  </InputGroup>
-  <InputGroup>
-    <Input />
-    <InputGroupAppend ml={0}>
-      <Button>Button</Button>
-    </InputGroupAppend>
-  </InputGroup>
-  <InputGroup>
-    <InputGroupPrepend mr={0}>
-      <Button variant="primary">Button</Button>
-    </InputGroupPrepend>
     <InputGroupPrepend>
-      <Button variant="secondary">Button</Button>
+      <Button variant="secondary">
+        Action
+      </Button>
     </InputGroupPrepend>
     <Input />
   </InputGroup>
   <InputGroup>
     <Input />
     <InputGroupAppend ml={0}>
-      <Button variant="primary">Button</Button>
+      <Button variant="secondary">
+        Action
+      </Button>
     </InputGroupAppend>
+  </InputGroup>
+  <InputGroup>
+    <InputGroupPrepend mr={0}>
+      <Button variant="secondary">
+        Host name
+        <Space width="1x" />
+        <TMIcon name="angle-down" />
+      </Button>
+    </InputGroupPrepend>
+    <Input />
     <InputGroupAppend>
-      <Button variant="secondary">Button</Button>
-    </InputGroupAppend>
+      <Button>
+        Action
+      </Button>
+        </InputGroupAppend>
+      </InputGroup>
+      <InputGroup>
+        <Input />
+        <ButtonGroup>
+          <Button borderRadius={0}>
+            Action
+          </Button>
+          <Button>
+        <TMIcon name="settings" />
+      </Button>
+    </ButtonGroup>
   </InputGroup>
 </Stack>
 ```
@@ -245,7 +257,7 @@ While multiple `<Input />`s are supported visually, validation styles are only a
 
 ### InputGroup
 
-`InputGroup` composes the [`Box`](./box) component. You can override the default styles with style props.
+`InputGroup` composes the [`Box`](./box) component.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |


### PR DESCRIPTION
* Change the background color for the `filled` variant
* Remove the \"Checkbox and radio add-ons" section
* Add `InputLabel` component
* Update `input.mdx` and `inputgroup.mdx`
* Export `useDisclosure` hook