### PR TITLE
refactor: textDecoration in hover or active state

### DIFF
--- a/packages/react-styled-core/src/Link/index.js
+++ b/packages/react-styled-core/src/Link/index.js
@@ -3,17 +3,18 @@ import PropTypes from 'prop-types';
 import PseudoBox from '../PseudoBox';
 import useColorMode from '../useColorMode';
 
-const baseStyleProps = (colorMode, hideUnderline) => {
+const baseStyleProps = (colorMode, disabled, textDecoration) => {
   const color = { light: 'blue:60', dark: 'blue:40' }[colorMode];
   const hoverColor = { light: 'blue:50', dark: 'blue:40' }[colorMode];
   const visitedColor = { light: 'purple:60', dark: 'purple:50' }[colorMode];
   const disabledColor = { light: 'black:disabled', dark: 'white:disabled' }[colorMode];
-
+  const hoverTextDecoration = !!disabled ? 'none' : 'underline';
+  const activeTextDecoration = !!disabled ? 'none' : 'underline';
   return {
     color,
     cursor: 'pointer',
     outline: 'none',
-    textDecoration: 'none',
+    textDecoration: textDecoration ?? 'none',
     _disabled: {
       color: disabledColor,
       cursor: 'not-allowed',
@@ -23,25 +24,25 @@ const baseStyleProps = (colorMode, hideUnderline) => {
     },
     _hover: {
       color: hoverColor,
-      textDecoration: hideUnderline ? 'none' : 'underline',
+      textDecoration: textDecoration ?? hoverTextDecoration,
     },
     _active: {
       color: 'blue:60',
-      textDecoration: hideUnderline ? 'none' : 'underline',
+      textDecoration: textDecoration ?? activeTextDecoration,
     },
   };
 };
 
-const Link = forwardRef(({ disabled, onClick, ...props }, ref) => {
+const Link = forwardRef(({ disabled, onClick, textDecoration, ...props }, ref) => {
   const { colorMode } = useColorMode();
-  const hideUnderline = props.textDecoration !== 'underline' && disabled;
+  //const hideUnderline = props.textDecoration !== 'underline' && disabled;
   return (
     <PseudoBox
       as="a"
       ref={ref}
       aria-disabled={disabled}
       onClick={disabled ? event => event.preventDefault() : onClick}
-      {...baseStyleProps(colorMode, hideUnderline)}
+      {...baseStyleProps(colorMode, disabled, textDecoration)}
       {...props}
     />
   );

--- a/packages/react-styled-core/src/Link/index.js
+++ b/packages/react-styled-core/src/Link/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import PseudoBox from '../PseudoBox';
 import useColorMode from '../useColorMode';
 
-const baseStyleProps = (colorMode) => {
+const baseStyleProps = (colorMode, hideUnderline) => {
   const color = { light: 'blue:60', dark: 'blue:40' }[colorMode];
   const hoverColor = { light: 'blue:50', dark: 'blue:40' }[colorMode];
   const visitedColor = { light: 'purple:60', dark: 'purple:50' }[colorMode];
@@ -23,25 +23,25 @@ const baseStyleProps = (colorMode) => {
     },
     _hover: {
       color: hoverColor,
-      textDecoration: 'underline',
+      textDecoration: hideUnderline ? 'none' : 'underline',
     },
     _active: {
       color: 'blue:60',
-      textDecoration: 'underline',
+      textDecoration: hideUnderline ? 'none' : 'underline',
     },
   };
 };
 
 const Link = forwardRef(({ disabled, onClick, ...props }, ref) => {
   const { colorMode } = useColorMode();
-
+  const hideUnderline = props.textDecoration !== 'underline' && disabled;
   return (
     <PseudoBox
       as="a"
       ref={ref}
       aria-disabled={disabled}
       onClick={disabled ? event => event.preventDefault() : onClick}
-      {...baseStyleProps(colorMode)}
+      {...baseStyleProps(colorMode, hideUnderline)}
       {...props}
     />
   );
@@ -51,6 +51,7 @@ Link.propTypes = {
   variant: PropTypes.string,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
+  textDecoration: PropTypes.string
 };
 
 Link.displayName = 'Link';

--- a/packages/react-styled-core/src/Link/index.js
+++ b/packages/react-styled-core/src/Link/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import PseudoBox from '../PseudoBox';
 import useColorMode from '../useColorMode';
 
-const baseStyleProps = (colorMode, disabled, textDecoration) => {
+const baseStyleProps = ({ colorMode, disabled, textDecoration }) => {
   const color = { light: 'blue:60', dark: 'blue:40' }[colorMode];
   const hoverColor = { light: 'blue:50', dark: 'blue:40' }[colorMode];
   const visitedColor = { light: 'purple:60', dark: 'purple:50' }[colorMode];
@@ -35,14 +35,13 @@ const baseStyleProps = (colorMode, disabled, textDecoration) => {
 
 const Link = forwardRef(({ disabled, onClick, textDecoration, ...props }, ref) => {
   const { colorMode } = useColorMode();
-  //const hideUnderline = props.textDecoration !== 'underline' && disabled;
   return (
     <PseudoBox
       as="a"
       ref={ref}
       aria-disabled={disabled}
       onClick={disabled ? event => event.preventDefault() : onClick}
-      {...baseStyleProps(colorMode, disabled, textDecoration)}
+      {...baseStyleProps({ colorMode, disabled, textDecoration })}
       {...props}
     />
   );

--- a/packages/styled-docs/pages/link.mdx
+++ b/packages/styled-docs/pages/link.mdx
@@ -32,26 +32,6 @@ import { Link } from '@trendmicro/react-styled-core';
 </Stack>
 ```
 
-### Link without `href` attribute
-
-```jsx
-function Example() {
-  const [value, setValue] = React.useState(0);
-
-  return (
-    <>
-      <Link
-        onClick={() => {
-          setValue(value => value + 1);
-        }}
-      >
-        Click Me
-      </Link>
-      <Box>Count: {value}</Box>
-    </>
-  );
-}
-```
 
 ### An underlined link
 
@@ -67,12 +47,21 @@ function Example() {
 ### Link with `disabled` attribute
 
 ```jsx
-<Link
-  href="https://github.com/trendmicro-frontend"
-  disabled
->
-  Trend Micro Frontend
-</Link>
+<Stack direction="column" spacing=".5rem">
+  <Link
+    href="https://github.com/trendmicro-frontend"
+    disabled
+  >
+    Trend Micro Frontend
+  </Link>
+  <Link
+    href="https://github.com/trendmicro-frontend"
+    textDecoration="underline"
+    disabled
+  >
+    Trend Micro Frontend
+  </Link>
+</Stack>
 ```
 
 ### Link to another page

--- a/packages/styled-docs/pages/link.mdx
+++ b/packages/styled-docs/pages/link.mdx
@@ -13,7 +13,7 @@ import { Link } from '@trendmicro/react-styled-core';
 ## Usage
 
 ```jsx
-<Stack direction="column" spacing=".5rem">
+<Stack shouldWrapChildren direction="column" spacing=".5rem">
   <Link href="https://github.com/trendmicro-frontend" fontSize="xs" lineHeight="xs">
     Trend Micro Frontend
   </Link>
@@ -47,7 +47,7 @@ import { Link } from '@trendmicro/react-styled-core';
 ### Link with `disabled` attribute
 
 ```jsx
-<Stack direction="column" spacing=".5rem">
+<Stack shouldWrapChildren direction="column" spacing=".5rem">
   <Link
     href="https://github.com/trendmicro-frontend"
     disabled


### PR DESCRIPTION
Fixed from VD reviewed comments:

1. The normal link would not have underline when hovering in disabled status
2. Add underline link disable example
3. VD 覺得目前沒有“link 沒有href的情境在產品上，所以先將onClick 那個範例拿掉，但是props那邊依然有告訴使用者可以使用onClick，這點看看 @roth1002 @tinaClin @cheton 你們覺得呢？