### PR TITLE
fix: disabled FocusLock by adding a new attribute ensureFocus

### DIFF
--- a/packages/react-styled-ui/src/Drawer/Drawer.js
+++ b/packages/react-styled-ui/src/Drawer/Drawer.js
@@ -21,6 +21,7 @@ const Drawer = ({
   onClose,
   initialFocusRef,
   finalFocusRef,
+  ensureFocus = false,
   autoFocus = false,
   id,
   children,
@@ -90,7 +91,7 @@ const Drawer = ({
     <DrawerProvider value={drawerState}>
       <Portal container={mountRef.current}>
         <FocusLock
-          disabled={!autoFocus}
+          disabled={!ensureFocus}
           autoFocus={autoFocus}
           returnFocus={returnFocus}
           onActivation={onFocusLockActivation}

--- a/packages/react-styled-ui/src/Drawer/Drawer.js
+++ b/packages/react-styled-ui/src/Drawer/Drawer.js
@@ -90,6 +90,7 @@ const Drawer = ({
     <DrawerProvider value={drawerState}>
       <Portal container={mountRef.current}>
         <FocusLock
+          disabled={!autoFocus}
           autoFocus={autoFocus}
           returnFocus={returnFocus}
           onActivation={onFocusLockActivation}

--- a/packages/react-styled-ui/src/Modal/Modal.js
+++ b/packages/react-styled-ui/src/Modal/Modal.js
@@ -19,6 +19,7 @@ const Modal = ({
   onClose,
   initialFocusRef,
   finalFocusRef,
+  ensureFocus = false,
   autoFocus = false,
   id,
   children,
@@ -86,6 +87,7 @@ const Modal = ({
     <ModalProvider value={modalState}>
       <Portal container={mountRef.current}>
         <FocusLock
+          disabled={!ensureFocus}
           autoFocus={autoFocus}
           returnFocus={returnFocus}
           onActivation={onFocusLockActivation}

--- a/packages/styled-ui-docs/pages/drawer.mdx
+++ b/packages/styled-ui-docs/pages/drawer.mdx
@@ -106,6 +106,7 @@ function Example() {
   }[colorMode];
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [placement, changePlacementBy] = useSelection('right');
+  const [ensureFocus, toggleEnsureFocus] = useToggle(false);
   const [autoFocus, toggleAutoFocus] = useToggle(false);
   const [backdrop, toggleBackdrop] = useToggle(true);
   const [closeOnEsc, toggleCloseOnEsc] = useToggle(true);
@@ -166,6 +167,13 @@ function Example() {
             </SelectableButton>
           ))}
         </ButtonGroup>
+      </FormGroup>
+      <FormGroup>
+        <TextLabel display="flex" alignItems="center">
+          <Checkbox checked={ensureFocus} onChange={toggleEnsureFocus} />
+          <Space width="2x" />
+          <Text fontFamily="mono" whiteSpace="nowrap">ensureFocus</Text>
+        </TextLabel>
       </FormGroup>
       <FormGroup>
         <TextLabel display="flex" alignItems="center">
@@ -265,6 +273,7 @@ function Example() {
       >
         {styles => (
           <Drawer
+            ensureFocus={ensureFocus}
             autoFocus={autoFocus}
             backdrop={backdrop}
             isCloseButtonVisible={isCloseButtonVisible}
@@ -351,6 +360,7 @@ function Example() {
         </Button>
       </Stack>
       <Drawer
+        ensureFocus
         autoFocus
         backdrop
         isCloseButtonVisible
@@ -404,6 +414,7 @@ function Example() {
         <Button onClick={handleClickBy('full')}>Full width</Button>
       </Stack>
       <Drawer
+        ensureFocus
         autoFocus
         backdrop
         isCloseButtonVisible
@@ -461,7 +472,6 @@ function Example() {
       >
         {styles => (
           <Drawer
-            autoFocus={false}
             backdrop
             isCloseButtonVisible
             isOpen={true} // Set to `true` if a transition is active
@@ -501,7 +511,8 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| autoFocus | boolean | false | If `true` and `initialFocusRef` is not set, it will automatically set focus on the first focusable element. |
+| ensureFocus | boolean | false | If `true`, it will always bring the focus back to the `Drawer` descendants, which does not allow the focus to escape while open. |
+| autoFocus | boolean | false | If `true` and `ensureFocus` is `true` and `initialFocusRef` is not set, it will automatically set focus on the first focusable element. |
 | backdrop | boolean | false | If `true`, it will wrap components with a backdrop to provide a click area for dismissing when clicking outside the drawer. |
 | finalFocusRef | React.ref | | The `ref` of element to receive focus when the drawer closes. |
 | initialFocusRef | React.ref | | The `ref` of the element to receive focus when the drawer opens. |

--- a/packages/styled-ui-docs/pages/modal.mdx
+++ b/packages/styled-ui-docs/pages/modal.mdx
@@ -175,6 +175,7 @@ function Example() {
     light: 'black:tertiary',
   }[colorMode];
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const [ensureFocus, toggleEnsureFocus] = useToggle(true);
   const [autoFocus, toggleAutoFocus] = useToggle(true);
   const [closeOnEsc, toggleCloseOnEsc] = useToggle(true);
   const [closeOnOutsideClick, toggleCloseOnOutsideClick] = useToggle(true);
@@ -213,6 +214,13 @@ function Example() {
             </SelectableButton>
           ))}
         </ButtonGroup>
+      </FormGroup>
+      <FormGroup>
+        <TextLabel display="flex" alignItems="center">
+          <Checkbox checked={ensureFocus} onChange={toggleEnsureFocus} />
+          <Space width="2x" />
+          <Text fontFamily="mono" whiteSpace="nowrap">ensureFocus</Text>
+        </TextLabel>
       </FormGroup>
       <FormGroup>
         <TextLabel display="flex" alignItems="center">
@@ -288,6 +296,7 @@ function Example() {
       >
         {styles => (
           <Modal
+            ensureFocus={ensureFocus}
             autoFocus={autoFocus}
             closeOnEsc={closeOnEsc}
             closeOnOutsideClick={closeOnOutsideClick}
@@ -371,6 +380,7 @@ function Example() {
         <Button onClick={handleClickBy('full')} mt="3x">Full width</Button>
       </Stack>
       <Modal
+        ensureFocus
         autoFocus
         closeOnEsc
         closeOnOutsideClick
@@ -496,6 +506,7 @@ function Example() {
       <Scale in={isOpen}>
         {styles => (
           <Modal
+            ensureFocus
             autoFocus
             closeOnEsc
             closeOnOutsideClick
@@ -543,6 +554,7 @@ function Example() {
       <SlideIn in={isOpen}>
         {styles => (
           <Modal
+            ensureFocus
             autoFocus
             closeOnEsc
             closeOnOutsideClick
@@ -580,7 +592,8 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| autoFocus | boolean | false | If `true` and `initialFocusRef` is not set, it will automatically set focus on the first focusable element. |
+| ensureFocus | boolean | false | If `true`, it will always bring the focus back to the `Modal` descendants, which does not allow the focus to escape while open. |
+| autoFocus | boolean | false | If `true` and `ensureFocus` is `true` and `initialFocusRef` is not set, it will automatically set focus on the first focusable element. |
 | finalFocusRef | React.ref | | The `ref` of element to receive focus when the modal closes. |
 | initialFocusRef | React.ref | | The `ref` of the element to receive focus when the modal opens. |
 | isCloseButtonVisible | boolean | false | If `true`, a close button will appear on the right side. |


### PR DESCRIPTION
`<FocusLock>` from [react-focus-lock](https://github.com/theKashey/react-focus-lock) in the `Drawer` and `Modal` components will “Get your focus and will not let him out!”
[Solution]: Add a new attribute `ensureFocus` to decide whether `FocusLock` be disabled by the user.
[Noted]: `ensureFocus` must be true, so that autoFocus will be working when it is true as well.