### PR TITLE
docs: use consistent conventions for writing documentation

### DIFF
--- a/packages/styled-docs/pages/accordion.mdx
+++ b/packages/styled-docs/pages/accordion.mdx
@@ -221,23 +221,23 @@ toggle (expand or collapse) the accordion.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| allowMultiple | `boolean` | false | If `true`, multiple accordion items can be expanded at once. |
-| allowToggle | `boolean` | false | If `true`, any expanded accordion item can be collapsed again. |
-| index | `number` or `array` | | The index(es) of the expanded accordion item. |
-| defaultIndex | `number` or `array` | | The initial index(es) of the expanded accordion item. |
-| onChange | `function` | | The callback invoked when accordion items are expanded or collapsed. |
-| children | `ReactNode` | | The content of the accordion. The children must be one of the `AccordionHeader` and `AccordionPanel` components. |
+| allowMultiple | boolean | false | If `true`, multiple accordion items can be expanded at once. |
+| allowToggle | boolean | false | If `true`, any expanded accordion item can be collapsed again. |
+| index | number \| array | | The index(es) of the expanded accordion item. |
+| defaultIndex | number \| array | | The initial index(es) of the expanded accordion item. |
+| onChange | function | | A callback invoked when accordion items are expanded or collapsed. |
+| children | ReactNode | | The content of the accordion. The children must be one of the `AccordionHeader` and `AccordionPanel` components. |
 
 ### AccordionItem Props
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| id | `string` | | A unique `id` for the accordion item. |
-| isOpen | `boolean` | false | If `true`, expands the accordion in the controlled mode. |
-| defaultIsOpen | `boolean` | false | If `true`, expands the accordion by on initial mount. |
-| isDisabled | `boolean` | false | If `true`, the accordion header will be disabled. |
-| onChange | `function` | | The callback fired when the accordion is expanded/collapsed. |
-| children | `ReactNode`, `(RenderProps) => ReactNode` | | The content of the accordion. The children must be one of the `AccordionHeader` and `AccordionPanel` components. |
+| id | string | | A unique id for the accordion item. |
+| isOpen | boolean | false | If `true`, expands the accordion in the controlled mode. |
+| defaultIsOpen | boolean | false | If `true`, expands the accordion by on initial mount. |
+| isDisabled | boolean | false | If `true`, the accordion header will be disabled. |
+| onChange | function | | A callback fired when the accordion is expanded/collapsed. |
+| children | ReactNode \| (RenderProps) => ReactNode | | The content of the accordion. The children must be one of the `AccordionHeader` and `AccordionPanel` components. |
 
 ### AccordionHeader Props
 

--- a/packages/styled-docs/pages/alert.mdx
+++ b/packages/styled-docs/pages/alert.mdx
@@ -90,9 +90,9 @@ create all kinds of layout. Here's an example of custom alert style and layout.
 
 Alert is the wrapper for alert component. It composes the `Flex` component.
 
-| Name    | Type                                           | Default  | Description                            |
-| ------- | ---------------------------------------------- | -------- | -------------------------------------- |
-| status  | `error`, `warning`, `info`                     | `info`   | The status of the alert                |
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| status | string | 'info' | The status of the alert. One of: `'error'`, `'warning'`, `'info'` |
 
 ### AlertIcon props
 

--- a/packages/styled-docs/pages/badge.mdx
+++ b/packages/styled-docs/pages/badge.mdx
@@ -25,7 +25,7 @@ can be any **color key with key 60** that exists in the `theme.colors`.
 * [Learn more about theming](./theme).
 
 ```jsx
-<div>
+<Stack direction="row" spacing="4x">
   <Badge>1</Badge>
   <Badge variantColor="green">2</Badge>
   <Badge variantColor="red">3</Badge>
@@ -34,7 +34,7 @@ can be any **color key with key 60** that exists in the `theme.colors`.
   <Badge variantColor="purple">6</Badge>
   <Badge variantColor="teal">7</Badge>
   <Badge variantColor="cyan">8</Badge>
-</div>
+</Stack>
 ```
 
 You can also change the size of the badge by passing `fontSize` prop.
@@ -54,4 +54,4 @@ You can also change the size of the badge by passing `fontSize` prop.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| variantColor | `string` | 'gray' | The color scheme to use for the badge. It must be a color key defined in `theme.colors`. |
+| variantColor | string | 'gray' | The color scheme to use for the badge. It must be a color key defined in `theme.colors`. |

--- a/packages/styled-docs/pages/box.mdx
+++ b/packages/styled-docs/pages/box.mdx
@@ -2,7 +2,7 @@ import AnimatedCubeDemo from '../components/AnimatedCubeDemo';
 
 # Box
 
