### PR TITLE
fix: fix duplicate event for Checkbox and Radio

### DIFF
--- a/packages/react-styled-ui/src/Checkbox/index.js
+++ b/packages/react-styled-ui/src/Checkbox/index.js
@@ -37,6 +37,7 @@ const Checkbox = forwardRef(
       iconColor,
 
       onChange,
+      onClick,
       onBlur,
       onFocus,
 
@@ -101,10 +102,8 @@ const Checkbox = forwardRef(
           value={value}
           defaultChecked={readOnly ? undefined : defaultChecked}
           onChange={readOnly ? undefined : onChange}
+          onClick={readOnly ? undefined : onClick}
           onBlur={onBlur}
-          onClick={(e) => {
-            e.stopPropagation();
-          }}
           onFocus={onFocus}
           checked={checked}
           disabled={disabled}

--- a/packages/react-styled-ui/src/Checkbox/index.js
+++ b/packages/react-styled-ui/src/Checkbox/index.js
@@ -102,6 +102,9 @@ const Checkbox = forwardRef(
           defaultChecked={readOnly ? undefined : defaultChecked}
           onChange={readOnly ? undefined : onChange}
           onBlur={onBlur}
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
           onFocus={onFocus}
           checked={checked}
           disabled={disabled}

--- a/packages/react-styled-ui/src/Radio/index.js
+++ b/packages/react-styled-ui/src/Radio/index.js
@@ -93,6 +93,9 @@ const Radio = forwardRef(
           defaultChecked={defaultChecked}
           onChange={onChange}
           onBlur={onBlur}
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
           onFocus={onFocus}
           checked={checked}
           disabled={disabled}

--- a/packages/react-styled-ui/src/Radio/index.js
+++ b/packages/react-styled-ui/src/Radio/index.js
@@ -29,6 +29,7 @@ const Radio = forwardRef(
       value,
       variantColor = 'blue',
       onChange,
+      onClick,
       onBlur,
       onFocus,
       ...rest
@@ -92,10 +93,8 @@ const Radio = forwardRef(
           value={value}
           defaultChecked={defaultChecked}
           onChange={onChange}
+          onClick={onClick}
           onBlur={onBlur}
-          onClick={(e) => {
-            e.stopPropagation();
-          }}
           onFocus={onFocus}
           checked={checked}
           disabled={disabled}


### PR DESCRIPTION
## Issue
Click event會trigger 2次

![image](https://user-images.githubusercontent.com/24446505/93998131-bcbbd600-fdc6-11ea-9eeb-42c0cd613e53.png)


## Root cause

https://ithelp.ithome.com.tw/articles/10192015

![image](https://user-images.githubusercontent.com/24446505/93998324-f2f95580-fdc6-11ea-8d44-d9cd90479ad2.png)


## Solution

Binding `onClick` event to input element for checkbox and radio button
