### PR TITLE
docs: change wording

### DIFF
--- a/packages/styled-ui-docs/pages/alert.mdx
+++ b/packages/styled-ui-docs/pages/alert.mdx
@@ -14,7 +14,7 @@ import { Alert } from '@trendmicro/react-styled-ui';
 
 ### Severity levels
 
-The alert offers four severity levels, each has a distinctive icon and color.
+Alerts provide four severity levels, each with a distinctive icon and color.
 
 ```jsx
 <Stack direction="column" spacing="4x">
@@ -35,7 +35,7 @@ The alert offers four severity levels, each has a distinctive icon and color.
 
 ### With close button
 
-Set `isCloseButtonVisible` to `true`, a close button will appear on the right side.
+Set `isCloseButtonVisible` to `true` to include a close button on the right-hand side of an alert.
 
 ```jsx
 <Stack direction="column" spacing="4x">
@@ -155,7 +155,7 @@ You can use the `Heading` component to display a formatted title above the conte
 
 ### Actions
 
-An alert can have an action, such as a close or action button. It is rendered after the message, at the end of the alert.
+An alert can have an action button (such close). It is rendered after the message, at the end of the alert.
 
 ```jsx
 <Stack direction="column" spacing={1}>

--- a/packages/styled-ui-docs/pages/button.mdx
+++ b/packages/styled-ui-docs/pages/button.mdx
@@ -18,7 +18,7 @@ import { Button } from '@trendmicro/react-styled-ui';
 
 ### Variants
 
-Use the `variant` prop to change the visual style of the Button. You can set the value to `emphasis`, `primary`, `default`, `secondary`, `ghost`.
+Use the `variant` prop to change the visual style of `Button`. You can set the value to `emphasis`, `primary`, `default`, `secondary`, or `ghost`.
 
 ```jsx
 <Stack direction="row" spacing="2x">
@@ -32,7 +32,7 @@ Use the `variant` prop to change the visual style of the Button. You can set the
 
 ### Sizes
 
-Use the `size` prop to change the size of the `Button`. You can set the value to `sm`, `md`, or `lg`.
+Use the `size` prop to change the size of the button. You can set the value to `sm`, `md`, or `lg`.
 
 ```jsx
 <Stack direction="column" spacing="4x">
@@ -84,7 +84,7 @@ Use the `size` prop to change the size of the `Button`. You can set the value to
 
 ### Button with icon
 
-Icon buttons are commonly used in toolbars. Sometimes you might want to add label to certain icon buttons to enhance the UX. You can use [Space](./space) to add a padding space with `.25rem` (`4px`) between icon and label.
+Icon buttons are commonly used in toolbars. If required, you can add a label to icon buttons. To add padding space (`.25rem` (`4px`)) between an icon and label, use [Space](./space).
 
 ```jsx
 <Stack direction="column" spacing="4x">
@@ -203,10 +203,9 @@ Icon buttons are commonly used in toolbars. Sometimes you might want to add labe
 </Stack>
 ```
 
-## Custom button
+## Custom Button
 
-In case you need to customize the button, pass style props to the [ButtonBase](./buttonbase) component to create a custom button.
-
+To create a custom button, you can use the style props for the [ButtonBase](./buttonbase) component.
 
 ## Props
 
@@ -214,6 +213,6 @@ In case you need to customize the button, pass style props to the [ButtonBase](.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| disabled | boolean | | If `true`, the button will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
+| disabled | boolean | | If `true`, the button will be disabled. This sets `aria-disabled=true`. You can style this state by using the `_disabled` prop. |
 | size | string | 'md' | The size of the button. One of: `'sm'`, `'md'`, `'lg'` |
 | variant | string | 'default' | The variant of the button style to use. One of: `'emphasis'`, `'primary'`, `'default'`, `'secondary'`, `'ghost'` |

--- a/packages/styled-ui-docs/pages/checkbox.mdx
+++ b/packages/styled-ui-docs/pages/checkbox.mdx
@@ -1,10 +1,10 @@
 # Checkbox
 
-`Checkbox` is used in forms when a user needs to select multiple values from several options.
+Use a `Checkbox` in forms when a user needs to select multiple values from a list of options.
 
-Native HTML checkboxes are 100% accessible by default, so we used a [very common CSS technique](https://dev.to/lkopacz/create-custom-keyboard-accessible-checkboxes-2036) to style the checkboxes.
+Since native HTML checkboxes are 100% accessible by default, a common [CSS technique](https://dev.to/lkopacz/create-custom-keyboard-accessible-checkboxes-2036) is used to style checkboxes.
 
-The `Checkbox` component composes [`ControlBox`](./controlbox), a component we created to make it easy to style an element based on sibling inputs.
+The `Checkbox` component is composed of the [`ControlBox`](./controlbox) component that is created to style an element based on sibling input.
 
 ## Import
 
@@ -22,7 +22,7 @@ import { Checkbox } from '@trendmicro/react-styled-ui';
 
 ### Colors
 
-Use the `variantColor` prop to change the color scheme of the Checkbox. `variantColor` can be any color key with key `50`(hover), `60`(checked, active) that exist in the `theme.colors`.
+Use the `variantColor` prop to change the color scheme of the checkbox. `variantColor` can be any color key with key `50` (hover) or `60` (checked, active) that exist in `theme.colors`.
 
 ```jsx
 <Stack direction="row" spacing="6x">
