### PR TITLE
fix: fix Warning: forwardRef render functions accept exactly two parameters: props and ref

### DIFF
--- a/packages/react-styled-ui/src/Badge/index.js
+++ b/packages/react-styled-ui/src/Badge/index.js
@@ -15,7 +15,8 @@ const Badge = forwardRef(
       borderColor,
       borderWidth = 1,
       ...restProps
-    }
+    },
+    ref,
   ) => {
     const badgeBorderColor = borderColor ?? variantColor;
     const badgeStyleProps = useBadgeStyle({
@@ -37,6 +38,7 @@ const Badge = forwardRef(
         {children}
         {!isHidden && (
           <Box
+            ref={ref}
             as="span"
             fontWeight="normal"
             borderRadius="sm"


### PR DESCRIPTION
# Issue
`Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter`
![Screen Shot 2020-09-23 at 12 04 58 PM](https://user-images.githubusercontent.com/9994905/93965573-0ab7e600-fd95-11ea-8963-aa52bb798fa3.png)
