### PR TITLE
fix: set `line-height` to 1 for base components and TMIcon component

### DIFF
--- a/packages/react-styled-ui/src/ButtonBase/styles.js
+++ b/packages/react-styled-ui/src/ButtonBase/styles.js
@@ -3,6 +3,7 @@ const baseProps = {
   backgroundColor: 'inherit',
   border: 'none',
   color: 'inherit',
+  lineHeight: 1,
   outline: 0,
   padding: 0,
 };

--- a/packages/react-styled-ui/src/Input/styles.js
+++ b/packages/react-styled-ui/src/Input/styles.js
@@ -28,7 +28,7 @@ const sizes = {
     fontSize: 'md',
     lineHeight: 'md',
     px: 'calc(.75rem - 1px)', // 12px - 1px
-    py: 'calc(.75rem - 1px)', // 12px - 1px
+    py: 'calc(.5625rem - 1px)', // 9px - 1px
   },
 };
 

--- a/packages/react-styled-ui/src/InputBase/styles.js
+++ b/packages/react-styled-ui/src/InputBase/styles.js
@@ -3,6 +3,7 @@ const baseProps = {
   backgroundColor: 'inherit',
   border: 'none',
   color: 'inherit',
+  lineHeight: 1,
   outline: 0,
   padding: 0,
   width: 'auto',

--- a/packages/styled-ui-docs/components/TMIcon.jsx
+++ b/packages/styled-ui-docs/components/TMIcon.jsx
@@ -25,7 +25,6 @@ const TMIcon = React.forwardRef(({
   spin,
   spinReverse,
   fontSize = 'md',
-  lineHeight = 'md',
   className,
   name,
   size,
@@ -36,7 +35,6 @@ const TMIcon = React.forwardRef(({
       size = `${size || 0}px`;
     }
     fontSize = size;
-    lineHeight = size;
   }
 
   return (
@@ -47,7 +45,7 @@ const TMIcon = React.forwardRef(({
       className={cx(className, 'tmicon', { [`tmicon-${name}`]: !!name })}
       display="inline-block"
       fontSize={fontSize}
-      lineHeight={lineHeight}
+      lineHeight="1"
       verticalAlign="top"
       animation={
         (spin && `${spinKeyframes} 2s infinite linear`) ||

--- a/packages/styled-ui-docs/pages/inputbase.mdx
+++ b/packages/styled-ui-docs/pages/inputbase.mdx
@@ -29,13 +29,13 @@ Standard input attributes are supported, e.g., `type`, `disabled`, `readOnly`, `
   rowGap="3x"
 >
   <Grid>
-    <InputLabel>Name:</InputLabel>
+    <TextLabel>Name:</TextLabel>
   </Grid>
   <Grid>
     <InputBase type="text" placeholder="John Doe" />
   </Grid>
   <Grid>
-    <InputLabel>Password:</InputLabel>
+    <TextLabel>Password:</TextLabel>
   </Grid>
   <Grid>
     <InputBase type="password" placeholder="Password" />


### PR DESCRIPTION
This PR addresses https://github.com/trendmicro-frontend/styled-ui/issues/123

![image](https://user-images.githubusercontent.com/447801/80776356-c8e39480-8b94-11ea-934a-456443386b6f.png)

As a base component, I suggest that we set its `line-height` to `1` in the `ButtonBase` component rather than inheriting `button` styles from browser default or CSS normalize. This can make sure the `ButtonBase` has an exact height as the children when implementing an `IconButton` like below:

```jsx
<ButtonBase>
    <Icon name="icon-name" /> /* 16px x 16px */
</ButtonBase>
```

The default style of `line-height: 1` will apply to `InputBase` and `TMIcon` components as well.