### PR TITLE
refactor: the `useToast` Hook should return object type for future expansion (close #129)

### DIFF
--- a/packages/react-styled-ui/src/useToast/index.js
+++ b/packages/react-styled-ui/src/useToast/index.js
@@ -36,8 +36,12 @@ const useToast = () => {
     },
     [theme, colorMode],
   );
+  const closeAll = toaster.closeAll;
 
-  return notify;
+  return {
+    closeAll,
+    notify,
+  };
 };
 
 export default useToast;

--- a/packages/styled-ui-docs/pages/alerttoast.mdx
+++ b/packages/styled-ui-docs/pages/alerttoast.mdx
@@ -4,6 +4,12 @@ An alert toast is a toast that offers severity levels.
 
 If you're looking for a simple toast, just to check out the [`Toast`](./toast) component.
 
+### Prerequisite
+
+The `AlertToast` component should work with the `useToast` Hook to trigger a toast notification.
+
+Learn more about the [`useToast`](./usetoast) Hook.
+
 ## Import
 
 ```js
@@ -11,12 +17,6 @@ import AlertToast from '@trendmicro/react-styled-ui/AlertToast';
 // or
 import { AlertToast } from '@trendmicro/react-styled-ui';
 ```
-
-## Prerequisite
-
-The `AlertToast` component should work with the `useToast` Hook to trigger a toast notification.
-
-Learn more about the [`useToast`](./usetoast) Hook.
 
 ## Usage
 

