### PR TITLE
fix(skeleton): fix incorrect skeleton colors for dark and light mode

### DIFF
--- a/packages/react-styled-ui/src/Skeleton/styles.js
+++ b/packages/react-styled-ui/src/Skeleton/styles.js
@@ -112,8 +112,8 @@ const useSkeletonStyle = ({
 }) => {
   const { colorMode } = useColorMode();
   const backgroundColor = {
-    dark: 'gray:90',
-    light: 'gray:10',
+    dark: 'gray:80',
+    light: 'gray:20',
   }[colorMode];
   const _props = {
     variant,


### PR DESCRIPTION
For dark mode, the background color should be #303030 (`gray:80`)

![image](https://user-images.githubusercontent.com/447801/83971993-8427e780-a910-11ea-8815-47df769e7793.png)