### PR TITLE
fix: fixed #215

### DIFF
--- a/packages/react-styled-ui/src/Icon/index.js
+++ b/packages/react-styled-ui/src/Icon/index.js
@@ -11,7 +11,7 @@ const Icon = forwardRef((
   ref
 ) => {
   const { icons = {} } = useTheme();
-  const { path, ...restIconProps } = { ..._get(icons, `tmicon-${icon}`) };
+  const { path, ...restIconProps } = { ..._get(icons, `tmicon-${icon}`, _get(icons, icon)) };
   return (
     <SVGIcon ref={ref} {...restIconProps} {...rest}>
       {path}

--- a/packages/react-styled-ui/src/Icon/index.js
+++ b/packages/react-styled-ui/src/Icon/index.js
@@ -11,7 +11,7 @@ const Icon = forwardRef((
   ref
 ) => {
   const { icons = {} } = useTheme();
-  const { path, ...restIconProps } = { ..._get(icons, `tmicon-${icon}`, _get(icons, icon)) };
+  const { path, ...restIconProps } = { ..._get(icons, icon, _get(icons, `tmicon-${icon}`)) };
   return (
     <SVGIcon ref={ref} {...restIconProps} {...rest}>
       {path}


### PR DESCRIPTION
Hi,

Currently, **it needs me to declare the customized icon with `tmicon-` prefix**, otherwise, it won't work...

**Work**
```
const customizedIcon = {
    “tmicon-xxx”: …
};

<Icon icon=“xxx” />
```

**Not working**
```
const customizedIcon = {
    “xxx”: …
};

<Icon icon=“xxx” />
```

### This PR is mainly about supporting customized icon without `tmicon-` prefix.

### changes:
- [x] supporting customized icon without `tmicon-` prefix.
- [x] change icon loopup priority, loop up customized icons first, then `tmicon-*`.

re: #215 