### PR TITLE
fix: keydown event for PopoverTrigger

### DIFF
--- a/packages/react-styled-ui/src/Popover/PopoverTrigger.js
+++ b/packages/react-styled-ui/src/Popover/PopoverTrigger.js
@@ -15,13 +15,18 @@ const PopoverTrigger = ({ children }) => {
     isHoveringRef,
     delay,
   } = usePopover();
-  const _children = <PseudoBox tabIndex="0" display="inline-block">{children}</PseudoBox>; // always wrap a div to make sure the element can be bound event.
+  const _children = <PseudoBox role="button" tabIndex="0" tabIndex="0" display="inline-block">{children}</PseudoBox>; // always wrap a div to make sure the element can be bound event.
   const child = Children.only(_children);
   let eventHandlers = {};
 
   if (trigger === 'click') {
     eventHandlers = {
       onClick: wrapEvent(child.props.onClick, onToggle),
+      onKeyDown: wrapEvent(child.props.onKeyDown, event => {
+        if (event.key === 'Enter') {
+          setTimeout(onOpen, delay.show);
+        }
+      }),
     };
   }
 

--- a/packages/react-styled-ui/src/Popover/PopoverTrigger.js
+++ b/packages/react-styled-ui/src/Popover/PopoverTrigger.js
@@ -15,7 +15,7 @@ const PopoverTrigger = ({ children }) => {
     isHoveringRef,
     delay,
   } = usePopover();
-  const _children = <PseudoBox role="button" tabIndex="0" tabIndex="0" display="inline-block">{children}</PseudoBox>; // always wrap a div to make sure the element can be bound event.
+  const _children = <PseudoBox role="button" tabIndex="0" display="inline-block">{children}</PseudoBox>; // always wrap a div to make sure the element can be bound event.
   const child = Children.only(_children);
   let eventHandlers = {};
 


### PR DESCRIPTION
Fix issue #127 

Problem & Solution: We use a `div` to wrap trigger children in order to make sure every child can be bound event such as `svg`. However the `div` event cant trigger keyboard keydown event, so I add the `role="button"` and define event handlers for keydown events for the open popover.

And the following is why I need to handle keydown event by ownself.
`Note: If using role="button" instead of the semantic <button> or <input type="button"> elements, you will need to make the element focusable and have to define event handlers for click and keydown events, including the Enter and Space keys, in order to process the user's input.`
Reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role