### PR TITLE
fix: heading component property

### DIFF
--- a/packages/react-styled-ui/src/Heading/index.js
+++ b/packages/react-styled-ui/src/Heading/index.js
@@ -1,75 +1,64 @@
 import React, { forwardRef } from 'react';
 import Box from '../Box';
-import useTheme from '../useTheme';
 
-const defaultVariantMapping = {
-  h1: {
-    as: 'h1',
-    fontSize: '4xl',
-    lineHeight: '4xl',
+const defaultTypeScaleMapping = {
+  heading1: {
+    fontSize: 'sm',
+    lineHeight: 'sm',
     fontWeight: 'semibold',
-    margin: 0,
   },
-  h2: {
-    as: 'h2',
-    fontSize: '2xl',
-    lineHeight: '2xl',
-    fontWeight: 'semibold',
-    margin: 0,
-  },
-  h3: {
-    as: 'h3',
-    fontSize: 'xl',
-    lineHeight: 'xl',
-    fontWeight: 'semibold',
-    margin: 0,
-  },
-  h4: {
-    as: 'h4',
+  heading2: {
     fontSize: 'md',
     lineHeight: 'md',
     fontWeight: 'semibold',
-    margin: 0,
   },
-  h5: {
-    as: 'h5',
-    fontSize: 'sm',
-    lineHeight: 'sm',
+  heading3: {
+    fontSize: 'lg',
+    lineHeight: 'lg',
     fontWeight: 'semibold',
-    margin: 0,
   },
-  h6: {
-    as: 'h6',
-    fontSize: 'sm',
-    lineHeight: 'sm',
+  heading4: {
+    fontSize: 'xl',
+    lineHeight: 'xl',
     fontWeight: 'normal',
-    margin: 0,
+  },
+  heading5: {
+    fontSize: 'xl',
+    lineHeight: 'xl',
+    fontWeight: 'semibold',
+  },
+  heading6: {
+    fontSize: '2xl',
+    lineHeight: '2xl',
+    fontWeight: 'normal',
+  },
+  heading7: {
+    fontSize: '3xl',
+    lineHeight: '3xl',
+    fontWeight: 'normal',
+  },
+  heading8: {
+    fontSize: '4xl',
+    lineHeight: '4xl',
+    fontWeight: 'normal',
   },
 };
 
 const Heading = forwardRef((
   {
-    size,
-    variant,
+    typeScale,
     ...rest
   },
   ref
 ) => {
-  const { fontSizes } = useTheme();
-  const sizeProps = {};
-  if ((size !== undefined) && Object.prototype.hasOwnProperty.call(fontSizes, size)) {
-    sizeProps.fontSize = size;
-    sizeProps.lineHeight = size;
-  }
-  const variantProps = defaultVariantMapping[variant];
+  const typeScaleProps = defaultTypeScaleMapping[typeScale];
 
   return (
     <Box
       ref={ref}
       display="block"
       fontFamily="heading"
-      {...sizeProps}
-      {...variantProps}
+      {...typeScaleProps}
       {...rest}
     />
   );

--- a/packages/styled-ui-docs/components/MDXComponents.jsx
+++ b/packages/styled-ui-docs/components/MDXComponents.jsx
@@ -49,9 +49,7 @@ const H1 = props => {
       borderBottom={1}
       borderBottomColor={borderColor}
       color={color}
-      fontSize="3xl"
-      fontWeight="normal"
-      lineHeight="3xl"
+      typeScale="heading7"
       {...props}
     />
   );
@@ -74,9 +72,7 @@ const H2 = props => {
       borderBottom={1}
       borderBottomColor={borderColor}
       color={color}
-      fontSize="2xl"
-      fontWeight="normal"
-      lineHeight="2xl"
+      typeScale="heading6"
       {...props}
     />
   );
@@ -92,9 +88,7 @@ const H3 = props => {
       mt="6x"
       mb="4x"
       color={color}
-      fontSize="xl"
-      fontWeight="semibold"
-      lineHeight="xl"
+      typeScale="heading5"
       {...props}
     />
   );
@@ -108,9 +102,7 @@ const H4 = props => {
     <Heading
       as="h4"
       color={color}
-      fontSize="lg"
-      fontWeight="semibold"
-      lineHeight="lg"
+      typeScale="heading3"
       my="2x"
       {...props}
     />
@@ -127,9 +119,7 @@ const H5 = props => {
       mt="6x"
       mb="4x"
       color={color}
-      fontSize="md"
-      fontWeight="semibold"
-      lineHeight="md"
+      typeScale="heading2"
       {...props}
     />
   );
@@ -145,9 +135,7 @@ const H6 = props => {
       mt="6x"
       mb="4x"
       color={color}
-      fontSize="sm"
-      fontWeight="semibold"
-      lineHeight="sm"
+      typeScale="heading1"
       {...props}
     />
   );

--- a/packages/styled-ui-docs/pages/heading.mdx
+++ b/packages/styled-ui-docs/pages/heading.mdx
@@ -45,29 +45,35 @@ Use the `size` prop to change the corresponding font size and line height. You c
 </Stack>
 ```
 
-### Variants
+### Type Scales
 
-The `Heading` component comes in six variants: `h1`, `h2`, `h3`, `h4`, `h5`, and `h6`. Pass the `variant` prop and set it to either of these values.
+The `Heading` component comes in 8 type scales, from `1` to `8`. It corresponds to font size, line height and font-weight. Pass the `typeScale` prop and set it to either of these values.
 
 ```jsx
 <Stack direction="column" spacing="4x">
-  <Heading variant="h1">
-    h1. Heading
+  <Heading typeScale="1">
+    Heading 1
   </Heading>
-  <Heading variant="h2">
-    h2. Heading
+  <Heading typeScale="2">
+    Heading 2
   </Heading>
-  <Heading variant="h3">
-    h3. Heading
+  <Heading typeScale="3">
+    Heading 3
   </Heading>
-  <Heading variant="h4">
-    h4. Heading
+  <Heading typeScale="4">
+    Heading 4
   </Heading>
-  <Heading variant="h5">
-    h5. Heading
+  <Heading typeScale="5">
+    Heading 5
   </Heading>
-  <Heading variant="h6">
-    h6. Heading
+  <Heading typeScale="6">
+    Heading 6
+  </Heading>
+  <Heading typeScale="7">
+    Heading 7
+  </Heading>
+  <Heading typeScale="8">
+    Heading 8
   </Heading>
 </Stack>
 ```
@@ -106,5 +112,5 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| variant | string | | One of: `'h1'`, `'h2'`, `'h3'`, `'h4'`, `'h5'`, `'h6'` |
+| typeScale | string | | One of: `'1'`, `'2'`, `'3'`, `'4'`, `'5'`, `'6'`, `'7'`, `'8'` |
 | size | string | | One of: `'4xl'`, `'3xl'`, `'2xl'`, `'xl'`, `'lg'`, `'md'`, `'sm'`, `'xs'` |

--- a/packages/styled-ui-docs/pages/heading.mdx
+++ b/packages/styled-ui-docs/pages/heading.mdx
@@ -12,68 +12,35 @@ import { Heading } from '@trendmicro/react-styled-ui';
 
 ## Usage
 
-### Sizes
-
-Use the `size` prop to change the corresponding font size and line height. You can set the value to `4xl`, `3xl`, `2xl`, `xl`, `lg`, `md`, `sm`, or `xs`.
-
-```jsx
-<Stack direction="column" spacing="4x">
-  <Heading size="4xl">
-    Four Extra Large (4XL)
-  </Heading>
-  <Heading size="3xl">
-    Three Extra Large (3XL)
-  </Heading>
-  <Heading size="2xl">
-    Two Extra Large (2XL)
-  </Heading>
-  <Heading size="xl">
-    Extra Large (XL)
-  </Heading>
-  <Heading size="lg">
-    Large (LG)
-  </Heading>
-  <Heading size="md">
-    Medium (MD)
-  </Heading>
-  <Heading size="sm">
-    Small (SM)
-  </Heading>
-  <Heading size="xs">
-    Extra Small (XS)
-  </Heading>
-</Stack>
-```
-
 ### Type Scales
 
-The `Heading` component comes in 8 type scales, from `1` to `8`. It corresponds to font size, line height and font-weight. Pass the `typeScale` prop and set it to either of these values.
+The `Heading` component comes in 8 type scales, from `heading1` to `heading8`. It corresponds to font size, line height and font-weight. Pass the `typeScale` prop and set it to either of these values.
 
 ```jsx
 <Stack direction="column" spacing="4x">
-  <Heading typeScale="1">
-    Heading 1
+  <Heading typeScale="heading1">
+    Heading 01 <Text size="sm" fontWeight="normal">(Font Size 14px / Line Height 20px / Font Weight 600)</Text>
   </Heading>
-  <Heading typeScale="2">
-    Heading 2
+  <Heading typeScale="heading2">
+    Heading 02 <Text size="sm" fontWeight="normal">(Font Size 16px / Line Height 22px / Font Weight 600)</Text>
   </Heading>
-  <Heading typeScale="3">
-    Heading 3
+  <Heading typeScale="heading3">
+    Heading 03 <Text size="sm" fontWeight="normal">(Font Size 18px / Line Height 24px / Font Weight 600)</Text>
   </Heading>
-  <Heading typeScale="4">
-    Heading 4
+  <Heading typeScale="heading4">
+    Heading 04 <Text size="sm" fontWeight="normal">(Font Size 20px / Line Height 28px)</Text>
   </Heading>
-  <Heading typeScale="5">
-    Heading 5
+  <Heading typeScale="heading5">
+    Heading 05 <Text size="sm" fontWeight="normal">(Font Size 20px / Line Height 28px / Font Weight 600)</Text>
   </Heading>
-  <Heading typeScale="6">
-    Heading 6
+  <Heading typeScale="heading6">
+    Heading 06 <Text size="sm" fontWeight="normal">(Font Size 24px / Line Height 32px)</Text>
   </Heading>
-  <Heading typeScale="7">
-    Heading 7
+  <Heading typeScale="heading7">
+    Heading 07 <Text size="sm" fontWeight="normal">(Font Size 28px / Line Height 36px)</Text>
   </Heading>
-  <Heading typeScale="8">
-    Heading 8
+  <Heading typeScale="heading8">
+    Heading 08 <Text size="sm" fontWeight="normal">(Font Size 32px / Line Height 40px)</Text>
   </Heading>
 </Stack>
 ```
@@ -98,8 +65,8 @@ function Example() {
       <Heading bg={bg} lineHeight="base" px="2x">
         For accessibility concerns, use a minimum value of 1.5 for <code>line-height</code> for main paragraph content
       </Heading>
-      <Heading bg={bg} fontSize="3rem" lineHeight="1.5" px="2x">
-        Pass fontSize and lineHeight props
+      <Heading bg={bg} fontSize="42px" lineHeight="52px" px="2x">
+        Heading 09 (Pass fontSize and lineHeight props)
       </Heading>
     </Stack>
   );
@@ -112,5 +79,4 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| typeScale | string | | One of: `'1'`, `'2'`, `'3'`, `'4'`, `'5'`, `'6'`, `'7'`, `'8'` |
-| size | string | | One of: `'4xl'`, `'3xl'`, `'2xl'`, `'xl'`, `'lg'`, `'md'`, `'sm'`, `'xs'` |
+| typeScale | string | | One of: `'heading1'`, `'heading2'`, `'heading3'`, `'heading4'`, `'heading5'`, `'heading6'`, `'heading7'`, `'heading8'` |

--- a/packages/styled-ui-docs/pages/skeleton.mdx
+++ b/packages/styled-ui-docs/pages/skeleton.mdx
@@ -47,14 +47,14 @@ function Example() {
   return (
     <Flex>
       <Stack direction="column" spacing="4x" flex="none" width={300}>
-        <Heading variant="h1"><Skeleton /></Heading>
-        <Heading variant="h3"><Skeleton /></Heading>
+        <Heading typeScale="heading8"><Skeleton /></Heading>
+        <Heading typeScale="heading5"><Skeleton /></Heading>
         <Text><Skeleton /></Text>
       </Stack>
       <Space width="8x" flex="none" />
       <Stack direction="column" spacing="4x" flex="1">
-        <Heading variant="h1">h1</Heading>
-        <Heading variant="h3">h3</Heading>
+        <Heading typeScale="heading8">Heading 8</Heading>
+        <Heading typeScale="heading5">Heading 5</Heading>
         <Text>body text</Text>
       </Stack>
     </Flex>


### PR DESCRIPTION
1. The `size` property of `Heading` was removed due to that `Heading` always needs font-weight CSS property, so it was not necessary to give a `size` with only font-size and line-height.

2. Therefore, `typeScale` was added to the `Heading` component to show the scale from `heading1` to `heading8`, the same as the design tokens created by the designer.

3. Updated the docs file using the `Heading` component.