@@ -40,7 +40,7 @@ Use the `variantColor` prop to change the color scheme of the Checkbox. `variant
 
 ### Sizes
 
-Use the `size` prop to change the size of the `Checkbox`. You can set the value to `sm`, `md`, or `lg`.
+Use the `size` prop to change the size of the checkbox. You can set the value to `sm`, `md`, or `lg`.
 
 ```jsx
 <Stack direction="row" spacing="4x">
@@ -106,15 +106,16 @@ function IndeterminateExample() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| id | string | | The id assigned to input field. |
-| name | string | | The name of the input field in a checkbox. It's useful for form submission. |
-| value | string \| number | | The value to be used in the checkbox input. This is the value that will be returned on form submission. |
-| variantColor | string | | The color of the checkbox when it's checked. This should be one of the color keys in the theme (e.g. `'green'`, `'red'`) |
-| size | string | 'md' | The size (width and height) of the checkbox. One of: `'sm'`, `'md'`, `'lg'` |
-| defaultChecked | boolean | | If `true`, the checkbox will be initially checked. |
-| checked | boolean | | If `true`, the checkbox will be checked. You'll need to pass `onChange` to update the state for a controlled component. |
-| disabled | boolean | | If `true`, the checkbox will be disabled. This sets `aria-disabled=true` and you can style this state by passingthe `_disabled` prop. |
-| indeterminate | boolean | | If `true`, the checkbox will be indeterminate. This only affects the icon shown inside checkbox. |
+| id | string | | The `id` attribute of the input field.  |
+| name | string | | The name of a input field in a checkbox. The name is useful for form submissions.  |
+| value | string \| number | | The value for checkbox input. This is the return value for form submissions. |
+The color of the checkbox when it is selected. The color should be one of the color keys in the theme (for example, `'green'`, `'red'`)
+| variantColor | string | | The color of the checkbox when it is selected. The color should be one of the color keys in the theme (for example, `'green'`, `'red'`) |
+| size | string | 'md' | The size (width and height) of the checkbox. Acceptable values: `'sm'`, `'md'`, `'lg'` |
+| defaultChecked | boolean | | If `true`, the checkbox will be selected initially. |
+| checked | boolean | | If `true`, the checkbox will be selected. Use onChange to update the state for a controlled component. |
+| disabled | boolean | | If `true`, the checkbox will be disabled. This sets `aria-disabled=true` and you can set this state by using the `_disabled` prop. |
+| indeterminate | boolean | | If `true`, the checkbox will be indeterminate. This only affects the icon shown inside the checkbox. |
 | children | ReactNode | | The children of the checkbox. |
 | onChange | function | | A callback called when the state is changed. |
 | onBlur | function | | A callback called when the checkbox loses focus. |

