### PR TITLE
docs: updated the theme wordings and color "black:emphasis" value changed

### DIFF
--- a/packages/react-styled-ui/src/Alert/styles.js
+++ b/packages/react-styled-ui/src/Alert/styles.js
@@ -128,8 +128,8 @@ const useAlertCloseButtonStyle = () => {
     light: 'black:tertiary',
   }[colorMode];
   const hoverColor = {
-    dark: 'black:emphasis',
-    light: 'black:emphasis',
+    dark: 'black:primary',
+    light: 'black:primary',
   }[colorMode];
   const activeColor = color;
   const focusColor = color;

--- a/packages/react-styled-ui/src/AlertToast/styles.js
+++ b/packages/react-styled-ui/src/AlertToast/styles.js
@@ -189,8 +189,8 @@ const useAlertToastCloseButtonStyle = () => {
     light: 'black:tertiary',
   }[colorMode];
   const hoverColor = {
-    dark: 'black:emphasis',
-    light: 'black:emphasis',
+    dark: 'black:primary',
+    light: 'black:primary',
   }[colorMode];
   const activeColor = color;
   const focusColor = color;

--- a/packages/react-styled-ui/src/Button/styles.js
+++ b/packages/react-styled-ui/src/Button/styles.js
@@ -9,7 +9,7 @@ const defaultVariantProps = (props) => {
   const { colorMode, color } = props;
   const _color = {
     dark: 'white:emphasis',
-    light: 'black:emphasis',
+    light: 'black:primary',
   }[colorMode];
 
   // background color
@@ -86,7 +86,7 @@ const secondaryVariantProps = ({ color, colorMode, theme: { colors } }) => {
   }[colorMode];
   const disabledColor = {
     dark: 'white:emphasis',
-    light: 'black:emphasis',
+    light: 'black:primary',
   }[colorMode];
   const activeColor = hoverColor;
   const focusColor = _color;
@@ -171,7 +171,7 @@ const fillColorVariantProps = ({ borderRadius, color, colorMode, theme: { colors
   //color
   const disabledColor = {
     dark: 'white:emphasis',
-    light: 'black:emphasis',
+    light: 'black:primary',
   }[colorMode];
 
   // background color

--- a/packages/react-styled-ui/src/Checkbox/styles.js
+++ b/packages/react-styled-ui/src/Checkbox/styles.js
@@ -76,7 +76,7 @@ const interactionProps = ({ color, colorMode }) => {
   const checkedAndFocusColor = _color;
   const checkedAndDisabledColor = {
     dark: 'white:emphasis',
-    light: 'black:emphasis',
+    light: 'black:primary',
   }[colorMode];
 
   // background color

--- a/packages/react-styled-ui/src/Drawer/styles.js
+++ b/packages/react-styled-ui/src/Drawer/styles.js
@@ -53,7 +53,7 @@ const useDrawerCloseButtonStyle = () => {
   }[colorMode];
   const hoverColor = {
     dark: 'white:emphasis',
-    light: 'black:emphasis',
+    light: 'black:primary',
   }[colorMode];
   const activeColor = color;
   const focusColor = color;

--- a/packages/react-styled-ui/src/Modal/styles.js
+++ b/packages/react-styled-ui/src/Modal/styles.js
@@ -51,7 +51,7 @@ const useModalCloseButtonStyle = () => {
   }[colorMode];
   const hoverColor = {
     dark: 'white:emphasis',
-    light: 'black:emphasis',
+    light: 'black:primary',
   }[colorMode];
   const activeColor = color;
   const focusColor = color;

--- a/packages/react-styled-ui/src/Popover/styles.js
+++ b/packages/react-styled-ui/src/Popover/styles.js
@@ -30,7 +30,7 @@ const usePopoverContentStyle = () => {
 
 const usePopoverHeaderStyle = () => {
   const { colorMode } = useColorMode();
-  const color = { dark: 'white:emphasis', light: 'black:emphasis' }[colorMode];
+  const color = { dark: 'white:emphasis', light: 'black:primary' }[colorMode];
   return {
     ...baseProps,
     fontWeight: 'semibold',

--- a/packages/react-styled-ui/src/Tabs/styles.js
+++ b/packages/react-styled-ui/src/Tabs/styles.js
@@ -58,7 +58,7 @@ const statusProps = {
 };
 
 const lineStyle = ({ size, colorMode, theme }) => {
-  const _color = { light: theme.colors['black:emphasis'], dark: theme.colors['white:emphasis'] }[colorMode];
+  const _color = { light: theme.colors['black:primary'], dark: theme.colors['white:emphasis'] }[colorMode];
   const _fontColor = setColorWithOpacity(_color, 0.6);
   const _hoveredBorderColor = 'gray:60';
   const _focusBorderColor = 'blue:60';
@@ -104,7 +104,7 @@ const enclosedStyle = ({ size, colorMode, theme }) => {
   const _focusBorderWidth = '2px';
   const _px = tabSizes[size] ? theme.space[tabSizes[size].px] : theme.space[tabSizes.md.px];
   const _lineHeight = tabSizes[size] ? theme.lineHeights[tabSizes[size].lineHeight] : theme.lineHeights[tabSizes.md.lineHeight];
-  const _color = { light: theme.colors['black:emphasis'], dark: theme.colors['white:emphasis'] }[colorMode];
+  const _color = { light: theme.colors['black:primary'], dark: theme.colors['white:emphasis'] }[colorMode];
   const _backgroundColor = { light: 'gray:20', dark: 'gray:90' }[colorMode];
   const _borderColor = { light: 'gray:30', dark: 'gray:80' }[colorMode];
   const _hoveredBorderColor = { light: 'gray:30', dark: 'gray:70' }[colorMode];

--- a/packages/react-styled-ui/src/Toast/styles.js
+++ b/packages/react-styled-ui/src/Toast/styles.js
@@ -103,8 +103,8 @@ const useToastCloseButtonStyle = () => {
     light: 'black:tertiary',
   }[colorMode];
   const hoverColor = {
-    dark: 'black:emphasis',
-    light: 'black:emphasis',
+    dark: 'black:primary',
+    light: 'black:primary',
   }[colorMode];
   const activeColor = color;
   const focusColor = color;

--- a/packages/styled-ui-docs/components/Header.jsx
+++ b/packages/styled-ui-docs/components/Header.jsx
@@ -15,7 +15,7 @@ const Header = React.forwardRef((props, ref) => {
     dark: 'gray:70',
   }[colorMode];
   const fontColor = {
-    light: 'black:emphasis', // FIXME
+    light: 'black:primary', // FIXME
     dark: 'white:emphasis',
   }[colorMode];
   return (

--- a/packages/styled-ui-docs/components/MDXComponents.jsx
+++ b/packages/styled-ui-docs/components/MDXComponents.jsx
@@ -50,7 +50,7 @@ const H1 = props => {
       borderBottomColor={borderColor}
       color={color}
       fontSize="3xl"
-      fontWeight="semibold"
+      fontWeight="normal"
       lineHeight="3xl"
       {...props}
     />
@@ -75,7 +75,7 @@ const H2 = props => {
       borderBottomColor={borderColor}
       color={color}
       fontSize="2xl"
-      fontWeight="semibold"
+      fontWeight="normal"
       lineHeight="2xl"
       {...props}
     />

--- a/packages/styled-ui-docs/pages/borders.mdx
+++ b/packages/styled-ui-docs/pages/borders.mdx
@@ -4,14 +4,13 @@ import ThemeParser from "../components/ThemeParser";
 # Borders
 
 The border theme object is around the following scales:
+The border theme object uses the following scales that are based on the [Styled System Theme Specification](https://styled-system.com/theme-specification):
 
 `borders`
 
 `borderWidths`
 
 `radii` (Radius)
-
-which is based on the [Styled System Theme Specification](https://styled-system.com/theme-specification)
 
 ## Border
 
@@ -52,9 +51,6 @@ which is based on the [Styled System Theme Specification](https://styled-system.
 
 ## Configuration Reference
 
-Except for breakpoints, colors, and spacing, all of the keys in the theme object
-map to one of our core theme. All of these keys can be replaced or
-extended.
+Except for breakpoints, colors, and spacing, all keys in the theme object map to one of the core themes. All keys can be replaced or extended.
 
-See the <a href="https://styled-system.com/table" target="_blank">full reference
-table</a> of properties.
+For more information, see the complete properties <a href="https://styled-system.com/table" target="_blank">reference table</a>.

--- a/packages/styled-ui-docs/pages/breakpoints.mdx
+++ b/packages/styled-ui-docs/pages/breakpoints.mdx
@@ -7,7 +7,7 @@ breakpoints array to your theme. These values will be used to generate
 mobile-first (i.e. min-width) media queries, which can then be used to apply
 responsive styles. 
 
-> The `breakpoints` array which is used at breakpoints theme scale.
+> The `breakpoints` array is used at breakpoints theme scale.
 
 > For example, you can write `<Box fontSize={["xs", "sm"]}/>` to make the font size responsive.
 
@@ -20,9 +20,6 @@ responsive styles.
 
 ## Configuration Reference
 
-Except for breakpoints, colors, and spacing, all of the keys in the theme object
-map to one of our core theme. All of these keys can be replaced or
-extended.
+Except for breakpoints, colors, and spacing, all keys in the theme object map to one of the core themes. All keys can be replaced or extended.
 
-See the <a href="https://styled-system.com/table" target="_blank">full reference
-table</a> of properties.
+For more information, see the complete properties <a href="https://styled-system.com/table" target="_blank">reference table</a>.

--- a/packages/styled-ui-docs/pages/button.mdx
+++ b/packages/styled-ui-docs/pages/button.mdx
@@ -214,5 +214,5 @@ To create a custom button, you can use the style props for the [ButtonBase](./bu
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
 | disabled | boolean | | If `true`, the button will be disabled. This sets `aria-disabled=true`. You can style this state by using the `_disabled` prop. |
-| size | string | 'md' | The size of the button. One of: `'sm'`, `'md'`, `'lg'` |
-| variant | string | 'default' | The variant of the button style to use. One of: `'emphasis'`, `'primary'`, `'default'`, `'secondary'`, `'ghost'` |
+| size | string | 'md' | The size of the button. Acceptable values: `'sm'`, `'md'`, `'lg'` |
+| variant | string | 'default' | The variant of the button style to use. Acceptable values: `'emphasis'`, `'primary'`, `'default'`, `'secondary'`, `'ghost'` |

--- a/packages/styled-ui-docs/pages/buttongroup.mdx
+++ b/packages/styled-ui-docs/pages/buttongroup.mdx
@@ -606,6 +606,6 @@ render(<SwitchButton />);
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| size | string | 'md' | The size for all buttons in the group. One of: `'sm'`, `'md'`, `'lg'` |
-| variant | string | 'default' | The variant of all buttons in the group. One of: `'emphasis'`, `'primary'`, `'default'`, `'secondary'`, `'ghost'` |
+| size | string | 'md' | The size for all buttons in the group. Acceptable values: `'sm'`, `'md'`, `'lg'` |
+| variant | string | 'default' | The variant of all buttons in the group. Acceptable values: `'emphasis'`, `'primary'`, `'default'`, `'secondary'`, `'ghost'` |
 | vertical | boolean | false | Make the set of Buttons appear vertically stacked. |

--- a/packages/styled-ui-docs/pages/colors.mdx
+++ b/packages/styled-ui-docs/pages/colors.mdx
@@ -15,7 +15,7 @@ The color palette  is defined for both Light Theme and Dark Theme where `10` - `
 
 <ThemeParser theme="colors" />
 
-### Base color palettes
+### Color palettes
 
 <ColorWrapper>
   <ColorPalettes hue="red" />

--- a/packages/styled-ui-docs/pages/colors.mdx
+++ b/packages/styled-ui-docs/pages/colors.mdx
@@ -7,17 +7,15 @@ import ThemeParser from "../components/ThemeParser";
 
 # Colors
 
-Add a `theme.colors` object to provide colors for your project. By default these
-colors can be referenced by the `color`, `borderColor`, and `backgroundColor`,
-`fill`, `stroke`, styles.
+Add a `theme.colors` object to provide colors for your project. By default these colors can be referenced by `color`, `borderColor`, and `backgroundColor`, `fill`, `stroke`, and styles.
 
-We recommend adding palette that go from `10` - `100`. The `10` being the lightest color and the `100` being the darkest color. We could communicate via the naming such as Red 10 or Red 70 to easily understand Red 10 is a light red, Red 70 is a dark red.
+We recommend adding a palette that go from `10` (lightest color) to `100` (darkest color). You can use a name (such as Red 10 or Red 70) to indicate that Red 10 is a light red color and Red 70 is a dark red color.
 
-The color palette both define for Light Theme and Dark Theme, `10` - `50` are pass AA contrast with black text, `60` - `100` are pass AA contrast with white text,
+The color palette  is defined for both Light Theme and Dark Theme where `10` - `50` means to pass AA contrast with black text and  `60` - `100` means to pass AA contrast with white text.
 
 <ThemeParser theme="colors" />
 
-### Base Color Palettes
+### Base color palettes
 
 <ColorWrapper>
   <ColorPalettes hue="red" />
@@ -30,7 +28,7 @@ The color palette both define for Light Theme and Dark Theme, `10` - `50` are pa
   <ColorPalettes hue="gray" />
 </ColorWrapper>
 
-### Text Color
+### Text color
 
 <ThemeParser mode="light" theme="text" />
 <ThemeParser mode="dark" theme="text" />
@@ -38,7 +36,7 @@ The color palette both define for Light Theme and Dark Theme, `10` - `50` are pa
 <FunctionalColorPalettes mode="light" palette="text" />
 <FunctionalColorPalettes mode="dark" palette="text" />
 
-### Functional Color
+### Functional color
 
 <ThemeParser mode="light" theme="risk" />
 <ThemeParser mode="dark" theme="risk" />
@@ -46,7 +44,7 @@ The color palette both define for Light Theme and Dark Theme, `10` - `50` are pa
 <FunctionalColorPalettes mode="light" palette="risk" />
 <FunctionalColorPalettes mode="dark" palette="risk" />
 
-### Chart Color
+### Chart color
 
 <ThemeParser mode="light" theme="chart" />
 <ThemeParser mode="dark" theme="chart" />
@@ -54,7 +52,7 @@ The color palette both define for Light Theme and Dark Theme, `10` - `50` are pa
 <FunctionalColorPalettes mode="light" palette="chart" />
 <FunctionalColorPalettes mode="dark" palette="chart" />
 
-### Gradient Color
+### Gradient color
 
 <ThemeParser theme="gradient" />
 
@@ -62,9 +60,6 @@ The color palette both define for Light Theme and Dark Theme, `10` - `50` are pa
 
 ## Configuration Reference
 
-Except for breakpoints, colors, and spacing, all of the keys in the theme object
-map to one of our core theme. All of these keys can be replaced or
-extended.
+Except for breakpoints, colors, and spacing, all keys in the theme object map to one of the core themes. All keys can be replaced or extended.
 
-See the <a href="https://styled-system.com/table" target="_blank">full reference
-table</a> of properties.
+For more information, see the complete properties <a href="https://styled-system.com/table" target="_blank">reference table</a>.

--- a/packages/styled-ui-docs/pages/positions.mdx
+++ b/packages/styled-ui-docs/pages/positions.mdx
@@ -3,12 +3,10 @@ import ThemeParser from "../components/ThemeParser";
 
 # Positions
 
-Use these style properties such as `zIndex`, `position`, `top`, `right`, `bottom` and `left` for quickly configuring the position of an element.
+Use these style properties such as `zIndex`, `position`, `top`, `right`, `bottom` and `left` to configure the position of an element.
 
 ## Z-Index
-
-We provides some zIndex values out of the box to control the stacking order
-of components.
+We provide some zIndex values out of the box to control the stacking order of components.
 
 <ThemeParser theme="zIndices" />
 
@@ -21,9 +19,6 @@ of components.
 
 ## Configuration Reference
 
-Except for breakpoints, colors, and spacing, all of the keys in the theme object
-map to one of our core theme. All of these keys can be replaced or
-extended.
+Except for breakpoints, colors, and spacing, all keys in the theme object map to one of the core themes. All keys can be replaced or extended.
 
-See the <a href="https://styled-system.com/table" target="_blank">full reference
-table</a> of properties.
+For more information, see the complete properties <a href="https://styled-system.com/table" target="_blank">reference table</a>.

--- a/packages/styled-ui-docs/pages/shadows.mdx
+++ b/packages/styled-ui-docs/pages/shadows.mdx
@@ -24,9 +24,6 @@ render(<Example />);
 
 ## Configuration Reference
 
-Except for breakpoints, colors, and spacing, all of the keys in the theme object
-map to one of our core theme. All of these keys can be replaced or
-extended.
+Except for breakpoints, colors, and spacing, all keys in the theme object map to one of the core themes. All keys can be replaced or extended.
 
-See the <a href="https://styled-system.com/table" target="_blank">full reference
-table</a> of properties.
+For more information, see the complete properties <a href="https://styled-system.com/table" target="_blank">reference table</a>.

--- a/packages/styled-ui-docs/pages/sizes.mdx
+++ b/packages/styled-ui-docs/pages/sizes.mdx
@@ -2,15 +2,11 @@ import { Box, Stack } from "@trendmicro/react-styled-ui";
 import ThemeParser from "../components/ThemeParser";
 
 # Sizes
-
-The `sizes` key allows you to customize the global sizeing of components you
-build for your project. By default these spacing value can be referenced by the
-`width`, `height`, and `maxWidth`, `minWidth`, `maxHeight`, `minHeight` styles.
+The `sizes` key allows you to customize the global sizing of components you build for your project. By default, these values can be referenced by the `width`, `height`, `maxWidth`, `minWidth`, `maxHeight`, and `minHeight` styles.
 
 <ThemeParser theme="sizes" />
 
-By default, the values are proportional, so `1x` spacing unit is equal to
-`0.25rem`, which translates to `4px` by default in common browsers.
+By default, the values are proportional. Therefore, a `1x` spacing unit is equal to `0.25rem`, which translates to `4px` by default in common browsers.
 
 | Name | Space   | Pixels | Example                            |
 | ---- | ------- | ------ | ---------------------------------- |
@@ -66,9 +62,6 @@ By default, the values are proportional, so `1x` spacing unit is equal to
 
 ## Configuration Reference
 
-Except for breakpoints, colors, and spacing, all of the keys in the theme object
-map to one of our core theme. All of these keys can be replaced or
-extended.
+Except for breakpoints, colors, and spacing, all keys in the theme object map to one of the core themes. All keys can be replaced or extended.
 
-See the <a href="https://styled-system.com/table" target="_blank">full reference
-table</a> of properties.
+For more information, see the complete properties <a href="https://styled-system.com/table" target="_blank">reference table</a>.

--- a/packages/styled-ui-docs/pages/spacing.mdx
+++ b/packages/styled-ui-docs/pages/spacing.mdx
@@ -3,14 +3,11 @@ import ThemeParser from "../components/ThemeParser";
 
 # Spacing
 
-The `space` key allows you to customize the global spacing and sizing scale for
-your project. By default these spacing value can be referenced by the `padding`,
-`margin`, and `top`, `left`, `right`, `bottom` styles.
+The `space` key allows you to customize the global spacing and sizing scale for your project. By default, these spacing values can be referenced by the `padding`, `margin`, `top`, `left`, `right`, and `bottom` styles.
 
 <ThemeParser theme="space" />
 
-By default, the values are proportional, so `1x` spacing unit is equal to
-`0.25rem`, which translates to `4px` by default in common browsers.
+By default, the values are proportional. Therefore, a `1x` spacing unit is equal to `0.25rem`, which translates to `4px` by default in common browsers.
 
 | Name | Space   | Pixels | Example                            |
 | ---- | ------- | ------ | ---------------------------------- |
@@ -61,9 +58,6 @@ By default, the values are proportional, so `1x` spacing unit is equal to
 
 ## Configuration Reference
 
-Except for breakpoints, colors, and spacing, all of the keys in the theme object
-map to one of our core theme. All of these keys can be replaced or
-extended.
+Except for breakpoints, colors, and spacing, all keys in the theme object map to one of the core themes. All keys can be replaced or extended.
 
-See the <a href="https://styled-system.com/table" target="_blank">full reference
-table</a> of properties.
+For more information, see the complete properties <a href="https://styled-system.com/table" target="_blank">reference table</a>.

--- a/packages/styled-ui-docs/pages/toast.mdx
+++ b/packages/styled-ui-docs/pages/toast.mdx
@@ -1,12 +1,12 @@
 # Toast
 
-A toast notification is a small message that shows up in a box at one side of the screen and disappears on its own after few seconds. It is a simple feedback about an operation in which current activity remains visibility and interactive. Basically it is to inform the user of something that is not critical and that does not require specific attention and does not prevent the user from using the app.
+A toast notification is a short message that displays at the  side of the screen and disappears automatically after a few seconds. A toast notification is a status update about an operation for which the current activity remains visibility and interactive. Basically, a toast notification is used inform the user of something that is not critical and that does not require specific attention, and does not prevent the user from using the app.
 
 ### Prerequisite
 
-The `Toast` component should work with the `useToast` Hook to trigger a toast notification.
+A `Toast` element works with the `useToast` hook to trigger a toast notification.
 
-Learn more about the [`useToast`](./usetoast) Hook.
+For more information, see the [`useToast`](./usetoast) hook.
 
 ## Import
 
@@ -18,12 +18,12 @@ import { Toast } from '@trendmicro/react-styled-ui';
 
 ## Usage
 
-### Layouts
+### Layout
 
 * Increase the vertical padding space to `4x` (or `1rem`) for a multiline paragraph.
 * Set the minimum horizontal margin space to `4x` (or `1rem`) before the close button.
 * Set the minimum horizontal margin space to `4x` (or `1rem`) between the icon and the content.
-* Apply vertical margin space with `2x` (or `.5rem`) between title and its content.
+* Apply vertical margin space with `2x` (or `.5rem`) between the title and its content.
 * Apply vertical margin space with `6x` (or `1.5rem`) between the end of the content and the action button (or action link).
 
 ```jsx noInline
@@ -227,7 +227,7 @@ render(<Example />);
 
 ### Appearances
 
-You can control the appearance of a toast notification. The value can be one of `success`, `info`, `warning`, or `error` if specified.
+You can control the appearance of a toast notification. If specified, the value can be one of `success`, `info`, `warning`, or `error`.
 
 ```jsx noInline
 const ToastSuccess = ({ onClose }) => (
@@ -460,7 +460,7 @@ render(<Example />);
 
 ## Props
 
-`Toast` composes the [`Box`](./box) component. You can override the default styles with style props.
+A `Toast` element is composed of the [`Box`](./box) component. You can override the default styles using the style props.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |

--- a/packages/styled-ui-docs/pages/typography.mdx
+++ b/packages/styled-ui-docs/pages/typography.mdx
@@ -5,7 +5,7 @@ import ThemeParser from "../components/ThemeParser";
 
 To manage Typography options, the theme object supports the following keys:
 
-- `fonts` (font families)
+- `fonts` (font family)
 - `fontSizes`
 - `fontWeights`
 - `lineHeights`
@@ -65,10 +65,7 @@ To manage Typography options, the theme object supports the following keys:
 
 ## Configuration Reference
 
-Except for breakpoints, colors, and spacing, all of the keys in the theme object
-map to one of our core theme. All of these keys can be replaced or
-extended.
+Except for breakpoints, colors, and spacing, all keys in the theme object map to one of the core themes. All keys can be replaced or extended.
 
-See the <a href="https://styled-system.com/table" target="_blank">full reference
-table</a> of properties.
+For more information, see the complete properties <a href="https://styled-system.com/table" target="_blank">reference table</a>.
 

--- a/packages/styled-ui-theme/src/base.js
+++ b/packages/styled-ui-theme/src/base.js
@@ -153,7 +153,7 @@ const colors = {
   'white:tertiary': 'rgba(255, 255, 255, .47)',
   'white:disabled': 'rgba(255, 255, 255, .28)',
 
-  'black:emphasis': 'rgba(0, 0, 0, .92)',
+  'black:emphasis': 'rgba(0, 0, 0, 1.0)',
   'black:primary': 'rgba(0, 0, 0, .92)',
   'black:secondary': 'rgba(0, 0, 0, .65)',
   'black:tertiary': 'rgba(0, 0, 0, .54)',


### PR DESCRIPTION
- Change black:emphasis from 0.92 to 1.0
- Replace black:emphasis with change black:primary from 0.92 to 1.0
- Change the font-weight of H1, H2 element of documentation
- Modify the theme section wordings