### PR TITLE
refactor: adjust component props

### DIFF
--- a/packages/react-styled-ui/src/Alert/index.js
+++ b/packages/react-styled-ui/src/Alert/index.js
@@ -44,7 +44,7 @@ const AlertCloseButton = (props) => (
 
 const Alert = forwardRef((
   {
-    isCloseable = true,
+    isCloseButtonVisible = true,
     onClose,
     severity = defaultSeverity,
     icon,
@@ -84,7 +84,7 @@ const Alert = forwardRef((
       <AlertMessage {...messageStyleProps}>
         {children}
       </AlertMessage>
-      {!!isCloseable && (
+      {!!isCloseButtonVisible && (
         <>
           <Space minWidth="4x" />
           <AlertCloseButton {...closeButtonStyleProps} onClick={onClose}>

--- a/packages/react-styled-ui/src/Alert/index.js
+++ b/packages/react-styled-ui/src/Alert/index.js
@@ -44,7 +44,7 @@ const AlertCloseButton = (props) => (
 
 const Alert = forwardRef((
   {
-    isCloseButtonVisible = true,
+    isCloseButtonVisible,
     onClose,
     severity = defaultSeverity,
     icon,

--- a/packages/react-styled-ui/src/AlertToast/index.js
+++ b/packages/react-styled-ui/src/AlertToast/index.js
@@ -44,7 +44,7 @@ const AlertToastCloseButton = (props) => (
 
 const AlertToast = forwardRef((
   {
-    isCloseable = true,
+    isCloseButtonVisible = true,
     onClose,
     severity = defaultSeverity,
     icon,
@@ -84,7 +84,7 @@ const AlertToast = forwardRef((
       <AlertToastMessage {...messageStyleProps}>
         {children}
       </AlertToastMessage>
-      {!!isCloseable && (
+      {!!isCloseButtonVisible && (
         <>
           <Space minWidth="4x" />
           <AlertToastCloseButton {...closeButtonStyleProps} onClick={onClose}>

--- a/packages/react-styled-ui/src/AlertToast/index.js
+++ b/packages/react-styled-ui/src/AlertToast/index.js
@@ -44,7 +44,7 @@ const AlertToastCloseButton = (props) => (
 
 const AlertToast = forwardRef((
   {
-    isCloseButtonVisible = true,
+    isCloseButtonVisible,
     onClose,
     severity = defaultSeverity,
     icon,

--- a/packages/react-styled-ui/src/InputBase/index.js
+++ b/packages/react-styled-ui/src/InputBase/index.js
@@ -12,7 +12,7 @@ const InputBase = forwardRef((
   },
   ref,
 ) => {
-  const { disabled, readOnly, required } = rest;
+  const { disabled, readOnly, required, isInvalid } = rest;
 
   return (
     <PseudoBox
@@ -21,6 +21,7 @@ const InputBase = forwardRef((
       aria-disabled={disabled}
       aria-readonly={readOnly}
       aria-required={required}
+      aria-invalid={isInvalid}
       {...baseProps}
       {...rest}
     >

--- a/packages/react-styled-ui/src/Select/index.js
+++ b/packages/react-styled-ui/src/Select/index.js
@@ -12,6 +12,7 @@ const Select = forwardRef((
     variant,
     multiple, // multiple options
     size, // multiple options
+    isInvalid,
     children,
     ...rest
   },
@@ -36,6 +37,7 @@ const Select = forwardRef((
         as="select"
         aria-disabled={disabled}
         aria-required={required}
+        aria-invalid={isInvalid}
         multiple={multiple}
         size={size}
         {...styleProps}

--- a/packages/react-styled-ui/src/Toast/index.js
+++ b/packages/react-styled-ui/src/Toast/index.js
@@ -20,7 +20,7 @@ const ToastCloseButton = (props) => (
 
 const Toast = forwardRef((
   {
-    isCloseButtonVisible = true,
+    isCloseButtonVisible,
     onClose,
     children,
     ...rest

--- a/packages/react-styled-ui/src/Toast/index.js
+++ b/packages/react-styled-ui/src/Toast/index.js
@@ -20,7 +20,7 @@ const ToastCloseButton = (props) => (
 
 const Toast = forwardRef((
   {
-    isCloseable = true,
+    isCloseButtonVisible = true,
     onClose,
     children,
     ...rest
@@ -42,7 +42,7 @@ const Toast = forwardRef((
       <ToastMessage {...messageStyleProps}>
         {children}
       </ToastMessage>
-      {!!isCloseable && (
+      {!!isCloseButtonVisible && (
         <>
           <Space minWidth="4x" />
           <ToastCloseButton {...closeButtonStyleProps} onClick={onClose}>

--- a/packages/styled-ui-docs/pages/alert.mdx
+++ b/packages/styled-ui-docs/pages/alert.mdx
@@ -181,7 +181,7 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| isCloseable | boolean | true | If `true`, a close button will appear on the right side. |
+| isCloseButtonVisible | boolean | true | If `true`, a close button will appear on the right side. |
 | onClose | function | | A callback called when the close button is clicked. |
 | severity | string | 'success' | The severity level of the alert. One of: `'success'`, `'info'`, `'warning'`, `'error'` |
 | icon | string \| ReactNode \| false | | Override the icon displayed before the children. Unless provided, the icon is mapped to the value of the `severity` prop. |

--- a/packages/styled-ui-docs/pages/alert.mdx
+++ b/packages/styled-ui-docs/pages/alert.mdx
@@ -33,6 +33,27 @@ The alert offers four severity levels, each has a distinctive icon and color.
 </Stack>
 ```
 
+### With close button
+
+Set `isCloseButtonVisible` to `true`, a close button will appear on the right side.
+
+```jsx
+<Stack direction="column" spacing="4x">
+  <Alert severity="success" isCloseButtonVisible>
+    <Text>This is a success alert.</Text>
+  </Alert>
+  <Alert severity="info" isCloseButtonVisible>
+    <Text>This is an info alert.</Text>
+  </Alert>
+  <Alert severity="warning" isCloseButtonVisible>
+    <Text>This is a warning alert.</Text>
+  </Alert>
+  <Alert severity="error" isCloseButtonVisible>
+    <Text>This is an error alert.</Text>
+  </Alert>
+</Stack>
+```
+
 ### Icons
 
 The `icon` prop allows you to override the default icon for the specified severity.
@@ -42,23 +63,27 @@ Setting the `icon` prop to `false` will remove the icon altogether.
 ```jsx
 <Stack direction="column" spacing="4x">
   <Alert
+    isCloseButtonVisible
     severity="success"
   >
     This is a success alert.
   </Alert>
   <Alert
+    isCloseButtonVisible
     severity="success"
     icon="_core.severity-success"
   >
     This is a success alert.
   </Alert>
   <Alert
+    isCloseButtonVisible
     severity="success"
     icon={<TMIcon name="check-circle-o" lineHeight={1} color="gray:80" />}
   >
     This is a success alert.
   </Alert>
   <Alert
+    isCloseButtonVisible
     severity="success"
     icon={false}
   >
@@ -76,7 +101,7 @@ const Paragraph = (props) => (
 
 function Example() {
   return (
-    <Alert severity="info">
+    <Alert isCloseButtonVisible severity="info">
       <Paragraph>This is the first paragraph.</Paragraph>
       <Paragraph>This is the second paragraph.</Paragraph>
       <Paragraph>This is the third paragraph.</Paragraph>
@@ -93,7 +118,7 @@ You can use the `Heading` component to display a formatted title above the conte
 
 ```jsx
 <Stack direction="column" spacing="4x">
-  <Alert severity="success">
+  <Alert isCloseButtonVisible severity="success">
     <Box mb="1x">
       <Heading fontWeight="bold">Success</Heading>
     </Box>
@@ -101,7 +126,7 @@ You can use the `Heading` component to display a formatted title above the conte
       This is a success alert.
     </Text>
   </Alert>
-  <Alert severity="info">
+  <Alert isCloseButtonVisible severity="info">
     <Box mb="1x">
       <Heading fontWeight="bold">Info</Heading>
     </Box>
@@ -109,7 +134,7 @@ You can use the `Heading` component to display a formatted title above the conte
       This is an info alert.
     </Text>
   </Alert>
-  <Alert severity="warning">
+  <Alert isCloseButtonVisible severity="warning">
     <Box mb="1x">
       <Heading fontWeight="bold">Warning</Heading>
     </Box>
@@ -117,7 +142,7 @@ You can use the `Heading` component to display a formatted title above the conte
       This is a warning alert.
     </Text>
   </Alert>
-  <Alert severity="error">
+  <Alert isCloseButtonVisible severity="error">
     <Box mb="1x">
       <Heading fontWeight="bold">Error</Heading>
     </Box>
@@ -134,10 +159,10 @@ An alert can have an action, such as a close or action button. It is rendered af
 
 ```jsx
 <Stack direction="column" spacing={1}>
-  <Alert severity="warning">
+  <Alert isCloseButtonVisible severity="warning">
     <Text>Your browser is currently not supported. <Link>More Information</Link></Text>
   </Alert>
-  <Alert severity="error">
+  <Alert isCloseButtonVisible severity="error">
     <Flex justify="space-between" mt={-1} mb={-2}>
       <Text>Your license will expire in 7 days.</Text>
       <FlatButton size="sm" variant="outline" variantColor="black:primary">
@@ -161,7 +186,7 @@ function Example() {
   return (
     <>
       <Collapse isOpen={isOpen}>
-        <Alert severity="info" onClose={handleClose}>
+        <Alert isCloseButtonVisible severity="info" onClose={handleClose}>
           Click the close button on the right side.
         </Alert>
       </Collapse>
@@ -181,7 +206,7 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| isCloseButtonVisible | boolean | true | If `true`, a close button will appear on the right side. |
+| isCloseButtonVisible | boolean | | If `true`, a close button will appear on the right side. |
 | onClose | function | | A callback called when the close button is clicked. |
 | severity | string | 'success' | The severity level of the alert. One of: `'success'`, `'info'`, `'warning'`, `'error'` |
 | icon | string \| ReactNode \| false | | Override the icon displayed before the children. Unless provided, the icon is mapped to the value of the `severity` prop. |

--- a/packages/styled-ui-docs/pages/alerttoast.mdx
+++ b/packages/styled-ui-docs/pages/alerttoast.mdx
@@ -446,7 +446,7 @@ render(<Example />);
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| isCloseable | boolean | true | If `true`, a close button will appear on the right side. |
+| isCloseButtonVisible | boolean | true | If `true`, a close button will appear on the right side. |
 | onClose | function | | A callback called when the close button is clicked. |
 | severity | string | 'success' | The severity level of the alert. One of: `'success'`, `'info'`, `'warning'`, `'error'` |
 | icon | string \| ReactNode \| false | | Override the icon displayed before the children. Unless provided, the icon is mapped to the value of the `severity` prop. |

--- a/packages/styled-ui-docs/pages/alerttoast.mdx
+++ b/packages/styled-ui-docs/pages/alerttoast.mdx
@@ -30,13 +30,13 @@ import { AlertToast } from '@trendmicro/react-styled-ui';
 
 ```jsx noInline
 const AlertToastSimple = ({ onClose }) => (
-  <AlertToast onClose={onClose}>
+  <AlertToast isCloseButtonVisible onClose={onClose}>
     <Text>This is a toast notification.</Text>
   </AlertToast>
 );
 
 const AlertToastWithIcon = ({ onClose }) => (
-  <AlertToast onClose={onClose} py="4x">
+  <AlertToast isCloseButtonVisible onClose={onClose} py="4x">
     <Flex align="flex-start">
       <Box
         bg="gray:40"
@@ -50,7 +50,7 @@ const AlertToastWithIcon = ({ onClose }) => (
 );
 
 const AlertToastWithTitle = ({ onClose }) => (
-  <AlertToast onClose={onClose} py="4x">
+  <AlertToast isCloseButtonVisible onClose={onClose} py="4x">
     <Box mb="2x">
       <Heading fontWeight="bold">Notification Title</Heading>
     </Box>
@@ -61,7 +61,7 @@ const AlertToastWithTitle = ({ onClose }) => (
 );
 
 const AlertToastWithActionButton = ({ onClose }) => (
-  <AlertToast onClose={onClose} py="4x">
+  <AlertToast isCloseButtonVisible onClose={onClose} py="4x">
     <Box mb="6x">
       <Text>This is a toast notification.</Text>
     </Box>
@@ -74,7 +74,7 @@ const AlertToastWithActionButton = ({ onClose }) => (
 );
 
 const AlertToastWithActionLink = ({ onClose }) => (
-  <AlertToast onClose={onClose} py="4x">
+  <AlertToast isCloseButtonVisible onClose={onClose} py="4x">
     <Box mb="6x">
       <Text>This is a toast notification.</Text>
     </Box>
@@ -85,7 +85,7 @@ const AlertToastWithActionLink = ({ onClose }) => (
 );
 
 const AlertToastWithAllTogether = ({ onClose }) => (
-  <AlertToast onClose={onClose} py="4x">
+  <AlertToast isCloseButtonVisible onClose={onClose} py="4x">
     <Box mb="2x">
       <Heading fontWeight="bold">Notification Title</Heading>
     </Box>
@@ -233,25 +233,25 @@ The alert toast offers four severity levels, each has a distinctive icon and col
 
 ```jsx noInline
 const AlertToastSuccess = ({ onClose }) => (
-  <AlertToast onClose={onClose} severity="success">
+  <AlertToast isCloseButtonVisible onClose={onClose} severity="success">
     This is a success toast alert.
   </AlertToast>
 );
 
 const AlertToastInfo = ({ onClose }) => (
-  <AlertToast onClose={onClose} severity="info">
+  <AlertToast isCloseButtonVisible onClose={onClose} severity="info">
     This is an info toast alert.
   </AlertToast>
 );
 
 const AlertToastWarning = ({ onClose }) => (
-  <AlertToast onClose={onClose} severity="warning">
+  <AlertToast isCloseButtonVisible onClose={onClose} severity="warning">
     This is a warning toast alert.
   </AlertToast>
 );
 
 const AlertToastError = ({ onClose }) => (
-  <AlertToast onClose={onClose} severity="error">
+  <AlertToast isCloseButtonVisible onClose={onClose} severity="error">
     This is an error toast alert.
   </AlertToast>
 );
@@ -334,6 +334,7 @@ Setting the `icon` prop to `false` will remove the icon altogether.
 ```jsx noInline
 const AlertToastWithDefaultIcon = ({ onClose }) => (
   <AlertToast
+    isCloseButtonVisible
     onClose={onClose}
     severity="success"
   >
@@ -343,6 +344,7 @@ const AlertToastWithDefaultIcon = ({ onClose }) => (
 
 const AlertToastWithAnotherIcon = ({ onClose }) => (
   <AlertToast
+    isCloseButtonVisible
     onClose={onClose}
     severity="success"
     icon="_core.severity-success"
@@ -353,6 +355,7 @@ const AlertToastWithAnotherIcon = ({ onClose }) => (
 
 const AlertToastWithProprietaryIcon = ({ onClose }) => (
   <AlertToast
+    isCloseButtonVisible
     onClose={onClose}
     severity="success"
     icon={<TMIcon name="check-circle-o" lineHeight={1} color="gray:80" />}
@@ -363,6 +366,7 @@ const AlertToastWithProprietaryIcon = ({ onClose }) => (
 
 const AlertToastWithoutIcon = ({ onClose }) => (
   <AlertToast
+    isCloseButtonVisible
     onClose={onClose}
     severity="success"
     icon={false}
@@ -446,7 +450,7 @@ render(<Example />);
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| isCloseButtonVisible | boolean | true | If `true`, a close button will appear on the right side. |
+| isCloseButtonVisible | boolean | | If `true`, a close button will appear on the right side. |
 | onClose | function | | A callback called when the close button is clicked. |
 | severity | string | 'success' | The severity level of the alert. One of: `'success'`, `'info'`, `'warning'`, `'error'` |
 | icon | string \| ReactNode \| false | | Override the icon displayed before the children. Unless provided, the icon is mapped to the value of the `severity` prop. |

--- a/packages/styled-ui-docs/pages/input.mdx
+++ b/packages/styled-ui-docs/pages/input.mdx
@@ -231,9 +231,9 @@ render(<Example />);
 
 ### Validation
 
-Use the `aria-invalid` attribute to indicate that the value entered into an input field does not conform to the format expected by the application. `aria-invalid` can also be used to indicate that a required field has not been filled in.
+Use the `isInvalid` attribute to indicate that the value entered into an input field does not conform to the format expected by the application. `isInvalid` can also be used to indicate that a required field has not been filled in.
 
-Set `aria-invalid` to `true` on the fields that have failed validation, otherwise set it to `false` if no errors detected.
+Set `isInvalid` to `true` on the fields that have failed validation, otherwise set it to `false` if no errors detected.
 
 ```jsx noInline
 const InlineError = (props) => (
@@ -249,7 +249,7 @@ const InputField = ({
   let invalidInputStyle = {};
   if (isInvalid) {
     invalidInputStyle = {
-      'aria-invalid': true,
+      isInvalid: true,
       pr: '10x',
     };
   }
@@ -302,4 +302,4 @@ render(<Example />);
 | variant | string | 'outline' | The variant of the input style to use. One of: `'outline'`, `'filled'`, `'unstyled'` |
 | disabled | boolean | | If `true`, the user cannot interact with the control. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
 | readOnly | boolean | | If `true`, prevents the value of the input from being edited. |
-| aria-invalid | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |
+| isInvalid | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |

--- a/packages/styled-ui-docs/pages/inputbase.mdx
+++ b/packages/styled-ui-docs/pages/inputbase.mdx
@@ -85,4 +85,4 @@ Standard input attributes are supported, e.g., `type`, `disabled`, `readOnly`, `
 | :--- | :--- | :------ | :---------- |
 | disabled | boolean | | If `true`, the user cannot interact with the control. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
 | readOnly | boolean | | If `true`, prevents the value of the input from being edited. |
-| aria-invalid | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |
+| isInvalid | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |

--- a/packages/styled-ui-docs/pages/searchinput.mdx
+++ b/packages/styled-ui-docs/pages/searchinput.mdx
@@ -164,6 +164,7 @@ Standard input attributes are supported, e.g., `disabled`, `readOnly`, `required
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| isInvalid | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |
 | isLoading | boolean | | If `true`, then display the loading spinner. |
 | onChange | function | | A callback called when the value is changed. |
 | onClearInput | function | | A callback called when the clear button is clicked. |
@@ -171,4 +172,3 @@ Standard input attributes are supported, e.g., `disabled`, `readOnly`, `required
 | variant | string | 'outline' | The variant of the input style to use. One of: `'outline'`, `'filled'`, `'unstyled'` |
 | disabled | boolean | | If `true`, the user cannot interact with the control. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
 | readOnly | boolean | | If `true`, prevents the value of the input from being edited. |
-| aria-invalid | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |

--- a/packages/styled-ui-docs/pages/select.mdx
+++ b/packages/styled-ui-docs/pages/select.mdx
@@ -119,4 +119,4 @@ render(<Example />);
 | :--- | :--- | :------ | :---------- |
 | variant | string | 'outline' | The variant of the select style to use. One of: `'outline'`, `'filled'`, `'unstyled'` |
 | disabled | boolean | | If `true`, the user cannot interact with the control. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
-| aria-invalid | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |
+| isInvalid | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |

--- a/packages/styled-ui-docs/pages/table.mdx
+++ b/packages/styled-ui-docs/pages/table.mdx
@@ -413,7 +413,7 @@ function SortableTable() {
                   overflow="hidden"
                   textOverflow="ellipsis"
                   whiteSpace="nowrap"
-                  width={`calc(100% - ${(column.isSorted ? '20px' : '0px')})`}
+                  maxWidth={`calc(100% - ${(column.isSorted ? '24px' : '0px')})`}
                 >
                   {column.render('Header')}
                 </Box>
@@ -421,7 +421,7 @@ function SortableTable() {
                   <Box as="span">
                     <Space minWidth="1x" />
                     {
-                      column.isSortedDesc ? <TMIcon name="sort-down" /> : <TMIcon name="sort-up" />
+                      column.isSortedDesc ? <TMIcon name="sort-down" size={20} /> : <TMIcon name="sort-up" size={20} />
                     }
                   </Box>
                 )}

--- a/packages/styled-ui-docs/pages/textarea.mdx
+++ b/packages/styled-ui-docs/pages/textarea.mdx
@@ -107,9 +107,9 @@ General form input attributes are supported, such as `disabled`, `readOnly`, `re
 
 ### Validation
 
-Use the `aria-invalid` attribute to indicate that the value entered into an input field does not conform to the format expected by the application. `aria-invalid` can also be used to indicate that a required field has not been filled in.
+Use the `isInvalid` attribute to indicate that the value entered into an input field does not conform to the format expected by the application. `isInvalid` can also be used to indicate that a required field has not been filled in.
 
-Set `aria-invalid` to `true` on the fields that have failed validation, otherwise set it to `false` if no errors detected.
+Set `isInvalid` to `true` on the fields that have failed validation, otherwise set it to `false` if no errors detected.
 
 ```jsx noInline
 const InlineError = (props) => (
@@ -125,7 +125,7 @@ const MultilineInputField = ({
   let invalidTextareaStyle = {};
   if (isInvalid) {
     invalidTextareaStyle = {
-      'aria-invalid': true,
+      isInvalid: true,
       pr: '10x',
     };
   }
@@ -184,4 +184,4 @@ render(<Example />);
 | variant | string | 'outline' | The variant of the input style to use. One of: `'outline'`, `'filled'`, `'unstyled'` |
 | disabled | boolean | | If `true`, the user cannot interact with the control. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
 | readOnly | boolean | | If `true`, prevents the value of the input from being edited. |
-| aria-invalid` | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |
+| isInvalid | boolean | | If `true`, the input will indicate an error. You can style this state by passing the `_invalid` prop. |

--- a/packages/styled-ui-docs/pages/toast.mdx
+++ b/packages/styled-ui-docs/pages/toast.mdx
@@ -30,13 +30,13 @@ import { Toast } from '@trendmicro/react-styled-ui';
 
 ```jsx noInline
 const ToastSimple = ({ onClose }) => (
-  <Toast onClose={onClose}>
+  <Toast isCloseButtonVisible onClose={onClose}>
     <Text>This is a toast notification.</Text>
   </Toast>
 );
 
 const ToastWithIcon = ({ onClose }) => (
-  <Toast onClose={onClose} py="4x">
+  <Toast isCloseButtonVisible onClose={onClose} py="4x">
     <Flex align="flex-start">
       <Box
         bg="gray:40"
@@ -50,7 +50,7 @@ const ToastWithIcon = ({ onClose }) => (
 );
 
 const ToastWithTitle = ({ onClose }) => (
-  <Toast onClose={onClose} py="4x">
+  <Toast isCloseButtonVisible onClose={onClose} py="4x">
     <Box mb="2x">
       <Heading fontWeight="bold">Notification Title</Heading>
     </Box>
@@ -61,7 +61,7 @@ const ToastWithTitle = ({ onClose }) => (
 );
 
 const ToastWithActionButton = ({ onClose }) => (
-  <Toast onClose={onClose} py="4x">
+  <Toast isCloseButtonVisible onClose={onClose} py="4x">
     <Box mb="6x">
       <Text>This is a toast notification.</Text>
     </Box>
@@ -74,7 +74,7 @@ const ToastWithActionButton = ({ onClose }) => (
 );
 
 const ToastWithActionLink = ({ onClose }) => (
-  <Toast onClose={onClose} py="4x">
+  <Toast isCloseButtonVisible onClose={onClose} py="4x">
     <Box mb="6x">
       <Text>This is a toast notification.</Text>
     </Box>
@@ -85,7 +85,7 @@ const ToastWithActionLink = ({ onClose }) => (
 );
 
 const ToastWithAllTogether = ({ onClose }) => (
-  <Toast onClose={onClose} py="4x">
+  <Toast isCloseButtonVisible onClose={onClose} py="4x">
     <Box mb="2x">
       <Heading fontWeight="bold">Notification Title</Heading>
     </Box>
@@ -233,5 +233,5 @@ render(<Example />);
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| isCloseButtonVisible | boolean | true | If `true`, a close button will appear on the right side. |
+| isCloseButtonVisible | boolean | | If `true`, a close button will appear on the right side. |
 | onClose | function | | A callback called when the close button is clicked. |

--- a/packages/styled-ui-docs/pages/toast.mdx
+++ b/packages/styled-ui-docs/pages/toast.mdx
@@ -233,5 +233,5 @@ render(<Example />);
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| isCloseable | boolean | true | If `true`, a close button will appear on the right side. |
+| isCloseButtonVisible | boolean | true | If `true`, a close button will appear on the right side. |
 | onClose | function | | A callback called when the close button is clicked. |


### PR DESCRIPTION
## Summary
- Add isInvalid prop into `InputBase`, `Select` components.
- Rename `isCloseable` prop to `isCloseButtonVisible` for `Alert`, `AlertToast`, and `Toast` components.
- Remove default value (`true`) of `isCloseButtonVisible` prop.
- Align sorting icon to text on `Table` example.

## Table Issue
### Sorting icon
![image](https://user-images.githubusercontent.com/24446505/83479481-4a4b8100-a4cb-11ea-9df3-1b95b1a3b60b.png)
### Fix
![image](https://user-images.githubusercontent.com/24446505/83479505-57687000-a4cb-11ea-89a6-6c3cb890e887.png)