--- a/packages/styled-ui-docs/pages/getting-started.mdx
+++ b/packages/styled-ui-docs/pages/getting-started.mdx
@@ -77,6 +77,10 @@ import { Button } from '@trendmicro/react-styled-ui';
 ```
 ## Recommended setup
 
+Sometimes you may need to apply base CSS styles to your application. Styled UI export a `CSSBaseline` that will normalize styles for a wide range of elements, which is based on the [normalize.css](https://github.com/necolas/normalize.css).
+
+`CSSBaseline` is recommended to add at the root to ensure all components work correctly.
+
 ```js
 import { Global, css } from '@emotion/core';
 import {

--- a/packages/styled-ui-docs/pages/link.mdx
+++ b/packages/styled-ui-docs/pages/link.mdx
@@ -23,7 +23,7 @@ import { Link } from '@trendmicro/react-styled-ui';
 ```
 
 
-### An underlined link
+### Underlined link
 
 ```jsx
 <Link
@@ -88,7 +88,7 @@ import { Link } from '@trendmicro/react-styled-ui';
 </Link>
 ```
 
-You can also create a `<ExternalLink>` component for convenience of use:
+You can also create an `ExternalLink` component for enhanced usability.
 
 ```jsx noInline
 const ExternalLink = React.forwardRef((props, ref) => (
@@ -111,9 +111,9 @@ render(
 
 ## Props
 
-`Link` composes the [`PseudoBox`](./pseudobox) component. You can override the default styles with style props.
+A `Link` element is composed of the [`PseudoBox`](./pseudobox) component. You can override the default styles with style props.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| disabled | boolean | | If `true`, the link will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
+| disabled | boolean | | If `true`, the link will be disabled. This sets `aria-disabled=true` and you can style this state by using the `_disabled` prop. |
 | onClick | function | | A callback called when the link is clicked. |

--- a/packages/styled-ui-docs/pages/popover.mdx
+++ b/packages/styled-ui-docs/pages/popover.mdx
@@ -1,23 +1,19 @@
 # Popover
 
-Popover is a non-modal dialog that floats around a trigger. It's used to display
-contextual information to the user, and should be paired with a clickable
-trigger element.
+`Popover` is a non-modal dialog that floats around a trigger. `Popover` is used to display contextual information to users, and should be paired with a clickable trigger element.
 
-Popover is built on top of the [Popper.js](https://popper.js.org/) library, and
-composes the `Popper` component.
+`Popover` is built on top of the [Popper.js](https://popper.js.org/) library, and is composed of the `Popper` component.
 
 <carbon-ad></carbon-ad>
 
 ## Import
 
-- `Popover`: The wrapper that provides props, state, and context to it's
-  children.
-- `PopoverTrigger`: Used to wrap the reference (or trigger) element.
-- `PopoverContent`: The popover itself.
-- `PopoverHeader`: The header of the popover.
-- `PopoverBody`: The body of the popover.
-- `PopoverFooter`: The footer of the popover.
+- `Popover`: The wrapper that provides props, state, and context to its children
+- `PopoverTrigger`: Used to wrap the reference (or trigger) element
+- `PopoverContent`: The popover itself
+- `PopoverHeader`: The header of the popover
+- `PopoverBody`: The body of the popover
+- `PopoverFooter`: The footer of the popover
 
 ```js
 import { Popover, PopoverTrigger, PopoverContent, PopoverHeader, PopoverBody, PopoverFooter } from '@trendmicro/react-styled-ui';
@@ -27,11 +23,9 @@ import Popover from '@trendmicro/react-styled-ui/Popover';
 
 ## Basic Usage
 
-When using this component, ensure the children passed to `PopoverTrigger` is
-focusable, user can tab to it using their keyboard, and it can take a `ref`.
-It's critical for accessiblity.
+When using this component, ensure the children passed to `PopoverTrigger` is focusable. `Popover` should be accessible and should allow users to access it using the tab key on a keyboard.
 
-**A11y:** When the Popover opens, focus is sent to the `PopoverContent`. When it closes, focus is returned to the trigger.
+**A11y:** When `Popover` opens, the focus status is sent to  `PopoverContent`. When `Popover` is closed, the focus status is returned to the trigger.
 
 ```jsx
 <Popover>
@@ -44,11 +38,9 @@ It's critical for accessiblity.
   </PopoverContent>
 </Popover>
 ```
-## Focus an element when Popover opens
+## Focus an element when `Popover` opens
 
-By default, focus is to sent to the `PopoverContent` when it opens, you might
-want to send focus to a specific element when it opens. Pass the
-`initialFocusRef` prop to do so.
+By default, the focus status is to sent to `PopoverContent` when `Popover` opens. You can send the focus status to a specific element when it opens by passing the `initialFocusRef` prop.
 
 ```jsx
 function WalkthroughPopover() {
@@ -91,8 +83,7 @@ function WalkthroughPopover() {
 
 ## Accessing Internal state
 
-Styled UI provides access to two internal details, `isOpen` and `onClose`. Use the
-render prop pattern to gain access to them.
+Trend Micro Styled UI provides access to two internal states:  `isOpen` and `onClose`. Use the render prop pattern to access the internal states.
 
 ```jsx
 function InternalStateEx() {
@@ -139,11 +130,9 @@ function InternalStateEx() {
 
 ## Controlled Usage
 
-You can completely controlled the opening and closing of the popover by passing
-the `isOpen`, and `onClose`.
+You can control the opening and closing of `Popover` by passing the `isOpen` or `onClose` state.
 
-Sometime, you might need to set `returnFocusOnClose` to `false` to prevent
-popver from returning focus to `PopoverTrigger`'s children.
+If required, you can set `returnFocusOnClose` to `false` to prevent Popver from returning the focus status to the children of `PopoverTrigger`.
 
 ```jsx
 function ControlledUsage() {
@@ -182,9 +171,9 @@ function ControlledUsage() {
 }
 ```
 
-## Customizing the Popover
+## Customizing Popover
 
-### Hide the arrow
+### Hide arrow
 
 ```jsx
 <Popover hideArrow>
@@ -214,11 +203,9 @@ function ControlledUsage() {
 
 ## Hover Trigger
 
-To show the popover when you mouse over or focus on the trigger, pass the prop
-`trigger` and set it to `hover`. When you focus on or mouse over the popover
-trigger, the popover will open.
+To show `Popover` when you mouse over or focus on the trigger, pass the prop `trigger` and set it to `hover`. When you focus on or mouse over the popover trigger, `Popover` will open.
 
-If you quickly move your cursor to the popover content when it's open, it'll remain open till you leave.
+If you quickly move your cursor to the popover content when it is open, `Popover` will remain open until you move away the cursor.
 
 ```jsx
 <Popover hideArrow trigger="hover">
@@ -232,12 +219,11 @@ If you quickly move your cursor to the popover content when it's open, it'll rem
 </Popover>
 ```
 
-## Popover Placements
+## Popover Placement
 
-Since popover is powered by PopperJS, you can change the placement of the
-popover by passing the `placement` prop.
+Since `Popover` is controlled by PopperJS, you can change the placement of `Popover` by passing the `placement` prop.
 
-Even though you specified the placement, Popover will try to reposition itself in event the available space at the specified placment isn't enough.
+Although you may have specified the placement, `Popover` will try to reposition itself if there is not enough available space at the specified placement.
 
 ```jsx
 <Stack direction="column" spacing="2rem">
@@ -361,46 +347,29 @@ Even though you specified the placement, Popover will try to reposition itself i
 ```
 
 ## Accessibility
+The word _"trigger"_ refers to the children of PopoverTrigger.
 
-When you see the word _"trigger"_, it's referring to the `children` of `PopoverTrigger`
-
-### Keyboard and Focus
-
-- When the popover is opened, focus is moved to the `PopoverContent`. If the
-  `initialFocusRef` is set, then focus moves to the element with that `ref`.
-- When the popover is closed, focus returns to the trigger. If you set
-  `returnFocusOnClose` to `false`, focus will not return.
+### Keyboard and focus
+- When `Popover` is opened, the focus status is moved to `PopoverContent`. If `initialFocusRef` is set, then the focus status is moved to the element with the related reference (`ref`).
+- When `Popover` is closed, the focus status returns to the trigger. If you set `returnFocusOnClose` to `false`, the focus status will not return.
 - If trigger is set to `hover`:
-  - Focusing on or mousing over the trigger will open the popover
-  - Blurring or mousing out of the trigger will close the popover. If you move
-    your mouse into the `PopoverContent`, it'll remain visible.
+  - Focusing on or mousing over the trigger will open `Popover`.
+  - Blurring or mousing out of the trigger will close `Popover`. If you move your mouse into `PopoverContent`, `Popover` remains visible.
 - If trigger is set to `click`:
-  - Clicking the trigger or using the `Space` or `Enter` when focus is on the
-    trigger will open the popover.
-  - Clicking the trigger again will close the popover.
-- Hitting the `Esc` key while the popover is open and focus is within the
-  `PopoverContent`, will close the popover. If you set `closeOnEsc` to `false`,
-  it will not close.
-- Clicking outside or blurring out of the `PopoverContent` closes the popover.
-  If you set `closeOnBlur` to `false`, it will not close.
+  - Clicking the trigger or using the `Space` or `Enter` key when the focus status is on the trigger will open `Popover`.
+  - Clicking the trigger again will close `Popover`.
+- Hitting the `Esc` key while `Popover` is open and the focus status is within `PopoverContent` will close `Popover`. If you set `closeOnEsc` to `false`, `Popover` will not close.
+- Clicking outside or blurring out of `PopoverContent` closes `Popover`. If you set `closeOnBlur` to `false`, `Popover` will not close.
 
-### ARIA Attributes
+### ARIA attributes
 
-- If the trigger is set to `click`, the `PopoverContent` element has role set to
-  `dialog`. If the trigger is set to `hover`, the `PopoverContent` has `role`
-  set to `tooltip`.
-- The `PopoverContent` has `aria-labelledby` set to the `id` of the
-  `PopoverHeader`.
-- The `PopoverContent` has `aria-describedby` set to the `id` of the
-  `PopoverBody`.
-- The `PopoverContent` has `aria-hidden` set to `true` or `false` depending on
-  the open/closed state of the popover.
-- The trigger has `aria-haspopup` set to `true` to denote that it triggers a
-  popover.
-- The trigger has `aria-controls` set to the `id` of the `PopoverContent` to
-  associate the popover and the trigger.
-- The trigger has `aria-expanded` set to `true` or `false` depending on the
-  open/closed state of the popover.
+- If the trigger is set to `click`, the role of the `PopoverContent` element is set to `dialog`. If the trigger is set to `hover`, the `PopoverContent` role is set to `tooltip`.
+- `PopoverContent` has `aria-labelledby` set to the `id` attribute of `PopoverHeader`.
+- `PopoverContent` has `aria-describedby` set to the `id` attribute of `PopoverBody`.
+- `PopoverContent` has `aria-hidden` set to `true` or `false` depending on the open/closed state of `Popover`.
+- The trigger has` aria-haspopup` set to `true` to denote that it triggers a popover.
+- The trigger has `aria-controls` set to the 'id' attribute of `PopoverContent` to associate the popover with the trigger.
+- The trigger has `aria-expanded` set to `true` or `false` depending on the open/closed state of the popover.
 
 ## Props
 
@@ -408,23 +377,23 @@ When you see the word _"trigger"_, it's referring to the `children` of `PopoverT
 
 | Name               | Type                                                         | Default                  | Description                                                                                                                                                                                                                                                                                                |
 | :----------------- | :----------------------------------------------------------- | :----------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| isOpen             | boolean                                                      |                          | If `true`, the popover is shown                                                                                                                                                                                                                                                                            |
+| isOpen             | boolean                                                      |                          | If `true`, the popover is shown.                                                                                                                                                                                                                                                                           |
 | defaultIsOpen      | boolean                                                      |                          | If `true`, the popover is shown initially.                                                                                                                                                                                                                                                                 |
-| initialFocusRef    | React.Ref                                                    |                          | The `ref` of the element that should receive focus when the popover opens.                                                                                                                                                                                                                                 |
+| initialFocusRef    | React.Ref                                                    |                          | The `ref` of the element that should receive the focus status when the popover opens.                                                                                                                                                                                                                                 |
 | trigger            | hover, click                                                 | `click`                  | The interaction that triggers the popover.                                                                                                                                                                                                                                                                 |
-| placement          | PopperJS.placement                                           | `bottom`                 | Position the tooltip relative to the trigger element as well as surrounding elements. One of: `'top'`, `'bottom'`, `'right'`, `'left'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`, `'right-start'`, `'right-end'`, `'left-start'`, `'left-end'` |
-| returnFocusOnClose | boolean                                                      | `true`                   | If `true`, the popover will return focus to the trigger when it closes                                                                                                                                                                                                                                     |
-| closeOnBlur        | boolean                                                      | `true`                   | If `true`, the popover will close when you blur out it by clicking outside or tabbing out                                                                                                                                                                                                                  |
-| closeOnEsc         | boolean                                                      | `true`                   | If `true`, close the popover when the `esc` key is pressed                                                                                                                                                                                                                                                 |
-| children           | React.ReactNode, (props: InternalState) => React.ReactNode   |                          | The children of the popover                                                                                                                                                                                                                                                                                |
-| hideArrow          | boolean                                                      |                          | If `true` hide the arrow tip on the popover.                                                                                                                                                                                                                                                               |
+| placement          | PopperJS.placement                                           | `bottom`                 | Position the popover relative to the trigger element as well as surrounding elements. Possible values: `'top'`, `'bottom'`, `'right'`, `'left'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`, `'right-start'`, `'right-end'`, `'left-start'`, `'left-end'` |
+| returnFocusOnClose | boolean                                                      | `true`                   | If `true`, the popover will return the focus status to the trigger when closing.                                                                                                                                                                                                                                     |
+| closeOnBlur        | boolean                                                      | `true`                   | If `true`, the popover will close when you use the tab key or click outside the popover dialog.                                                                                                                                                                                                                  |
+| closeOnEsc         | boolean                                                      | `true`                   | If `true`, the popover will close when you press the `esc` key.                                                                                                                                                                                                                                                 |
+| children           | React.ReactNode, (props: InternalState) => React.ReactNode   |                          | The children of the popover.                                                                                                                                                                                                                                                                                |
+| hideArrow          | boolean                                                      |                          | If `true`, hide the arrow tip on the popover.                                                                                                                                                                                                                                                               |
 | skidding           | number                                                       | `0`                      | Displaces the popover (in pixels) along the reference element. Used by [`popper.js`](https://popper.js.org/docs/v2/modifiers/offset/#skidding-1)                                                                                                                                                           |
 | distance           | number                                                       | `4`                      | Displaces the popover (in pixels) away from, or toward, the reference. Used by [`popper.js`](https://popper.js.org/docs/v2/modifiers/offset/#distance-1)                                                                                                                                                   |
 | delay              | number or object                                             | show=`0`, hide=`100`     | If `trigger` is hover, delay showing and hiding the popover (ms). Object structure is: `delay={{ show: 500, hide: 100 }}`                                                                                                                                                                                                      |
-| usePortal          | boolean                                                      | `true`                   | If `true` the popover is displayed with a `Portal`. Rendering content inside a Portal allows the popover content to escape the physical bounds of its parent while still being positioned correctly relative to its target                                                                                 |
-| onOpen             | () => void                                                   |                          | Callback fired when the popover opens                                                                                                                                                                                                                                                                      |
-| onClose            | () => void                                                   |                          | Callback fired when the popover closes                                                                                                                                                                                                                                                                     |
+| usePortal          | boolean                                                      | `true`                   | If `true`, the popover is displayed with a `Portal`. Rendering content inside a Portal allows the popover content to escape the physical bounds of its parent while still being positioned correctly relative to its target.                                                                                 |
+| onOpen             | () => void                                                   |                          | A callback called when the popover opens.                                                                                                                                                                                                                                                                      |
+| onClose            | () => void                                                   |                          | A callback called when the popover closes.                                                                                                                                                                                                                                                                     |
 
-### Other Props
-- `PopoverContent` composes [`PseudoBox`](./pseudobox). You can override the default styles with style props.
-- `PopoverHeader`, `PopoverFooter` and `PopoverBody` composes [`Box`](./box).
+### Other props
+- `PopoverContent` is composed of [`PseudoBox`](./pseudobox). You can override the default styles with style props.
+- `PopoverHeader`, `PopoverFooter`,and `PopoverBody` are composed of [`Box`](./box).

--- a/packages/styled-ui-docs/pages/radio.mdx
+++ b/packages/styled-ui-docs/pages/radio.mdx
@@ -1,6 +1,6 @@
 # Radio
 
-Radios are used when only one choice may be selected in a series of options.
+Radio buttons are used when only one choice may be selected in a series of options.
 
 ## Import
 
@@ -18,7 +18,7 @@ import { Radio } from '@trendmicro/react-styled-ui';
 
 ### Colors
 
-Use the `variantColor` prop to change the color scheme of the Radio. `variantColor` can be any color key with key `50`(hover), `60`(checked) that exist in the `theme.colors`.
+Use the `variantColor` prop to change the color scheme of a radio button. `variantColor` can be any color key with key `50` (hover) or `60` (checked) that exist in `theme.colors`.
 
 ```jsx
 <Stack direction="row" spacing="3x">
@@ -29,7 +29,7 @@ Use the `variantColor` prop to change the color scheme of the Radio. `variantCol
 
 ### Sizes
 
-Use the `size` prop to change the size of the `Radio`. You can set the value to `sm`, `md`, or `lg`.
+Use the `size` prop to change the radio button size. You can set the value to `sm`, `md`, or `lg`.
 
 ```jsx
 <Stack direction="column" spacing="1x" shouldWrapChildren>
@@ -56,15 +56,15 @@ Use the `size` prop to change the size of the `Radio`. You can set the value to 
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| id | string | | The id assigned to input field. |
-| name | string | | The name of the input field in a radio. It's useful for form submission. |
-| value | string \| number | | The value to be used in the radio input. This is the value that will be returned on form submission. |
-| variantColor | string | | The color of the radio when it's checked. This should be one of the color keys in the theme (e.g. `'green'`, `'red'`) |
-| size | string | 'md' | The size (width and height) of the radio. One of: `'sm'`, `'md'`, `'lg'` |
-| defaultChecked | boolean | | If `true`, the radio will be initially checked. |
-| checked | boolean | | If `true`, the radio will be checked. You'll need to pass `onChange` to update the state for a controlled component. |
-| disabled | boolean | | If `true`, the radio will be disabled. This sets `aria-disabled=true` and you can style this state bypassing the `_disabled` prop. |
-| children | ReactNode | | The children of the radio. |
+| id | string | | The id attribute of the input field. |
+| name | string | | The name of a input field in a series of radio buttons. The name is useful for form submissions.  |
+| value | string \| number | | The value for radio button input. This is the return value for form submissions. |
+| variantColor | string | | The color of the radio button when it is selected. The color should be one of the color keys in the theme (for example, `'green'`, `'red'`) |
+| size | string | 'md' | The size (width and height) of a radio button. Acceptable values: `'sm'`, `'md'`, `'lg'` |
+| defaultChecked | boolean | | If `true`, the radio button will be selected initially. |
+| checked | boolean | | If `true`, the radio button will be selected. Use `onChange` to update the state for a controlled component. |
+| disabled | boolean | | If `true`, the radio button will be disabled. This sets `aria-disabled=true` and you can set this state by using the `_disabled` prop. |
+| children | ReactNode | | The children of the radio button. |
 | onChange | function | | A callback called when the state is changed. |
-| onBlur | function | | A callback called when the radio loses focus. |
-| onFocus | function | | A callback called when the radio receives focus. |
+| onBlur | function | | A callback called when the radio button loses focus. |
+| onFocus | function | | A callback called when the radio button receives focus. |

--- a/packages/styled-ui-docs/pages/spinner.mdx
+++ b/packages/styled-ui-docs/pages/spinner.mdx
@@ -1,6 +1,6 @@
 # Spinner
 
-A spinner can be used to display the loading state when the part of the page is waiting for the results.
+A spinner can be used to display the loading state when the part of the page is waiting for action results.
 
 ## Import
 
@@ -30,7 +30,7 @@ import { Spinner } from '@trendmicro/react-styled-ui';
 
 ### Sizes
 
-Use the `size` prop to change the size of the `Spinner`. You can set the value to `xs`, `sm`, `md`, `lg`, or `xs`. The corresponding stroke width is listed as below:
+Use the `size` prop to change the size of a spinner. You can set the value to `xs`, `sm`, `md`, `lg`, or `xs`. The corresponding stroke width is listed below:
 
 | Size | Stroke Width |
 | :---- | :------------- |
@@ -78,7 +78,7 @@ Use the `size` prop to change the size of the `Spinner`. You can set the value t
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| size | string | 'md' | The size of the spinner. One of: `'xl'`, `'lg'`, `'md'`, `'sm'`, `'xs'` |
+| size | string | 'md' | The size of the spinner. Acceptable values: `'xl'`, `'lg'`, `'md'`, `'sm'`, `'xs'`. |
 | color | string | 'blue:60' | The color of the spinner. |
-| strokeWidth | number | | Set a different stroke width for the spinner. |
-| speed | float | 2 | Set a different speed for the spinner. |
+| strokeWidth | number | | Set the stroke width for the spinner. |
+| speed | float | 2 | Set the spinning speed for the spinner. |

--- a/packages/styled-ui-docs/pages/tooltip.mdx
+++ b/packages/styled-ui-docs/pages/tooltip.mdx
@@ -1,11 +1,8 @@
 # Tooltip
 
-A tooltip is a brief, informative message that appears when a user interacts
-with an element. Tooltips are usually initiated in one of two ways: through a
-mouse-hover gesture or through a keyboard-hover gesture.
+A tooltip is a brief, informative message that appears when a user interacts with an element. Tooltips are usually initiated in one of two ways: through a mouse-hover or keyboard-hover action.
 
-The Tooltip component follows the
-[WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/#tooltip) Tooltip Pattern.
+The `Tooltip` component follows the [WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/#tooltip) Tooltip pattern.
 
 ## Import
 
@@ -17,8 +14,7 @@ import { Tooltip } from '@trendmicro/react-styled-ui';
 
 ## Usage
 
-If the `children` of Tooltip is a string, we wrap with in a `span` with
-`tabIndex` set to `0`, to ensure it meets the accessibility requirements.
+If the `children` of Tooltip is a string, wrap within a `span` with `tabIndex` set to `0` to ensure accessibility requirements are met.
 
 ```jsx
 <Tooltip label="Hey, I'm here!">Hover me</Tooltip>
@@ -42,9 +38,7 @@ If the `children` of Tooltip is a string, we wrap with in a `span` with
 
 ### Tooltip with focusable content
 
-If the children of the tooltip is a focusable element, the tooltip will show
-when you focus or hover on the element, and will hide when you blur or move
-cursor out of the element.
+If the children of Tooltip are focusable elements, Tooltip will show when you focus or hover on the a children element and will hide when you blur or move cursor out of the element.
 
 ```jsx
 <Tooltip label="Search places" placement="top">
@@ -110,15 +104,15 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
 | isOpen | boolean | | If `true`, the tooltip is shown. |
-| defaultIsOpen | boolean | | If `true`, the tooltip is initially shown. |
+| defaultIsOpen | boolean | | If `true`, the tooltip is shown initially. |
 | label | string | | The label of the tooltip.|
 | aria-label | string | | An alternate label for screen readers. |
-| placement | PopperJS.Placement | 'bottom' | Position the tooltip relative to the trigger element as well as surrounding elements. One of: `'top'`, `'bottom'`, `'right'`, `'left'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`, `'right-start'`, `'right-end'`, `'left-start'`, `'left-end'` |
-| children | ReactNode | | The `ReactNode` to be used as the trigger of the tooltip. |
-| hideArrow | boolean | | If `true` hide the arrow tip on the tooltip. |
+| placement | PopperJS.Placement | 'bottom' | Position the tooltip relative to the trigger element as well as surrounding elements. Possible values: `'top'`, `'bottom'`, `'right'`, `'left'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`, `'right-start'`, `'right-end'`, `'left-start'`, `'left-end'` |
+| children | ReactNode | | The `ReactNode` element to be used as the trigger of the tooltip. |
+| hideArrow | boolean | | If `true`, hide the arrow tip on the tooltip. |
 | showDelay | number | | The delay in milliseconds for the tooltip to show. |
 | hideDelay | number | | The delay in milliseconds for the tooltip to hide. |
-| closeOnClick | boolean | | If `true` hide the tooltip, when the trigger is clicked. |
+| closeOnClick | boolean | | If `true`, hide the tooltip when the trigger is clicked. |
 | shouldWrapChildren | boolean | | If `true`, the tooltip will wrap the children in a `span` with `tabIndex=0`. |
 | onOpen | function | | A callback called when the tooltip shows. |
 | onClose| function | | A callback called when the tooltip hides. |


### PR DESCRIPTION
Change the wording of Alert, Button, Checkbox, Link, Popover, Radio, Spinner, and Tooltip