### PR TITLE
docs: update sizes and spacing theme example

### DIFF
--- a/packages/styled-docs/pages/sizes.mdx
+++ b/packages/styled-docs/pages/sizes.mdx
@@ -9,7 +9,7 @@ build for your project. By default these spacing value can be referenced by the
 
 <ThemeParser theme="sizes" />
 
-By default, the values are proportional, so 1x spacing unit is equal to
+By default, the values are proportional, so `1x` spacing unit is equal to
 `0.25rem`, which translates to `4px` by default in common browsers.
 
 | Name | Space   | Pixels |                                    |
@@ -45,7 +45,7 @@ By default, the values are proportional, so 1x spacing unit is equal to
 ## Width
 
 ```jsx
-<Stack direction="column" spacing=".5rem">
+<Stack direction="column" spacing="4x">
   <Box width="40x" p="1x" fontSize="sm" bg="gray:70">Width 10rem(160px)</Box>
   <Box width="48x" p="1x" fontSize="sm" bg="gray:70">Width 12rem(192px)</Box>
   <Box width="56x" p="1x" fontSize="sm" bg="gray:70">Width 14rem(224px)</Box>
@@ -56,7 +56,7 @@ By default, the values are proportional, so 1x spacing unit is equal to
 ## Height
 
 ```jsx
-<Stack direction="row" spacing=".5rem">
+<Stack direction="row" spacing="4x">
   <Box width="40x" height="8x" p="1x" fontSize="sm" bg="gray:70">Height 2rem(32px)</Box>
   <Box width="40x" height="16x" p="1x" fontSize="sm" bg="gray:70">Height 4rem(64px)</Box>
   <Box width="40x" height="24x" p="1x" fontSize="sm" bg="gray:70">Height 6rem(96px)</Box>

--- a/packages/styled-docs/pages/sizes.mdx
+++ b/packages/styled-docs/pages/sizes.mdx
@@ -9,6 +9,39 @@ build for your project. By default these spacing value can be referenced by the
 
 <ThemeParser theme="sizes" />
 
