### PR TITLE
fix: destroy markdown layout on Spinner

### DIFF
--- a/packages/styled-docs/pages/spinner.mdx
+++ b/packages/styled-docs/pages/spinner.mdx
@@ -31,6 +31,7 @@ import { Spinner } from '@trendmicro/react-styled-core';
 ### Sizes
 
 Use the `size` prop to change the size of the `Spinner`. You can set the value to `xs`, `sm`, `md`, `lg`, or `xs`. The corresponding stroke width is listed as below:
+
 | Size | Stroke Width |
 | :---- | :------------- |
 | xs | 2px |


### PR DESCRIPTION
before

<img width="920" alt="螢幕快照 2020-03-28 下午8 18 51" src="https://user-images.githubusercontent.com/8485590/77822860-7d6f3e00-7131-11ea-986c-9797ff1b3c38.png">

after

<img width="849" alt="螢幕快照 2020-03-28 下午8 18 26" src="https://user-images.githubusercontent.com/8485590/77822866-83fdb580-7131-11ea-9ee4-e7317811eb6b.png">