-The Box component serves as a wrapper component for most of the CSS utility needs. It allows you to control styles using [style props](https://styled-system.com/api) for building UI components with [Styled System](https://styled-system.com).
+The `Box` component serves as a wrapper component for most of the CSS utility needs. It allows you to control styles using [style props](https://styled-system.com/api) for building UI components with [Styled System](https://styled-system.com).
 
 <AnimatedCubeDemo />
 

--- a/packages/styled-docs/pages/button.mdx
+++ b/packages/styled-docs/pages/button.mdx
@@ -198,7 +198,7 @@ In case you need to customize the button, pass style props to the [ButtonBase](.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| disabled | `boolean` | | If `true`, the button will be disabled. |
-| selected | `boolean` | | If `true`, the button will be selected. |
-| size | `string` | `md` | The size of the button. One of: `sm`, `md`, `lg` |
-| variant | `string` | `default` | The variant of the button style to use. One of: `emphasis`, `primary`, `default`, `secondary`, `ghost` |
+| disabled | boolean | | If `true`, the button will be disabled. |
+| selected | boolean | | If `true`, the button will be selected. |
+| size | string | 'md' | The size of the button. One of: `'sm'`, `'md'`, `'lg'` |
+| variant | string | 'default' | The variant of the button style to use. One of: `'emphasis'`, `'primary'`, `'default'`, `'secondary'`, `'ghost'` |

--- a/packages/styled-docs/pages/buttonbase.mdx
+++ b/packages/styled-docs/pages/buttonbase.mdx
@@ -94,4 +94,4 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| `disabled` | `boolean` | | If `true`, the input will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
+| disabled | boolean | | If `true`, the input will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |

--- a/packages/styled-docs/pages/buttongroup.mdx
+++ b/packages/styled-docs/pages/buttongroup.mdx
@@ -121,6 +121,6 @@ Make a set of buttons appear vertically stacked rather than horizontally, by add
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| `size` | `string` | `md` | Sets the size for all Buttons in the group. |
-| `variant` | `string` | `default` | Sets the variant of all Buttons in the group. |
-| `vertical` | `boolean` | false | Make the set of Buttons appear vertically stacked. |
+| size | string | 'md' | The size for all buttons in the group. One of: `'sm'`, `'md'`, `'lg'` |
+| variant | string | 'default' | The variant of all buttons in the group. One of: `'emphasis'`, `'primary'`, `'default'`, `'secondary'`, `'ghost'` |
+| vertical | boolean | false | Make the set of Buttons appear vertically stacked. |

--- a/packages/styled-docs/pages/checkbox.mdx
+++ b/packages/styled-docs/pages/checkbox.mdx
@@ -4,8 +4,7 @@
 
 Native HTML checkboxes are 100% accessible by default, so we used a [very common CSS technique](https://dev.to/lkopacz/create-custom-keyboard-accessible-checkboxes-2036) to style the checkboxes.
 
-The Checkbox component composes [ControlBox](./controlbox), a component we created to make it easy to style an element based on sibling inputs.
-
+The `Checkbox` component composes [`ControlBox`](./controlbox), a component we created to make it easy to style an element based on sibling inputs.
 
 ## Import
 
@@ -96,16 +95,16 @@ function IndeterminateExample() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| id | `string` | | The id assigned to input field |
-| name | `string` | | The name of the input field in a checkbox (Useful for form submission) |
-| value | `string` or `number` | | The value to be used in the checkbox input. This is the value that will be returned on form submission. |
-| variantColor | `string` | | The color of the checkbox when it's checked. This should be one of the color keys in the theme (e.g."green", "red") |
-| size | `sm`, `md`, `lg` | `md` | The size (width and height) of the checkbox |
-| defaultChecked | `boolean` | | If `true`, the checkbox will be initially checked. |
-| checked | `boolean` | | If `true`, the checkbox will be checked. You'll need to pass `onChange` to update it's value (since it's now controlled) |
-| disabled | `boolean` | | If `true`, the checkbox will be disabled |
-| indeterminate | `boolean` | | If `true`, the checkbox will be indeterminate. This only affects the icon shown inside checkbox |
-| children | `React.ReactNode` | | The children of the checkbox. |
-| onChange | `function` | | Function called when the state of the checkbox changes. |
-| onBlur | `function` | | Function called when you blur out of the checkbox. |
-| onFocus | `function` | | Function called when the checkbox receive focus. |
+| id | string | | The id assigned to input field. |
+| name | string | | The name of the input field in a checkbox. It's useful for form submission. |
+| value | string \| number | | The value to be used in the checkbox input. This is the value that will be returned on form submission. |
+| variantColor | string | | The color of the checkbox when it's checked. This should be one of the color keys in the theme (e.g. `'green'`, `'red'`) |
+| size | string | 'md' | The size (width and height) of the checkbox. One of: `'sm'`, `'md'`, `'lg'` |
+| defaultChecked | boolean | | If `true`, the checkbox will be initially checked. |
+| checked | boolean | | If `true`, the checkbox will be checked. You'll need to pass `onChange` to update it's value (since it's now controlled) |
+| disabled | boolean | | If `true`, the checkbox will be disabled |
+| indeterminate | boolean | | If `true`, the checkbox will be indeterminate. This only affects the icon shown inside checkbox |
+| children | ReactNode | | The children of the checkbox. |
+| onChange | function | | Function called when the state of the checkbox changes. |
+| onBlur | function | | Function called when you blur out of the checkbox. |
+| onFocus | function | | Function called when the checkbox receive focus. |

--- a/packages/styled-docs/pages/checkbox.mdx
+++ b/packages/styled-docs/pages/checkbox.mdx
@@ -101,10 +101,10 @@ function IndeterminateExample() {
 | variantColor | string | | The color of the checkbox when it's checked. This should be one of the color keys in the theme (e.g. `'green'`, `'red'`) |
 | size | string | 'md' | The size (width and height) of the checkbox. One of: `'sm'`, `'md'`, `'lg'` |
 | defaultChecked | boolean | | If `true`, the checkbox will be initially checked. |
-| checked | boolean | | If `true`, the checkbox will be checked. You'll need to pass `onChange` to update it's value (since it's now controlled) |
-| disabled | boolean | | If `true`, the checkbox will be disabled |
-| indeterminate | boolean | | If `true`, the checkbox will be indeterminate. This only affects the icon shown inside checkbox |
+| checked | boolean | | If `true`, the checkbox will be checked. You'll need to pass `onChange` to update the state for a controlled component. |
+| disabled | boolean | | If `true`, the checkbox will be disabled. |
+| indeterminate | boolean | | If `true`, the checkbox will be indeterminate. This only affects the icon shown inside checkbox. |
 | children | ReactNode | | The children of the checkbox. |
-| onChange | function | | Function called when the state of the checkbox changes. |
-| onBlur | function | | Function called when you blur out of the checkbox. |
-| onFocus | function | | Function called when the checkbox receive focus. |
+| onChange | function | | A callback called when the state is changed. |
+| onBlur | function | | A callback called when the checkbox loses focus. |
+| onFocus | function | | A callback called when the checkbox receives focus. |

--- a/packages/styled-docs/pages/checkboxgroup.mdx
+++ b/packages/styled-docs/pages/checkboxgroup.mdx
@@ -1,5 +1,7 @@
 # CheckboxGroup
 
+`CheckboxGroup` is used to group related checkboxes.
+
 ## Import
 
 ```js
@@ -93,10 +95,10 @@ Use the `size` prop to change the size of the `CheckboxGroup`. You can set the v
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| value | `Array<Checkbox["value"]>` | | The value of the checkbox group. |
-| disabled | `boolean` | false | If `true`, all checkboxes will be disabled. |
-| variantColor | `string` | | The color of the radio when it's checked. This should be one of the color keys in the theme (e.g."green", "red"). |
-| size | `sm`, `md`, `lg` | `md` | The size (width and height) of the radio. |
-| defaultValue | `Array<Checkbox["value"]>` | | The initial value of the checkbox group. |
-| children | `React.ReactNode` | | The content of the checkbox group. Must be the `Checkbox` component. |
-| onChange | `function` | | The callback fired when any children Checkbox is checked or unchecked. |
+| value | Array<Checkbox['value']> | | The value of the checkbox group. |
+| disabled | boolean | false | If `true`, all checkboxes will be disabled. |
+| variantColor | string | | The color of the checkbox when it's checked. This should be one of the color keys in the theme (e.g. `'green'`, `'red'`) |
+| size | string | 'md' | The size (width and height) of the checkbox. One of: `'sm'`, `'md'`, `'lg'` |
+| defaultValue | Array<Checkbox['value']> | | The initial value of the checkbox group. |
+| children | ReactNode | | The content of the checkbox group. Must be the `Checkbox` component. |
+| onChange | function | | A callback fired when any descendant `Checkbox` is checked or unchecked. |

--- a/packages/styled-docs/pages/collapse.mdx
+++ b/packages/styled-docs/pages/collapse.mdx
@@ -70,10 +70,10 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| isOpen | `boolean` | false | If `true`, the content will be visible. |
-| animateOpacity | `boolean` | true | If `true`, the opacity of the content will be animated. |
-| duration | `number` | | The animation duration as it expands. |
-| startingHeight | `number` | 0 | The height you want the content in it's collapsed state. Set to `0` by default. |
-| endingHeight | `number` | 'auto' | The height you want the content in it's expanded state. Set to `auto` by default. |
-| onAnimationEnd | `function` | | The function to be called when the collapse animation starts. It provides the `currentHeight` as an argument. |
-| onAnimationStart | `function` | | The function to be called when the collapse animation ends. It provides the `currentHeight` as an argument. |
+| isOpen | boolean | false | If `true`, the content will be visible. |
+| animateOpacity | boolean | true | If `true`, the opacity of the content will be animated. |
+| duration | number | | The animation duration as it expands. |
+| startingHeight | number | 0 | The height you want the content in it's collapsed state. |
+| endingHeight | number | 'auto' | The height you want the content in it's expanded state. |
+| onAnimationEnd | function | | A callback which will be called when animation starts. This first argument passed to this callback is an object containing `newHeight`, the pixel value of the height at which the animation will end. |
+| onAnimationStart | function | | A callback which will be called when animation ends. This first argument passed to this callback is an object containing `newHeight`, the pixel value of the height at which the animation ended. |

--- a/packages/styled-docs/pages/collapse.mdx
+++ b/packages/styled-docs/pages/collapse.mdx
@@ -75,5 +75,5 @@ function Example() {
 | duration | number | | The animation duration as it expands. |
 | startingHeight | number | 0 | The height you want the content in it's collapsed state. |
 | endingHeight | number | 'auto' | The height you want the content in it's expanded state. |
-| onAnimationEnd | function | | A callback which will be called when animation starts. This first argument passed to this callback is an object containing `newHeight`, the pixel value of the height at which the animation will end. |
-| onAnimationStart | function | | A callback which will be called when animation ends. This first argument passed to this callback is an object containing `newHeight`, the pixel value of the height at which the animation ended. |
+| onAnimationEnd | function | | A callback which will be called when animation starts. The first argument passed to this callback is an object containing `newHeight`, the pixel value of the height at which the animation will end. |
+| onAnimationStart | function | | A callback which will be called when animation ends. The first argument passed to this callback is an object containing `newHeight`, the pixel value of the height at which the animation ended. |

--- a/packages/styled-docs/pages/controlbox.mdx
+++ b/packages/styled-docs/pages/controlbox.mdx
@@ -1,6 +1,6 @@
 # ControlBox
 
-ControlBox provides style props to change it's styles based on a sibling `checkbox` or `radio` input. It relies on a [common CSS technique](https://dev.to/lkopacz/create-custom-keyboard-accessible-checkboxes-2036) for styling custom controls.
+`ControlBox` provides style props to change it's styles based on a sibling `checkbox` or `radio` input. It relies on a [common CSS technique](https://dev.to/lkopacz/create-custom-keyboard-accessible-checkboxes-2036) for styling custom controls.
 
 For this component to work, it should have a sibling `input` and be contained in a `label`.
 
@@ -63,9 +63,11 @@ Creating a custom radio component
 
 ## Props
 
-ControlBox composes the [Box](./box) component so you can pass all Box props. By default, we toggle the opacity of the `ControlBox` children by setting `_child` to `{ opacity: 0 }` and `_checkedAndChild` to `{ opacity: 1 }`
+`ControlBox` composes the [`Box`](./box) component.
 
-| Prop | CSS selector | Description |
+By default, it toggles the opacity of the `ControlBox` children by setting `_child` to `{ opacity: 0 }` and `_checkedAndChild` to `{ opacity: 1 }`.
+
+| Name | Selector | Description |
 | :--- | :----------- | :---------- |
 | \_child | `[input] + & > *` | Styles for the child of the `ControlBox` |
 | \_disabled | `[input]:disabled + &` | Styles for when the sibling `input` is disabled |

--- a/packages/styled-docs/pages/controlbox.mdx
+++ b/packages/styled-docs/pages/controlbox.mdx
@@ -69,19 +69,19 @@ By default, it toggles the opacity of the `ControlBox` children by setting `_chi
 
 | Name | Selector | Description |
 | :--- | :----------- | :---------- |
-| \_child | `[input] + & > *` | Styles for the child of the `ControlBox` |
-| \_disabled | `[input]:disabled + &` | Styles for when the sibling `input` is disabled |
-| \_focus | `[input]:focus + &` | Styles for when the sibling `input` is focused |
-| \_hover | `[input]:hover:not(:disabled):not(:checked):not(:focus) + &` | Styles for when the sibling `input` is hovered |
-| \_checked | `[input]:checked + &` | Styles for when the sibling `input` is checked |
-| \_checkedAndActive | `[input]:checked:active:not(:disabled):not(:focus) + &` | Styles for when the sibling `input` is checked and actived |
-| \_checkedAndChild | `[input]:checked + & > *` | Styles for the child of the `ControlBox` when the sibling `input` is checked |
-| \_checkedAndDisabled | `[input]:checked:disabled + &` | Styles for when the sibling `input` is checked and disabled |
-| \_checkedAndFocus | `[input]:checked:focus + &` | Styles for when the sibling `input` is checked and focused |
-| \_checkedAndHover | `[input]:checked:hover:not(:disabled):not(:focus) + &` | Styles for when the sibling `input` is checked and hovered |
-| \_indeterminate | `[input][data-indeterminate=true] + &` | Styles for when the sibling `input` is indeterminate |
-| \_indeterminateAndActive | `[input][data-indeterminate=true]:active:not(:disabled):not(:focus) + &` | Styles for when the sibling `input` is indeterminate and actived |
-| \_indeterminateAndChild | `[input][data-indeterminate=true] + & > *` | Styles for the child of the `ControlBox` when the sibling `input` is indeterminate |
-| \_indeterminateAndDisabled | `[input][data-indeterminate=true]:disabled + &` | Styles for when the sibling `input` is indeterminate and disabled |
-| \_indeterminateAndFocus | `[input][data-indeterminate=true]:focus + &` | Styles for when the sibling `input` is indeterminate and focused |
-| \_indeterminateAndHover | `[input][data-indeterminate=true]:hover:not(:disabled):not(:focus) + &` | Styles for when the sibling `input` is indeterminate and hovered |
+| \_child | `[input] + & > *` | Styles for the child of the `ControlBox`. |
+| \_disabled | `[input]:disabled + &` | Styles for when the sibling `input` is disabled. |
+| \_focus | `[input]:focus + &` | Styles for when the sibling `input` is focused. |
+| \_hover | `[input]:hover:not(:disabled):not(:checked):not(:focus) + &` | Styles for when the sibling `input` is hovered. |
+| \_checked | `[input]:checked + &` | Styles for when the sibling `input` is checked. |
+| \_checkedAndActive | `[input]:checked:active:not(:disabled):not(:focus) + &` | Styles for when the sibling `input` is checked and actived. |
+| \_checkedAndChild | `[input]:checked + & > *` | Styles for the child of the `ControlBox` when the sibling `input` is checked. |
+| \_checkedAndDisabled | `[input]:checked:disabled + &` | Styles for when the sibling `input` is checked and disabled. |
+| \_checkedAndFocus | `[input]:checked:focus + &` | Styles for when the sibling `input` is checked and focused. |
+| \_checkedAndHover | `[input]:checked:hover:not(:disabled):not(:focus) + &` | Styles for when the sibling `input` is checked and hovered. |
+| \_indeterminate | `[input][data-indeterminate=true] + &` | Styles for when the sibling `input` is indeterminate. |
+| \_indeterminateAndActive | `[input][data-indeterminate=true]:active:not(:disabled):not(:focus) + &` | Styles for when the sibling `input` is indeterminate and actived. |
+| \_indeterminateAndChild | `[input][data-indeterminate=true] + & > *` | Styles for the child of the `ControlBox` when the sibling `input` is indeterminate. |
+| \_indeterminateAndDisabled | `[input][data-indeterminate=true]:disabled + &` | Styles for when the sibling `input` is indeterminate and disabled. |
+| \_indeterminateAndFocus | `[input][data-indeterminate=true]:focus + &` | Styles for when the sibling `input` is indeterminate and focused. |
+| \_indeterminateAndHover | `[input][data-indeterminate=true]:hover:not(:disabled):not(:focus) + &` | Styles for when the sibling `input` is indeterminate and hovered. |

--- a/packages/styled-docs/pages/cssbaseline.mdx
+++ b/packages/styled-docs/pages/cssbaseline.mdx
@@ -1,6 +1,6 @@
 # CSSBaseline
 
-The CSSBaseline component normalizes styles using [normalize.css](https://github.com/necolas/normalize.css) that provides better cross-browser consistency in the default styling of HTML elements.
+The `CSSBaseline` component normalizes styles using [normalize.css](https://github.com/necolas/normalize.css) that provides better cross-browser consistency in the default styling of HTML elements.
 
 - Preserves useful defaults, unlike many CSS resets.
 - Normalizes styles for a wide range of elements.

--- a/packages/styled-docs/pages/fade.mdx
+++ b/packages/styled-docs/pages/fade.mdx
@@ -44,5 +44,5 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| show | `boolean` | false | If `true`, the content will be visible. |
-| duration | `number` | 200 | The duration for the transition, in milliseconds. |
+| show | boolean | false | If `true`, the content will be visible. |
+| duration | number | 200 | The duration for the transition, in milliseconds. |

--- a/packages/styled-docs/pages/flatbutton.mdx
+++ b/packages/styled-docs/pages/flatbutton.mdx
@@ -82,7 +82,7 @@ Use the `size` prop to change the size of the `Button`. You can set the value to
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| disabled | `boolean` | | If `true`, the button will be disabled. |
-| size | `string` | `md` | The size of the button. One of: `sm`, `md`, `lg` |
-| variant | `string` | `solid` | The variant of the button style to use. One of: `solid`, `outline` |
-| variantColor | `string` | `gray` | The color of the button. It must be a color key defined in `theme.colors`. |
+| disabled | boolean | | If `true`, the button will be disabled. |
+| size | string | 'md' | The size of the button. One of: `'sm'`, `'md'`, `'lg'` |
+| variant | string | 'solid' | The variant of the button style to use. One of: `'solid'`, `'outline'` |
+| variantColor | string | 'gray' | The color of the button. It must be a color key defined in `theme.colors`. |

--- a/packages/styled-docs/pages/flex.mdx
+++ b/packages/styled-docs/pages/flex.mdx
@@ -1,6 +1,6 @@
 # Flex
 
-Flex is [Box](./box) with `display="flex"` and comes with helpful style shorthand props.
+`Flex` is a [`Box`](./box) with `display: flex` and comes with helpful style shorthand props.
 
 ## Import
 

--- a/packages/styled-docs/pages/grid.mdx
+++ b/packages/styled-docs/pages/grid.mdx
@@ -1,6 +1,6 @@
 # Grid
 
-Flex is [Box](./box) with `display: grid` and comes with helpful style shorthand props.
+`Grid` is a [`Box`](./box) with `display: grid` and comes with helpful style shorthand props.
 
 ## Import
 

--- a/packages/styled-docs/pages/heading.mdx
+++ b/packages/styled-docs/pages/heading.mdx
@@ -1,6 +1,6 @@
 # Heading
 
-Headings are used for rendering headlines.
+`Heading` is used for rendering headline text.
 
 ## Import
 
@@ -106,5 +106,5 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| variant | `string` | | One of: 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' |
-| `size` | `string` | | One of: '4xl', '3xl', '2xl', 'xl', 'lg', 'md', 'sm', 'xs' |
+| variant | string | | One of: `'h1'`, `'h2'`, `'h3'`, `'h4'`, `'h5'`, `'h6'` |
+| size | string | | One of: `'4xl'`, `'3xl'`, `'2xl'`, `'xl'`, `'lg'`, `'md'`, `'sm'`, `'xs'` |

--- a/packages/styled-docs/pages/input.mdx
+++ b/packages/styled-docs/pages/input.mdx
@@ -236,22 +236,12 @@ render(<Example />);
 
 ## Props
 
-### Input
-
 `Input` composes the [`InputBase`](./inputbase) component.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| `size` | `string` | 'md' | The visual size of the `input` element. One of: 'sm', 'md', 'lg' |
-| `variant` | `string` | 'outline' | The variant of the input style to use. One of: 'outline', 'filled', 'unstyled' |
-| `disabled` | `boolean` | | If `true`, the input will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
-| `readOnly` | `boolean` | | If `true`, prevents the value of the input from being edited. |
-| `aria-invalid` | `boolean` | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |
-
-### TextLabel
-
-`TextLabel` composes the [`Box`](./box) component.
-
-| Name | Type | Default | Description |
-| :--- | :--- | :------ | :---------- |
-| `size` | `string` | 'md' | One of: 'sm', 'md', 'lg' |
+| size | string | 'md' | The visual size of the `input` element. One of: `'sm'`, `'md'`, `'lg'` |
+| variant | string | 'outline' | The variant of the input style to use. One of: `'outline'`, `'filled'`, `'unstyled'` |
+| disabled | boolean | | If `true`, the input will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
+| readOnly | boolean | | If `true`, prevents the value of the input from being edited. |
+| aria-invalid | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |

--- a/packages/styled-docs/pages/inputbase.mdx
+++ b/packages/styled-docs/pages/inputbase.mdx
@@ -83,6 +83,6 @@ Standard input attributes are supported, e.g., `type`, `disabled`, `readOnly`, `
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| `disabled` | `boolean` | | If `true`, the input will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
-| `readOnly` | `boolean` | | If `true`, prevents the value of the input from being edited. |
-| `aria-invalid` | `boolean` | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |
+| disabled | boolean | | If `true`, the input will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
+| readOnly | boolean | | If `true`, prevents the value of the input from being edited. |
+| aria-invalid | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |

--- a/packages/styled-docs/pages/inputgroup.mdx
+++ b/packages/styled-docs/pages/inputgroup.mdx
@@ -261,8 +261,8 @@ While multiple `<Input />`s are supported visually, validation styles are only a
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| `size` | `string` | 'md' | The relative size to the input group itself. One of: 'sm', 'md', 'lg' |
-| `variant` | `string` | 'outline' | The variant of the input style to use. One of: 'outline', 'filled', 'unstyled' |
+| size | string | 'md' | The relative size to the input group itself. One of: `'sm'`, `'md'`, `'lg'` |
+| variant | string | 'outline' | The variant of the input style to use. One of: `'outline'`, `'filled'`, `'unstyled'` |
 
 ### InputGroupAddon
 
@@ -270,8 +270,8 @@ While multiple `<Input />`s are supported visually, validation styles are only a
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| `size` | `string` | 'md' | The relative size to the input group itself. One of: 'sm', 'md', 'lg' |
-| `variant` | `string` | 'outline' | The variant of the input style to use. One of: 'outline', 'filled', 'unstyled' |
+| size | string | 'md' | The relative size to the input group itself. One of: `'sm'`, `'md'`, `'lg'` |
+| variant | string | 'outline' | The variant of the input style to use. One of: `'outline'`, `'filled'`, `'unstyled'` |
 
 ### InputGroupAppend
 

--- a/packages/styled-docs/pages/link.mdx
+++ b/packages/styled-docs/pages/link.mdx
@@ -112,5 +112,5 @@ render(
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| disabled | `boolean` | | If `true`, the link will be disabled. |
-| onClick | `function` | | Function called when the link is clicked. |
+| disabled | boolean | | If `true`, the link will be disabled. |
+| onClick | function | | A callback called when the link is clicked. |

--- a/packages/styled-docs/pages/pseudobox.mdx
+++ b/packages/styled-docs/pages/pseudobox.mdx
@@ -1,12 +1,10 @@
 # PesudoBox
 
-PseudoBox provides useful props to style common CSS <b>pseudo-class</b> and <b>pseudo-element</b> selectors.
+`PseudoBox` provides useful props to style common CSS pseudo-class and pseudo-element selectors.
 
-A <b>pseudo-class</b> selector targets elements depending on their state rather than on information from the document tree. For example, the selector `:hover` matches when the user interacts with an element with a pointing device, but does not necessary activate it.
+A pseudo-class selector targets elements depending on their state rather than on information from the document tree. For example, the selector `:hover` matches when the user interacts with an element with a pointing device, but does not necessary activate it.
 
-A <b>pseudo-element</b> selector applies styles to parts of your document content in scenarios where there isn't a specific HTML element to select. For example, `::before` creates a <b>pseudo-element</b> that is the first child of the selected element. It is often used to add cosmetic content to an element with the `content` property.
-
-This component composes [Box](./box).
+A pseudo-element selector applies styles to parts of your document content in scenarios where there isn't a specific HTML element to select. For example, `::before` creates a <b>pseudo-element</b> that is the first child of the selected element. It is often used to add cosmetic content to an element with the `content` property.
 
 ## Import
 
@@ -348,33 +346,35 @@ function Example() {
 }
 ```
 
-## Selectors and Props
+## Props
 
-| Selector | Props |
-| :------- | :---- |
-| `&:active` | `_active` |
-| `&:checked` | `_checked` |
-| `&:disabled` | `_disabled` |
-| `&:empty` | `_empty` |
-| `&:enabled` | `_enabled` |
-| `&:first-child` | `_firstChild` |
-| `&:first-of-type` | `_firstOfType` |
-| `&:fullscreen` | `_fullscreen` |
-| `&:focus` | `_focus` |
-| `&:focus-within` | `_focusWithin` |
-| `&:hover` | `_hover` |
-| `&:indeterminate` | `_indeterminate` |
-| `&:invalid` | `_invalid` |
-| `&:last-child` | `_lastChild` |
-| `&:last-of-type` | `_lastOfType` |
-| `&:nth-of-type()` | `_nthOfType` |
-| `&:read-only` | `_readOnly` |
-| `&:visited` | `_visited` |
-| `&::after` | `__after` |
-| `&::backdrop` | `__backdrop` |
-| `&::before` | `__before` |
-| `&::cue` | `__cue` |
-| `&::first-letter` | `__firstLetter` |
-| `&::first-line` | `__firstLine` |
-| `&::placeholder` | `__placeholder` |
-| `&::selection` | `__selection` |
+`PseudoBox` composes the [`Box`](./box) component.
+
+| Name | Selector |
+| :------- | :--- |
+| _active | `&:active` |
+| _checked | `&:checked` |
+| _disabled | `&:disabled` |
+| _empty | `&:empty` |
+| _enabled | `&:enabled` |
+| _firstChild | `&:first-child` |
+| _firstOfType | `&:first-of-type` |
+| _fullscreen | `&:fullscreen` |
+| _focus | `&:focus` |
+| _focusWithin | `&:focus-within` |
+| _hover | `&:hover` |
+| _indeterminate | `&:indeterminate` |
+| _invalid | `&:invalid` |
+| _lastChild | `&:last-child` |
+| _lastOfType | `&:last-of-type` |
+| _nthOfType | `&:nth-of-type()` |
+| _readOnly | `&:read-only` |
+| _visited | `&:visited` |
+| __after | `&::after` |
+| __backdrop | `&::backdrop` |
+| __before | `&::before` |
+| __cue | `&::cue` |
+| __firstLetter | `&::first-letter` |
+| __firstLine | `&::first-line` |
+| __placeholder | `&::placeholder` |
+| __selection | `&::selection` |

--- a/packages/styled-docs/pages/radio.mdx
+++ b/packages/styled-docs/pages/radio.mdx
@@ -62,9 +62,9 @@ Use the `size` prop to change the size of the `Radio`. You can set the value to 
 | variantColor | string | | The color of the radio when it's checked. This should be one of the color keys in the theme (e.g. `'green'`, `'red'`) |
 | size | string | 'md' | The size (width and height) of the radio. One of: `'sm'`, `'md'`, `'lg'` |
 | defaultChecked | boolean | | If `true`, the radio will be initially checked. |
-| checked | boolean | | If `true`, the radio will be checked. You'll need to pass `onChange` to update it's value (since it's now controlled). |
+| checked | boolean | | If `true`, the radio will be checked. You'll need to pass `onChange` to update the state for a controlled component. |
 | disabled | boolean | | If `true`, the radio will be disabled. |
 | children | ReactNode | | The children of the radio. |
-| onChange | function | | A callback called when the state of the radio changes. |
-| onBlur | function | | A callback called when you blur out of the radio. |
-| onFocus | function | | A callback called when the radio receive focus. |
+| onChange | function | | A callback called when the state is changed. |
+| onBlur | function | | A callback called when the radio loses focus. |
+| onFocus | function | | A callback called when the radio receives focus. |

--- a/packages/styled-docs/pages/radio.mdx
+++ b/packages/styled-docs/pages/radio.mdx
@@ -2,10 +2,6 @@
 
 Radios are used when only one choice may be selected in a series of options.
 
-Native HTML radios are 100% accessible by default, so we used a [very common CSS technique](https://dev.to/lkopacz/create-custom-keyboard-accessible-radio-buttons-22eh) to style the radio.
-
-The Radio component composes `ControlBox`, a component we created to make it easy to style sibling inputs. [Check it out](./controlbox)
-
 ## Import
 
 ```js
@@ -56,17 +52,19 @@ Use the `size` prop to change the size of the `Radio`. You can set the value to 
 
 ## Props
 
+`Radio` composes the [`ControlBox`](./controlbox).
+
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| id | `string` | | The id assigned to input field |
-| name | `string` | | The name of the input field in a radio (Useful for form submission) |
-| value | `string` or `number` | | The value to be used in the radio input. This is the value that will be returned on form submission |
-| variantColor | `string` | | The color of the radio when it's checked. This should be one of the color keys in the theme (e.g."green", "red") |
-| size | `sm`, `md`, `lg` | `md` | The size (width and height) of the radio |
-| defaultChecked | `boolean` | | If `true`, the radio will be initially checked |
-| checked | `boolean` | | If `true`, the radio will be checked. You'll need to pass `onChange` to update it's value (since it's now controlled) |
-| disabled | `boolean` | | If `true`, the radio will be disabled |
-| children | `React.ReactNode` | | The children of the radio |
-| onChange | `function` | | Function called when the state of the radio changes |
-| onBlur | `function` | | Function called when you blur out of the radio |
-| onFocus | `function` | | Function called when the radio receive focus |
+| id | string | | The id assigned to input field. |
+| name | string | | The name of the input field in a radio. It's useful for form submission. |
+| value | string \| number | | The value to be used in the radio input. This is the value that will be returned on form submission. |
+| variantColor | string | | The color of the radio when it's checked. This should be one of the color keys in the theme (e.g. `'green'`, `'red'`) |
+| size | string | 'md' | The size (width and height) of the radio. One of: `'sm'`, `'md'`, `'lg'` |
+| defaultChecked | boolean | | If `true`, the radio will be initially checked. |
+| checked | boolean | | If `true`, the radio will be checked. You'll need to pass `onChange` to update it's value (since it's now controlled). |
+| disabled | boolean | | If `true`, the radio will be disabled. |
+| children | ReactNode | | The children of the radio. |
+| onChange | function | | A callback called when the state of the radio changes. |
+| onBlur | function | | A callback called when you blur out of the radio. |
+| onFocus | function | | A callback called when the radio receive focus. |

--- a/packages/styled-docs/pages/radiogroup.mdx
+++ b/packages/styled-docs/pages/radiogroup.mdx
@@ -1,5 +1,6 @@
 # RadioGroup
-
+ 
+`RadioGroup` is used to group related radios.
 
 ## Import
 
@@ -98,11 +99,11 @@ Use the `size` prop to change the size of the `RadioGroup`. You can set the valu
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| name | `string` | | The name used to reference the value of the control. If you don't provide this prop, it falls back to a randomly generated name. |
-| value | `string` or `number` | | The value to be used in the radio input. This is the value that will be returned on form submission. |
-| disabled | `boolean` | false | If `true`, all radios will be disabled. |
-| variantColor | `string` | | The color of the radio when it's checked. This should be one of the color keys in the theme (e.g."green", "red"). |
-| size | `sm`, `md`, `lg` | `md` | The size (width and height) of the radio. |
-| defaultValue | `string` or `number` | | The default `input` element value. Use when the component is not controlled. |
-| children | `React.ReactNode` | | The children of the radio. |
-| onChange | `function` | | Function called when the state of the radio changes. |
+| name | string | | The name used to reference the value of the control. If you don't provide this prop, it falls back to a randomly generated name. |
+| value | string \| number | | The value to be used in the radio input. This is the value that will be returned on form submission. |
+| disabled | boolean | false | If `true`, all radios will be disabled. |
+| variantColor | string | | The color of the radio when it's checked. This should be one of the color keys in the theme (e.g. `'green'`, `'red'`). |
+| size | string | 'md' | The size (width and height) of the radio. One of: `'sm'`, `'md'`, `'lg'` |
+| defaultValue | string \| number | | The default `input` element value. Use when the component is not controlled. |
+| children | ReactNode | | The children of the radio. |
+| onChange | function` | | A callback called when the state of the radio changes. |

--- a/packages/styled-docs/pages/spinner.mdx
+++ b/packages/styled-docs/pages/spinner.mdx
@@ -78,7 +78,7 @@ Use the `size` prop to change the size of the `Spinner`. You can set the value t
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| `size` | `string` | 'md' | The size of the spinner. One of: 'xl', 'lg', 'md', 'sm', 'xs' |
-| `color` | `string` | 'blue:60' | The color of the spinner. |
-| `strokeWidth` | `number` | | Set a different stroke width for the spinner. |
-| `speed` | `float` | 2 | Set a different speed for the spinner. |
+| size | string | 'md' | The size of the spinner. One of: `'xl'`, `'lg'`, `'md'`, `'sm'`, `'xs'` |
+| color | string | 'blue:60' | The color of the spinner. |
+| strokeWidth | number | | Set a different stroke width for the spinner. |
+| speed | float | 2 | Set a different speed for the spinner. |

--- a/packages/styled-docs/pages/stack.mdx
+++ b/packages/styled-docs/pages/stack.mdx
@@ -128,6 +128,6 @@ render(<Example />);
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| `direction` | `string` | 'column' | The direction to stack the items. One of: 'column', 'column-reverse', 'row', 'row-reverse' |
-| `spacing` | `string` or `number` | 0 | The space between each stack item. |
-| `shouldWrapChildren` | `boolean` | false | If `true`, the children will be wrapped in a `Box` with `display="inline-block"`, and the Box will take the spacing props. |
+| direction | string | 'column' | The direction to stack the items. One of: `'column'`, `'column-reverse'`, `'row'`, `'row-reverse'` |
+| spacing | string \| number | 0 | The space between each stack item. |
+| shouldWrapChildren | boolean | false | If `true`, the children will be wrapped in a `Box` with `display: inline-block`, and the `Box` will take the `spacing` props. |

--- a/packages/styled-docs/pages/svgicon.mdx
+++ b/packages/styled-docs/pages/svgicon.mdx
@@ -61,7 +61,7 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| size | `string` | | The size of the icon. |
-| color | `string` | 'currentColor' | The color of the icon. |
-| focusable | `boolean` | false | Denotes that the icon is not an interactive element, and only used for presentation |
-| role | `string` | 'presentation' | One of: 'presentation', 'img' |
+| size | string | | The size of the icon. |
+| color | string | 'currentColor' | The color of the icon. |
+| focusable | boolean | false | Denotes that the icon is not an interactive element, and only used for presentation. |
+| role | string | 'presentation' | One of: `'presentation'`, `'img'` |

--- a/packages/styled-docs/pages/text.mdx
+++ b/packages/styled-docs/pages/text.mdx
@@ -1,6 +1,6 @@
 # Text
 
-Text is [Box](./box) with `display="inline-block"` and `fontFamily="base"`.
+`Text` is used for rendering text and paragraphs.
 
 ## Import
 
@@ -129,4 +129,4 @@ render(<Example />);
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| `size` | `string` | | One of: '4xl', '3xl', '2xl', 'xl', 'lg', 'md', 'sm', 'xs' |
+| size | string | | One of: `'4xl'`, `'3xl'`, `'2xl'`, `'xl'`, `'lg'`, `'md'`, `'sm'`, `'xs'` |

--- a/packages/styled-docs/pages/textarea.mdx
+++ b/packages/styled-docs/pages/textarea.mdx
@@ -176,12 +176,12 @@ render(<Example />);
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| `rows` | `number` | | Specifies the visible number of lines in a text area. |
-| `cols` | `number` | | Specifies the visible width of a text area. |
-| `maxLength` | `number` | | Specifies a maximum number of characters that is allowed to contain. |
-| `minLength` | `number` | | Specifies a minimum length that is considered valid. |
-| `resize` | `string` | | One of: 'none', 'both', 'horizontal', 'vertical' |
-| `variant` | `string` | 'outline' | The variant of the input style to use. One of: 'outline', 'filled', 'unstyled' |
-| `disabled` | `boolean` | | If `true`, the input will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
-| `readOnly` | `boolean` | | If `true`, prevents the value of the input from being edited. |
-| `aria-invalid` | `boolean` | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |
+| rows | number | | Specifies the visible number of lines in a text area. |
+| cols | number | | Specifies the visible width of a text area. |
+| maxLength | number | | Specifies a maximum number of characters that is allowed to contain. |
+| minLength | number | | Specifies a minimum length that is considered valid. |
+| resize | string | | One of: `'none'`, `'both'`, `'horizontal'`, `'vertical'` |
+| variant | string | 'outline' | The variant of the input style to use. One of: `'outline'`, `'filled'`, `'unstyled'` |
+| disabled | boolean | | If `true`, the input will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
+| readOnly | boolean | | If `true`, prevents the value of the input from being edited. |
+| aria-invalid` | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |

--- a/packages/styled-docs/pages/textlabel.mdx
+++ b/packages/styled-docs/pages/textlabel.mdx
@@ -24,4 +24,4 @@ The text colors in the dark mode and light mode are `white:secondary` and `black
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| `size` | `string` | | One of: '4xl', '3xl', '2xl', 'xl', 'lg', 'md', 'sm', 'xs' |
+| size | string | | One of: `'4xl'`, `'3xl'`, `'2xl'`, `'xl'`, `'lg'`, `'md'`, `'sm'`, `'xs'` |

--- a/packages/styled-docs/pages/tooltip.mdx
+++ b/packages/styled-docs/pages/tooltip.mdx
@@ -107,18 +107,18 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 
 ## Props
 
-| Name                 | Type                 | Default  | Description                                                                                |
-| -------------------- | -------------------- | -------- | ------------------------------------------------------------------------------------------ |
-| `isOpen`             | `boolean`            |          | If `true`, the tooltip is shown.                                                           |
-| `defaultIsOpen`      | `boolean`            |          | If `true`, the tooltip is initially shown.                                                 |
-| `label`              | `string`             |          | The label of the tooltip.                                                                  |
-| `aria-label`         | `string`             |          | An alternate label for screen readers.                                                     |
-| `placement`          | `PopperJS.Placement` | `bottom` | Position the tooltip relative to the trigger element as well as surrounding elements.      |
-| `children`           | `React.ReactNode`    |          | The `ReactNode` to be used as the trigger of the tooltip.                                  |
-| `hideArrow`          | `boolean`            |          | If `true` hide the arrow tip on the tooltip.                                               |
-| `showDelay`          | `number`             |          | The delay in `ms` for the tooltip to show                                                  |
-| `hideDelay`          | `number`             |          | The delay in `ms` for the tooltip to hide                                                  |
-| `closeOnClick`       | `boolean`            |          | If `true` hide the tooltip, when the trigger is clicked.                                   |
-| `shouldWrapChildren` | `boolean`            |          | If `true`, the tooltip will wrap the children in a `span` with `tabIndex=0`                |
-| `onOpen`             | `function`           |          | Function called when the tooltip shows.                                                    |
-| `onClose`            | `function`           |          | Function called when the tooltip hides.                                                    |
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| isOpen | boolean | | If `true`, the tooltip is shown. |
+| defaultIsOpen | boolean | | If `true`, the tooltip is initially shown. |
+| label | string | | The label of the tooltip.|
+| aria-label | string | | An alternate label for screen readers. |
+| placement | PopperJS.Placement | 'bottom' | Position the tooltip relative to the trigger element as well as surrounding elements. One of: `'auto'`, `'auto-start'`, `'auto-end'`, `'top'`, `'bottom'`, `'right'`, `'left'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`, `'right-start'`, `'right-end'`, `'left-start'`, `'left-end'` |
+| children | ReactNode | | The `ReactNode` to be used as the trigger of the tooltip. |
+| hideArrow | boolean | | If `true` hide the arrow tip on the tooltip. |
+| showDelay | number | | The delay in milliseconds for the tooltip to show. |
+| hideDelay | number | | The delay in milliseconds for the tooltip to hide. |
+| closeOnClick | boolean | | If `true` hide the tooltip, when the trigger is clicked. |
+| shouldWrapChildren | boolean| | If `true`, the tooltip will wrap the children in a `span` with `tabIndex=0`. |
+| onOpen | function | | A callback called when the tooltip shows. |
+| onClose| function | | A callback called when the tooltip hides. |


### PR DESCRIPTION
* No backticks (`) in the **Name**, **Type**, and **Default** columns
* Use backtick (`) in the **Description** column for all special words including types like boolean and string values.
* Use a period to end the sentence in the **Description** column.