--- a/packages/styled-ui-docs/pages/alerttoast.mdx
+++ b/packages/styled-ui-docs/pages/alerttoast.mdx
@@ -128,7 +128,7 @@ const ToastLayout = (props) => {
 function Example() {
   const toast = useToast();
   const handleClickBy = (AlertToastNotification) => () => {
-    toast({
+    toast.notify({
       position: 'bottom-right',
       duration: 5000,
       render: ({ onClose, position }) => {
@@ -278,7 +278,7 @@ const ToastLayout = (props) => {
 function Example() {
   const toast = useToast();
   const handleClickBy = (AlertToastNotification) => () => {
-    toast({
+    toast.notify({
       position: 'bottom-right',
       duration: 5000,
       render: ({ onClose, position }) => {
@@ -393,7 +393,7 @@ const ToastLayout = (props) => {
 function Example() {
   const toast = useToast();
   const handleClickBy = (AlertToastNotification) => () => {
-    toast({
+    toast.notify({
       position: 'bottom-right',
       duration: 5000,
       render: ({ onClose, position }) => {

--- a/packages/styled-ui-docs/pages/toast.mdx
+++ b/packages/styled-ui-docs/pages/toast.mdx
@@ -4,6 +4,12 @@ A toast notification is a small message that shows up in a box at one side of th
 
 If you're looking for a toast that offers severity levels, such as `success`, `info`, `warning`, and `error`, just to check out the [`AlertToast`](./alerttoast) component.
 
+### Prerequisite
+
+The `Toast` component should work with the `useToast` Hook to trigger a toast notification.
+
+Learn more about the [`useToast`](./usetoast) Hook.
+
 ## Import
 
 ```js
@@ -11,12 +17,6 @@ import Toast from '@trendmicro/react-styled-ui/Toast';
 // or
 import { Toast } from '@trendmicro/react-styled-ui';
 ```
-
-## Prerequisite
-
-The `Toast` component should work with the `useToast` Hook to trigger a toast notification.
-
-Learn more about the [`useToast`](./usetoast) Hook.
 
 ## Usage
 

--- a/packages/styled-ui-docs/pages/toast.mdx
+++ b/packages/styled-ui-docs/pages/toast.mdx
@@ -128,7 +128,7 @@ const ToastLayout = (props) => {
 function Example() {
   const toast = useToast();
   const handleClickBy = (ToastNotification) => () => {
-    toast({
+    toast.notify({
       position: 'bottom-right',
       duration: 5000,
       render: ({ onClose, position }) => {

--- a/packages/styled-ui-docs/pages/usetoast.mdx
+++ b/packages/styled-ui-docs/pages/usetoast.mdx
@@ -25,7 +25,7 @@ function Example() {
   // Get a toast function
   const toast = useToast();
 
-  toast({
+  toast.notify({
     // [optional] The position to display toast notifications.
     position: 'bottom-right',
 
@@ -119,7 +119,7 @@ const ToastLayout = (props) => {
 function Example() {
   const toast = useToast();
   const handleClickBy = (ToastNotification) => () => {
-    toast({
+    toast.notify({
       position: 'bottom-right',
       duration: 5000,
       render: ({ onClose, position }) => {
@@ -200,7 +200,7 @@ function Example() {
   const toast = useToast();
   const duration = 5000; // in ms
   const handleClickBy = (position) => () => {
-    toast({
+    toast.notify({
       duration,
       position,
       render: ({ onClose, position }) => {

--- a/packages/styled-ui-docs/pages/usetoast.mdx
+++ b/packages/styled-ui-docs/pages/usetoast.mdx
@@ -18,7 +18,12 @@ import { useToast } from '@trendmicro/react-styled-ui';
 const toast = useToast();
 ```
 
-Returns a toast function, which is used to trigger a toast notification.
+The `useToast` Hook returns an object with the following fields:
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| notify | function | | A function to trigger a toast notification. |
+| closeAll | function | | A function To close all toast notificatios. |
 
 ```jsx disabled
 function Example() {
@@ -140,13 +145,22 @@ function Example() {
       },
     });
   };
+  const handleCloseAll = () => {
+    toast.closeAll();
+  };
 
   return (
     <>
-      <Button variant="secondary" onClick={handleClickBy(ToastNotification)}>
-        Show
-      </Button>
-      <ToastLayout mt="4x">
+      <Box mb="4x">
+        <Button variant="secondary" onClick={handleClickBy(ToastNotification)}>
+          Show
+        </Button>
+        <Space width="2x" />
+        <Button variant="secondary" onClick={handleCloseAll}>
+          Close All
+        </Button>
+      </Box>
+      <ToastLayout>
         <ToastNotification />
       </ToastLayout>
     </>
@@ -221,31 +235,41 @@ function Example() {
       }
     });
   };
+  const handleCloseAll = () => {
+    toast.closeAll();
+  };
 
   return (
-    <Grid
-      gap="4x"
-      templateColumns="1fr 1fr 1fr"
-    >
-      <Button onClick={handleClickBy('top-left')}>
-        Top Left
-      </Button>
-      <Button onClick={handleClickBy('top')}>
-        Top
-      </Button>
-      <Button onClick={handleClickBy('top-right')}>
-        Top Right
-      </Button>
-      <Button onClick={handleClickBy('bottom-left')}>
-        Bottom Left
-      </Button>
-      <Button onClick={handleClickBy('bottom')}>
-        Bottom
-      </Button>
-      <Button onClick={handleClickBy('bottom-right')}>
-        Bottom Right
-      </Button>
-    </Grid>
+    <>
+      <Box mb="4x">
+        <Button variant="secondary" onClick={handleCloseAll}>
+          Close All
+        </Button>
+      </Box>
+      <Grid
+        gap="4x"
+        templateColumns="1fr 1fr 1fr"
+      >
+        <Button onClick={handleClickBy('top-left')}>
+          Top Left
+        </Button>
+        <Button onClick={handleClickBy('top')}>
+          Top
+        </Button>
+        <Button onClick={handleClickBy('top-right')}>
+          Top Right
+        </Button>
+        <Button onClick={handleClickBy('bottom-left')}>
+          Bottom Left
+        </Button>
+        <Button onClick={handleClickBy('bottom')}>
+          Bottom
+        </Button>
+        <Button onClick={handleClickBy('bottom-right')}>
+          Bottom Right
+        </Button>
+      </Grid>
+    </>
   );
 }
 


### PR DESCRIPTION
#### Before

```js
const toast = useToast();
toast();
```

#### After

```js
const toast = useToast();
toast.notify();
```

or 

```js
const { notify } = useToast();
notify();
```