### PR TITLE
fix: use size instead of width and height for Icon

### DIFF
--- a/packages/react-styled-core/src/Alert/index.js
+++ b/packages/react-styled-core/src/Alert/index.js
@@ -50,8 +50,7 @@ const AlertIcon = props => {
   return (
     <Icon
       mr="2x"
-      width="4x"
-      height="4x"
+      size="4x"
       name={`_core.${iconName}`}
       {...props}
     />

--- a/packages/react-styled-core/src/Checkbox/index.js
+++ b/packages/react-styled-core/src/Checkbox/index.js
@@ -110,8 +110,7 @@ const Checkbox = forwardRef(
           <Icon
             zIndex="1"
             name={indeterminate ? '_core.minus' : '_core.check'}
-            width={iconSize}
-            height={iconSize}
+            size={iconSize}
             color={iconColor}
             transition="transform 240ms, opacity 240ms"
           />

--- a/packages/react-styled-core/src/Checkbox/styles.js
+++ b/packages/react-styled-core/src/Checkbox/styles.js
@@ -89,11 +89,13 @@ const useCheckboxStyle = props => {
     md: '16px',
     sm: 'auto',
   };
+  const size = sizes[props.size];
   const _props = { ...props, colorMode };
   return {
     ...baseProps,
     ...props.indeterminate ? { ...indeterminateProps(_props) } : { ...interactionProps(_props) },
-    size: sizes[props.size],
+    width: size,
+    height: size,
   };
 };
 

--- a/packages/react-styled-core/src/Toast/index.js
+++ b/packages/react-styled-core/src/Toast/index.js
@@ -62,8 +62,7 @@ const ToastIcon = props => {
   return (
     <Icon
       mr="2x"
-      width="4x"
-      height="4x"
+      size="4x"
       name={`_core.${iconName}`}
       {...iconProps}
       {...props}


### PR DESCRIPTION
`Icon` composes the `SVGIcon` component, and `SVGIcon` component has handled `size` prop, so `Icon` component should use `size` instead of `width` and `height`.
![image](https://user-images.githubusercontent.com/24446505/78957461-f69a6800-7b17-11ea-9d4a-492ce1901ee3.png)

### Issue
![image](https://user-images.githubusercontent.com/24446505/78957298-90ade080-7b17-11ea-96cb-a0e556e32a43.png)
![image](https://user-images.githubusercontent.com/24446505/78958057-9d333880-7b19-11ea-845a-6abd011ad14e.png)

### Fix
![image](https://user-images.githubusercontent.com/24446505/78957391-ca7ee700-7b17-11ea-9e95-372c54055677.png)
![image](https://user-images.githubusercontent.com/24446505/78958069-a2908300-7b19-11ea-9d08-dff31c71ae16.png)