+By default, the values are proportional, so 1x spacing unit is equal to
+`0.25rem`, which translates to `4px` by default in common browsers.
+
+| Name | Space   | Pixels |                                    |
+| ---- | ------- | ------ | ---------------------------------- |
+| 0    | 0       | 0px    | <Box bg="blue:60" h="4x" w={0}/>   |
+| 1x   | .25rem  | 4px    | <Box bg="blue:60" h="4x" w="1x"/>  |
+| 2x   | .5rem   | 8px    | <Box bg="blue:60" h="4x" w="2x"/>  |
+| 3x   | .75rem  | 12px   | <Box bg="blue:60" h="4x" w="3x"/>  |
+| 4x   | 1rem    | 16px   | <Box bg="blue:60" h="4x" w="4x"/>  |
+| 5x   | 1.25rem | 20px   | <Box bg="blue:60" h="4x" w="5x"/>  |
+| 6x   | 1.5rem  | 24px   | <Box bg="blue:60" h="4x" w="6x"/>  |
+| 7x   | 1.75rem | 28px   | <Box bg="blue:60" h="4x" w="7x"/>  |
+| 8x   | 2rem    | 32px   | <Box bg="blue:60" h="4x" w="8x"/>  |
+| 9x   | 2.25rem | 36px   | <Box bg="blue:60" h="4x" w="9x"/>  |
+| 10x  | 2.5rem  | 40px   | <Box bg="blue:60" h="4x" w="10x"/> |
+| 11x  | 2.75rem | 44px   | <Box bg="blue:60" h="4x" w="11x"/> |
+| 12x  | 3rem    | 48px   | <Box bg="blue:60" h="4x" w="12x"/> |
+| 13x  | 3.25rem | 52px   | <Box bg="blue:60" h="4x" w="13x"/> |
+| 14x  | 3.5rem  | 56px   | <Box bg="blue:60" h="4x" w="14x"/> |
+| 15x  | 3.75rem | 60px   | <Box bg="blue:60" h="4x" w="15x"/> |
+| 16x  | 4rem    | 64px   | <Box bg="blue:60" h="4x" w="16x"/> |
+| 17x  | 4.25rem | 68px   | <Box bg="blue:60" h="4x" w="17x"/> |
+| 18x  | 4.5rem  | 72px   | <Box bg="blue:60" h="4x" w="18x"/> |
+| 19x  | 4.75rem | 76px   | <Box bg="blue:60" h="4x" w="19x"/> |
+| 20x  | 5rem    | 80px   | <Box bg="blue:60" h="4x" w="20x"/> |
+| 24x  | 6rem    | 96px   | <Box bg="blue:60" h="4x" w="24x"/> |
+| 32x  | 8rem    | 128px  | <Box bg="blue:60" h="4x" w="32x"/> |
+| 40x  | 10rem   | 160px  | <Box bg="blue:60" h="4x" w="40x"/> |
+| 48x  | 12rem   | 192px  | <Box bg="blue:60" h="4x" w="48x"/> |
+| 56x  | 14rem   | 224px  | <Box bg="blue:60" h="4x" w="56x"/> |
+| 64x  | 16rem   | 256px  | <Box bg="blue:60" h="4x" w="64x"/> |
+
 ## Width
 
 ```jsx

--- a/packages/styled-docs/pages/spacing.mdx
+++ b/packages/styled-docs/pages/spacing.mdx
@@ -9,7 +9,7 @@ your project. By default these spacing value can be referenced by the `padding`,
 
 <ThemeParser theme="space" />
 
-By default, the values are proportional, so 1 spacing unit is equal to
+By default, the values are proportional, so 1x spacing unit is equal to
 `0.25rem`, which translates to `4px` by default in common browsers.
 
 | Name | Space   | Pixels |                                    |
@@ -25,8 +25,15 @@ By default, the values are proportional, so 1 spacing unit is equal to
 | 8x   | 2rem    | 32px   | <Box bg="blue:60" h="4x" w="8x"/>  |
 | 9x   | 2.25rem | 36px   | <Box bg="blue:60" h="4x" w="9x"/>  |
 | 10x  | 2.5rem  | 40px   | <Box bg="blue:60" h="4x" w="10x"/> |
+| 11x  | 2.75rem | 44px   | <Box bg="blue:60" h="4x" w="11x"/> |
 | 12x  | 3rem    | 48px   | <Box bg="blue:60" h="4x" w="12x"/> |
+| 13x  | 3.25rem | 52px   | <Box bg="blue:60" h="4x" w="13x"/> |
+| 14x  | 3.5rem  | 56px   | <Box bg="blue:60" h="4x" w="14x"/> |
+| 15x  | 3.75rem | 60px   | <Box bg="blue:60" h="4x" w="15x"/> |
 | 16x  | 4rem    | 64px   | <Box bg="blue:60" h="4x" w="16x"/> |
+| 17x  | 4.25rem | 68px   | <Box bg="blue:60" h="4x" w="17x"/> |
+| 18x  | 4.5rem  | 72px   | <Box bg="blue:60" h="4x" w="18x"/> |
+| 19x  | 4.75rem | 76px   | <Box bg="blue:60" h="4x" w="19x"/> |
 | 20x  | 5rem    | 80px   | <Box bg="blue:60" h="4x" w="20x"/> |
 | 24x  | 6rem    | 96px   | <Box bg="blue:60" h="4x" w="24x"/> |
 | 32x  | 8rem    | 128px  | <Box bg="blue:60" h="4x" w="32x"/> |

--- a/packages/styled-docs/pages/spacing.mdx
+++ b/packages/styled-docs/pages/spacing.mdx
@@ -9,7 +9,7 @@ your project. By default these spacing value can be referenced by the `padding`,
 
 <ThemeParser theme="space" />
 
-By default, the values are proportional, so 1x spacing unit is equal to
+By default, the values are proportional, so `1x` spacing unit is equal to
 `0.25rem`, which translates to `4px` by default in common browsers.
 
 | Name | Space   | Pixels |                                    |


### PR DESCRIPTION
For now, I use same example for sizes and spacing themes. 
I think the visual designer will make a new example design for it. I’ll follow up when they have an update.