### PR TITLE
docs: refine documentation for toasts

### DIFF
--- a/packages/react-styled-ui/src/AlertToast/styles.js
+++ b/packages/react-styled-ui/src/AlertToast/styles.js
@@ -13,7 +13,7 @@ const getDefaultStyle = ({
 }) => {
   const backgroundColor = {
     dark: 'gray:10',
-    light: 'gray:10',
+    light: 'white',
   }[colorMode];
   const color = 'black:primary';
 
@@ -30,7 +30,7 @@ const getSuccessStyle = ({
   const { sizes } = theme;
   const backgroundColor = {
     dark: 'gray:10',
-    light: 'gray:10',
+    light: 'white',
   }[colorMode];
   const color = 'black:primary';
   const borderStyle = {
@@ -54,7 +54,7 @@ const getInfoStyle = ({
   const { sizes } = theme;
   const backgroundColor = {
     dark: 'gray:10',
-    light: 'gray:10',
+    light: 'white',
   }[colorMode];
   const color = 'black:primary';
   const borderStyle = {
@@ -78,7 +78,7 @@ const getWarningStyle = ({
   const { sizes } = theme;
   const backgroundColor = {
     dark: 'gray:10',
-    light: 'gray:10',
+    light: 'white',
   }[colorMode];
   const color = 'black:primary';
   const borderStyle = {
@@ -102,7 +102,7 @@ const getErrorStyle = ({
   const { sizes } = theme;
   const backgroundColor = {
     dark: 'gray:10',
-    light: 'gray:10',
+    light: 'white',
   }[colorMode];
   const color = 'black:primary';
   const borderStyle = {

--- a/packages/react-styled-ui/src/Toast/styles.js
+++ b/packages/react-styled-ui/src/Toast/styles.js
@@ -12,7 +12,7 @@ const useToastRootStyle = () => {
   const { colorMode } = useColorMode();
   const backgroundColor = {
     dark: 'gray:10',
-    light: 'gray:10',
+    light: 'white',
   }[colorMode];
   const color = 'black:primary';
 

--- a/packages/react-styled-ui/src/useToast/index.js
+++ b/packages/react-styled-ui/src/useToast/index.js
@@ -13,7 +13,6 @@ const useToast = () => {
       position = 'top',
       duration = 5000,
       render,
-      status,
     }) => {
       const options = {
         position,
@@ -25,10 +24,10 @@ const useToast = () => {
       }
 
       return toaster.notify(
-        ({ onClose, id }) => (
+        ({ id, onClose }) => (
           <ThemeProvider theme={theme}>
             <ColorModeProvider value={colorMode}>
-              {render({ onClose, id })}
+              {render({ id, onClose, position, duration })}
             </ColorModeProvider>
           </ThemeProvider>
         ),

--- a/packages/styled-ui-docs/pages/alerttoast.mdx
+++ b/packages/styled-ui-docs/pages/alerttoast.mdx
@@ -106,7 +106,7 @@ const AlertToastWithAllTogether = ({ onClose }) => (
   </AlertToast>
 );
 
-const AlertToastLayout = (props) => {
+const ToastLayout = (props) => {
   const { colorMode } = useColorMode();
   const boxShadow = {
     dark: 'dark.sm',
@@ -114,20 +114,39 @@ const AlertToastLayout = (props) => {
   }[colorMode];
 
   return (
-    <Box fontSize="sm" lineHeight="sm" textAlign="left" my="1x" boxShadow={boxShadow} {...props} />
+    <Box
+      fontSize="sm"
+      lineHeight="sm"
+      textAlign="left"
+      boxShadow={boxShadow}
+      width={320}
+      {...props}
+    />
   );
 };
 
 function Example() {
   const toast = useToast();
-  const handleClickBy = (AlertToastComponent) => () => {
+  const handleClickBy = (AlertToastNotification) => () => {
     toast({
+      position: 'bottom-right',
       duration: 5000,
-      render: ({ onClose }) => (
-        <AlertToastLayout minWidth={320}>
-          <AlertToastComponent onClose={onClose} />
-        </AlertToastLayout>
-      ),
+      render: ({ onClose, position }) => {
+        const styleProps = {
+          'top-left': { mt: '2x', mx: '4x' },
+          'top': { mt: '2x', mx: '4x' },
+          'top-right': { mt: '2x', mx: '4x' },
+          'bottom-left': { mb: '2x', mx: '4x' },
+          'bottom': { mb: '2x', mx: '4x' },
+          'bottom-right': { mb: '2x', mx: '4x' },
+        }[position];
+
+        return (
+          <ToastLayout {...styleProps}>
+            <AlertToastNotification onClose={onClose} />
+          </ToastLayout>
+        );
+      },
     });
   };
 
@@ -141,9 +160,9 @@ function Example() {
           >
             Show
           </Button>
-          <AlertToastLayout mt="4x">
+          <ToastLayout mt="4x">
             <AlertToastSimple />
-          </AlertToastLayout>
+          </ToastLayout>
         </Box>
         <Box>
           <Button
@@ -152,9 +171,9 @@ function Example() {
           >
             Show
           </Button>
-          <AlertToastLayout mt="4x">
+          <ToastLayout mt="4x">
             <AlertToastWithIcon />
-          </AlertToastLayout>
+          </ToastLayout>
         </Box>
         <Box>
           <Button
@@ -163,11 +182,10 @@ function Example() {
           >
             Show
           </Button>
-          <AlertToastLayout mt="4x">
+          <ToastLayout mt="4x">
             <AlertToastWithTitle />
-          </AlertToastLayout>
+          </ToastLayout>
         </Box>
-
         <Box>
           <Button
             variant="secondary"
@@ -175,9 +193,9 @@ function Example() {
           >
             Show
           </Button>
-          <AlertToastLayout mt="4x">
+          <ToastLayout mt="4x">
             <AlertToastWithActionButton />
-          </AlertToastLayout>
+          </ToastLayout>
         </Box>
         <Box>
           <Button
@@ -186,9 +204,9 @@ function Example() {
           >
             Show
           </Button>
-          <AlertToastLayout mt="4x">
+          <ToastLayout mt="4x">
             <AlertToastWithActionLink />
-          </AlertToastLayout>
+          </ToastLayout>
         </Box>
         <Box>
           <Button
@@ -197,9 +215,9 @@ function Example() {
           >
             Show
           </Button>
-          <AlertToastLayout mt="4x">
+          <ToastLayout mt="4x">
             <AlertToastWithAllTogether />
-          </AlertToastLayout>
+          </ToastLayout>
         </Box>
       </Stack>
     </>
@@ -246,7 +264,14 @@ const ToastLayout = (props) => {
   }[colorMode];
 
   return (
-    <Box fontSize="sm" lineHeight="sm" textAlign="left" my="2x" boxShadow={boxShadow} {...props} />
+    <Box
+      fontSize="sm"
+      lineHeight="sm"
+      textAlign="left"
+      boxShadow={boxShadow}
+      width={320}
+      {...props}
+    />
   );
 };
 
@@ -254,12 +279,24 @@ function Example() {
   const toast = useToast();
   const handleClickBy = (AlertToastNotification) => () => {
     toast({
+      position: 'bottom-right',
       duration: 5000,
-      render: ({ onClose }) => (
-        <ToastLayout minWidth={320}>
-          <AlertToastNotification onClose={onClose} />
-        </ToastLayout>
-      ),
+      render: ({ onClose, position }) => {
+        const styleProps = {
+          'top-left': { mt: '2x', mx: '4x' },
+          'top': { mt: '2x', mx: '4x' },
+          'top-right': { mt: '2x', mx: '4x' },
+          'bottom-left': { mb: '2x', mx: '4x' },
+          'bottom': { mb: '2x', mx: '4x' },
+          'bottom-right': { mb: '2x', mx: '4x' },
+        }[position];
+
+        return (
+          <ToastLayout {...styleProps}>
+            <AlertToastNotification onClose={onClose} />
+          </ToastLayout>
+        );
+      },
     });
   };
   const alertToasts = [
@@ -342,7 +379,14 @@ const ToastLayout = (props) => {
   }[colorMode];
 
   return (
-    <Box fontSize="sm" lineHeight="sm" textAlign="left" my="2x" boxShadow={boxShadow} {...props} />
+    <Box
+      fontSize="sm"
+      lineHeight="sm"
+      textAlign="left"
+      boxShadow={boxShadow}
+      width={320}
+      {...props}
+    />
   );
 };
 
@@ -350,12 +394,24 @@ function Example() {
   const toast = useToast();
   const handleClickBy = (AlertToastNotification) => () => {
     toast({
+      position: 'bottom-right',
       duration: 5000,
-      render: ({ onClose }) => (
-        <ToastLayout minWidth={320}>
-          <AlertToastNotification onClose={onClose} />
-        </ToastLayout>
-      ),
+      render: ({ onClose, position }) => {
+        const styleProps = {
+          'top-left': { mt: '2x', mx: '4x' },
+          'top': { mt: '2x', mx: '4x' },
+          'top-right': { mt: '2x', mx: '4x' },
+          'bottom-left': { mb: '2x', mx: '4x' },
+          'bottom': { mb: '2x', mx: '4x' },
+          'bottom-right': { mb: '2x', mx: '4x' },
+        }[position];
+
+        return (
+          <ToastLayout {...styleProps}>
+            <AlertToastNotification onClose={onClose} />
+          </ToastLayout>
+        );
+      },
     });
   };
   const alertToasts = [

--- a/packages/styled-ui-docs/pages/text.mdx
+++ b/packages/styled-ui-docs/pages/text.mdx
@@ -65,9 +65,6 @@ function Example() {
       <Text bg={bg} lineHeight="base" px="2x">
         For accessibility concerns, use a minimum value of 1.5 for <code>line-height</code> for main paragraph content
       </Text>
-      <Text bg={bg} fontSize="3rem" lineHeight="1.5" px="2x">
-        Pass fontSize and lineHeight props
-      </Text>
     </Stack>
   );
 }

--- a/packages/styled-ui-docs/pages/toast.mdx
+++ b/packages/styled-ui-docs/pages/toast.mdx
@@ -114,20 +114,39 @@ const ToastLayout = (props) => {
   }[colorMode];
 
   return (
-    <Box fontSize="sm" lineHeight="sm" textAlign="left" my="1x" boxShadow={boxShadow} {...props} />
+    <Box
+      fontSize="sm"
+      lineHeight="sm"
+      textAlign="left"
+      boxShadow={boxShadow}
+      width={320}
+      {...props}
+    />
   );
 };
 
 function Example() {
   const toast = useToast();
-  const handleClickBy = (ToastComponent) => () => {
+  const handleClickBy = (ToastNotification) => () => {
     toast({
+      position: 'bottom-right',
       duration: 5000,
-      render: ({ onClose }) => (
-        <ToastLayout minWidth={320}>
-          <ToastComponent onClose={onClose} />
-        </ToastLayout>
-      ),
+      render: ({ onClose, position }) => {
+        const styleProps = {
+          'top-left': { mt: '2x', mx: '4x' },
+          'top': { mt: '2x', mx: '4x' },
+          'top-right': { mt: '2x', mx: '4x' },
+          'bottom-left': { mb: '2x', mx: '4x' },
+          'bottom': { mb: '2x', mx: '4x' },
+          'bottom-right': { mb: '2x', mx: '4x' },
+        }[position];
+
+        return (
+          <ToastLayout {...styleProps}>
+            <ToastNotification onClose={onClose} />
+          </ToastLayout>
+        );
+      },
     });
   };
 

--- a/packages/styled-ui-docs/pages/usetoast.mdx
+++ b/packages/styled-ui-docs/pages/usetoast.mdx
@@ -27,16 +27,27 @@ function Example() {
 
   toast({
     // [optional] The position to display toast notifications.
-    position: 'top',
+    position: 'bottom-right',
 
     // [optional] The duration (in ms) that a toast notification remains visible and interactive.
     duration: 5000,
 
-    render: ({ onClose }) => (
-      <ToastLayout minWidth={320}>
-        <ToastNotification onClose={onClose} />
-      </ToastLayout>
-    ),
+    render: ({ onClose, position }) => {
+      const styleProps = {
+        'top-left': { mt: '2x', mx: '4x' },
+        'top': { mt: '2x', mx: '4x' },
+        'top-right': { mt: '2x', mx: '4x' },
+        'bottom-left': { mb: '2x', mx: '4x' },
+        'bottom': { mb: '2x', mx: '4x' },
+        'bottom-right': { mb: '2x', mx: '4x' },
+      }[position];
+
+      return (
+        <ToastLayout {...styleProps}>
+          <ToastNotification onClose={onClose} />
+        </ToastLayout>
+      );
+    },
   });
 }
 ```
@@ -55,7 +66,14 @@ const ToastLayout = (props) => {
   }[colorMode];
 
   return (
-    <Box fontSize="sm" lineHeight="sm" textAlign="left" my="2x" boxShadow={boxShadow} {...props} />
+    <Box
+      fontSize="sm"
+      lineHeight="sm"
+      textAlign="left"
+      boxShadow={boxShadow}
+      width={320}
+      {...props}
+    />
   );
 };
 ```
@@ -87,7 +105,14 @@ const ToastLayout = (props) => {
   }[colorMode];
 
   return (
-    <Box fontSize="sm" lineHeight="sm" textAlign="left" my="1x" boxShadow={boxShadow} {...props} />
+    <Box
+      fontSize="sm"
+      lineHeight="sm"
+      textAlign="left"
+      boxShadow={boxShadow}
+      width={320}
+      {...props}
+    />
   );
 };
 
@@ -95,13 +120,24 @@ function Example() {
   const toast = useToast();
   const handleClickBy = (ToastNotification) => () => {
     toast({
-      position: 'top',
+      position: 'bottom-right',
       duration: 5000,
-      render: ({ onClose }) => (
-        <ToastLayout minWidth={320}>
-          <ToastNotification onClose={onClose} />
-        </ToastLayout>
-      ),
+      render: ({ onClose, position }) => {
+        const styleProps = {
+          'top-left': { mt: '2x', mx: '4x' },
+          'top': { mt: '2x', mx: '4x' },
+          'top-right': { mt: '2x', mx: '4x' },
+          'bottom-left': { mb: '2x', mx: '4x' },
+          'bottom': { mb: '2x', mx: '4x' },
+          'bottom-right': { mb: '2x', mx: '4x' },
+        }[position];
+
+        return (
+          <ToastLayout {...styleProps}>
+            <ToastNotification onClose={onClose} />
+          </ToastLayout>
+        );
+      },
     });
   };
 
@@ -130,7 +166,7 @@ You can display toast notifications in different positions, including `top-left`
 
 When the `duration` is set to `null`, the toast notification will appear indefinitely until manually closed by the user. The default value is `5000` in milliseconds.
 
-#### `render`
+#### `render({ id, onClose, position, duration })`
 
 A render function that renders toast notifications.
 
@@ -149,7 +185,14 @@ const ToastLayout = (props) => {
   }[colorMode];
 
   return (
-    <Box fontSize="sm" lineHeight="sm" textAlign="left" my="1x" boxShadow={boxShadow} {...props} />
+    <Box
+      fontSize="sm"
+      lineHeight="sm"
+      textAlign="left"
+      boxShadow={boxShadow}
+      width={320}
+      {...props}
+    />
   );
 };
 
@@ -160,11 +203,22 @@ function Example() {
     toast({
       duration,
       position,
-      render: ({ onClose }) => (
-        <ToastLayout>
-          <ToastBasic onClose={onClose} />
-        </ToastLayout>
-      ),
+      render: ({ onClose, position }) => {
+        const styleProps = {
+          'top-left': { mt: '2x', mx: '4x' },
+          'top': { mt: '2x', mx: '4x' },
+          'top-right': { mt: '2x', mx: '4x' },
+          'bottom-left': { mb: '2x', mx: '4x' },
+          'bottom': { mb: '2x', mx: '4x' },
+          'bottom-right': { mb: '2x', mx: '4x' },
+        }[position];
+
+        return (
+          <ToastLayout {...styleProps}>
+            <ToastBasic onClose={onClose} />
+          </ToastLayout>
+        );
+      }
     });
   };
 


### PR DESCRIPTION
### Toast
https://trendmicro-frontend.github.io/styled-ui-demo/pr-120/toast

### AlertToast
https://trendmicro-frontend.github.io/styled-ui-demo/pr-120/alerttoast

### useToast
https://trendmicro-frontend.github.io/styled-ui-demo/pr-120/usetoast

### What's Changed

* The render function will pass the following parameters (https://github.com/trendmicro-frontend/styled-ui/pull/120/commits/5b850f23296f3ff18e9df1a01018ebc895396bc1):
  - render({ `id`, `onClose`, `position`, `duration` })
* Toast examples
  - Change the positon from `top` to `bottom-right` for the common use
  - The vertical space between toasts is `8px`
  - The horizontal space to the edge is `16px`
  - Use `white` background color for the light mode
  - Apply a default width (`320px`) for all toast examples

