### PR TITLE
fix(SSR): change the unreliable pseudo class ":first-child" to ":first-of-type"

### DIFF
--- a/packages/react-styled-ui/src/Checkbox/styles.js
+++ b/packages/react-styled-ui/src/Checkbox/styles.js
@@ -158,7 +158,7 @@ const interactionProps = ({ color, colorMode }) => {
       bg: 'inherit',
       borderColor: checkedAndFocusBorderColor,
       color: checkedAndFocusColor, // Icon color
-      '& > :first-child': {
+      '& > div:first-of-type': {
         bg: checkedAndFocusBgColor,
       },
     },

--- a/packages/react-styled-ui/src/Drawer/DrawerBody.js
+++ b/packages/react-styled-ui/src/Drawer/DrawerBody.js
@@ -1,20 +1,15 @@
 import React, { forwardRef } from 'react';
-import Box from '../Box';
+import PseudoBox from '../PseudoBox';
+import {
+  useDrawerBodyStyle,
+} from './styles';
 
 const DrawerBody = forwardRef((props, ref) => {
+  const styleProps = useDrawerBodyStyle();
   return (
-    <Box
+    <PseudoBox
       ref={ref}
-      px="6x"
-      pb="6x"
-      flex="1"
-      h="auto"
-      overflowY="auto"
-      css={{
-        '&:first-child': {
-          marginTop: (16 + 28 + 12),
-        },
-      }}
+      {...styleProps}
       {...props}
     />
   );

--- a/packages/react-styled-ui/src/Drawer/DrawerContent.js
+++ b/packages/react-styled-ui/src/Drawer/DrawerContent.js
@@ -5,7 +5,7 @@ import Icon from '../Icon';
 import useForkRef from '../utils/useForkRef';
 import { useDrawer } from './context';
 import {
-  useDrawerContentStyles,
+  useDrawerContentStyle,
   useDrawerCloseButtonStyle,
 } from './styles';
 
@@ -62,7 +62,7 @@ const DrawerContentFront = forwardRef(({ children, ...props }, ref) => {
     contentRef,
   } = { ...context };
   const combinedRef = useForkRef(ref, contentRef);
-  const contentStyleProps = useDrawerContentStyles({ placement, size });
+  const contentStyleProps = useDrawerContentStyle({ placement, size });
 
   return (
     <Box

--- a/packages/react-styled-ui/src/Drawer/DrawerFooter.js
+++ b/packages/react-styled-ui/src/Drawer/DrawerFooter.js
@@ -1,27 +1,15 @@
 import React, { forwardRef } from 'react';
-import Flex from '../Flex';
-import useColorMode from '../useColorMode';
+import PseudoBox from '../PseudoBox';
+import {
+  useDrawerFooterStyle,
+} from './styles';
 
 const DrawerFooter = forwardRef((props, ref) => {
-  const { colorMode } = useColorMode();
-  const borderColor = {
-    dark: 'gray:80',
-    light: 'gray:20', // TBD: light mode is not ready yet
-  }[colorMode];
-
+  const styleProps = useDrawerFooterStyle();
   return (
-    <Flex
+    <PseudoBox
       ref={ref}
-      justify="flex-end"
-      px="6x"
-      py="4x"
-      borderTop={1}
-      borderTopColor={borderColor}
-      css={{
-        '&:first-child': {
-          marginTop: (16 + 28 + 12),
-        },
-      }}
+      {...styleProps}
       {...props}
     />
   );

--- a/packages/react-styled-ui/src/Drawer/DrawerHeader.js
+++ b/packages/react-styled-ui/src/Drawer/DrawerHeader.js
@@ -1,17 +1,16 @@
 import React, { forwardRef } from 'react';
 import PseudoBox from '../PseudoBox';
+import {
+  useDrawerHeaderStyle,
+} from './styles';
 
 const DrawerHeader = forwardRef((props, ref) => {
+  const styleProps = useDrawerHeaderStyle();
+
   return (
     <PseudoBox
       ref={ref}
-      pt="4x"
-      pb="3x"
-      pl="6x"
-      pr="12x"
-      position="relative"
-      fontSize="xl"
-      lineHeight="xl"
+      {...styleProps}
       {...props}
     />
   );

--- a/packages/react-styled-ui/src/Drawer/DrawerHeader.js
+++ b/packages/react-styled-ui/src/Drawer/DrawerHeader.js
@@ -1,9 +1,9 @@
 import React, { forwardRef } from 'react';
-import Box from '../Box';
+import PseudoBox from '../PseudoBox';
 
 const DrawerHeader = forwardRef((props, ref) => {
   return (
-    <Box
+    <PseudoBox
       ref={ref}
       pt="4x"
       pb="3x"

--- a/packages/react-styled-ui/src/Drawer/styles.js
+++ b/packages/react-styled-ui/src/Drawer/styles.js
@@ -139,6 +139,18 @@ const useDrawerContentStyle = ({
   };
 };
 
+const useDrawerHeaderStyle = () => {
+  return {
+    pt: '4x',
+    pb: '3x',
+    pl: '6x',
+    pr: '12x',
+    position: 'relative',
+    fontSize: 'xl',
+    lineHeight: 'xl',
+  };
+};
+
 const useDrawerBodyStyle = () => {
   const { sizes, lineHeights } = useTheme();
 
@@ -178,6 +190,7 @@ const useDrawerFooterStyle = () => {
 export {
   useDrawerCloseButtonStyle,
   useDrawerContentStyle,
+  useDrawerHeaderStyle,
   useDrawerBodyStyle,
   useDrawerFooterStyle,
 };

--- a/packages/react-styled-ui/src/Drawer/styles.js
+++ b/packages/react-styled-ui/src/Drawer/styles.js
@@ -97,7 +97,7 @@ const useDrawerCloseButtonStyle = () => {
   };
 };
 
-const useDrawerContentStyles = ({
+const useDrawerContentStyle = ({
   placement,
   size,
 }) => {
@@ -110,7 +110,7 @@ const useDrawerContentStyles = ({
     display: 'flex',
     flexDirection: 'column',
   };
-  const colorModeStyles = {
+  const colorModeStyle = {
     light: {
       color: 'black:primary',
       bg: 'white',
@@ -133,7 +133,7 @@ const useDrawerContentStyles = ({
 
   return {
     ...baseStyle,
-    ...colorModeStyles,
+    ...colorModeStyle,
     ...placementProps,
     ...sizeProps,
   };
@@ -141,5 +141,5 @@ const useDrawerContentStyles = ({
 
 export {
   useDrawerCloseButtonStyle,
-  useDrawerContentStyles,
+  useDrawerContentStyle,
 };

--- a/packages/react-styled-ui/src/Drawer/styles.js
+++ b/packages/react-styled-ui/src/Drawer/styles.js
@@ -139,7 +139,45 @@ const useDrawerContentStyle = ({
   };
 };
 
+const useDrawerBodyStyle = () => {
+  const { sizes, lineHeights } = useTheme();
+
+  return {
+    px: '6x',
+    pb: '6x',
+    flex: 1,
+    height: 'auto',
+    overflowY: 'auto',
+    _firstOfType: {
+      marginTop: `calc(${get(sizes, '4x')} + ${get(lineHeights, 'xl')} + ${get(sizes, '3x')})`,
+    },
+  };
+};
+
+const useDrawerFooterStyle = () => {
+  const { colorMode } = useColorMode();
+  const { sizes, lineHeights } = useTheme();
+  const borderColor = {
+    dark: 'gray:80',
+    light: 'gray:20', // TBD: light mode is not ready yet
+  }[colorMode];
+
+  return {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    px: '6x',
+    py: '4x',
+    borderTop: 1,
+    borderTopColor: borderColor,
+    _firstOfType: {
+      marginTop: `calc(${get(sizes, '4x')} + ${get(lineHeights, 'xl')} + ${get(sizes, '3x')})`,
+    },
+  };
+};
+
 export {
   useDrawerCloseButtonStyle,
   useDrawerContentStyle,
+  useDrawerBodyStyle,
+  useDrawerFooterStyle,
 };

--- a/packages/react-styled-ui/src/Input/styles.js
+++ b/packages/react-styled-ui/src/Input/styles.js
@@ -172,7 +172,7 @@ const getInputGroupCSS = ({
   const useNegativeMargin = (variant === 'outline' || variant === 'filled');
 
   return {
-    '&:not(:first-child)': {
+    '&:not(:first-of-type)': {
       borderTopLeftRadius: 0,
       borderBottomLeftRadius: 0,
     },

--- a/packages/react-styled-ui/src/InputGroupAppend/styles.js
+++ b/packages/react-styled-ui/src/InputGroupAppend/styles.js
@@ -11,8 +11,8 @@ const notLastChildStyle = {
 const baseProps = {
   ml: -1,
   css: {
-    '& > *:first-child': notFirstChildStyle,
-    '&:not(:last-child) > *:first-child': notLastChildStyle,
+    '& > *:first-of-type': notFirstChildStyle,
+    '&:not(:last-child) > *:first-of-type': notLastChildStyle,
   }
 };
 

--- a/packages/react-styled-ui/src/InputGroupPrepend/styles.js
+++ b/packages/react-styled-ui/src/InputGroupPrepend/styles.js
@@ -11,8 +11,8 @@ const notLastChildStyle = {
 const baseProps = {
   mr: -1,
   css: {
-    '& > *:first-child': notLastChildStyle,
-    '&:not(:first-child) > *:first-child': notFirstChildStyle,
+    '& > *:first-of-type': notLastChildStyle,
+    '&:not(:first-of-type) > *:first-of-type': notFirstChildStyle,
   },
 };
 

--- a/packages/react-styled-ui/src/Modal/ModalBody.js
+++ b/packages/react-styled-ui/src/Modal/ModalBody.js
@@ -1,20 +1,16 @@
 import React, { forwardRef } from 'react';
-import Box from '../Box';
+import PseudoBox from '../PseudoBox';
+import {
+  useModalBodyStyle,
+} from './styles';
 
 const ModalBody = forwardRef((props, ref) => {
+  const styleProps = useModalBodyStyle();
+
   return (
-    <Box
+    <PseudoBox
       ref={ref}
-      px="6x"
-      pb="6x"
-      flex="1"
-      h="auto"
-      overflowY="auto"
-      css={{
-        '&:first-child': {
-          marginTop: (16 + 28 + 12),
-        },
-      }}
+      {...styleProps}
       {...props}
     />
   );

--- a/packages/react-styled-ui/src/Modal/ModalContent.js
+++ b/packages/react-styled-ui/src/Modal/ModalContent.js
@@ -5,7 +5,7 @@ import Icon from '../Icon';
 import useForkRef from '../utils/useForkRef';
 import { useModal } from './context';
 import {
-  useModalContentStyles,
+  useModalContentStyle,
   useModalCloseButtonStyle,
 } from './styles';
 
@@ -61,7 +61,7 @@ const ModalContentFront = forwardRef(({ children, ...props }, ref) => {
     contentRef,
   } = { ...context };
   const combinedRef = useForkRef(ref, contentRef);
-  const contentStyleProps = useModalContentStyles({ size });
+  const contentStyleProps = useModalContentStyle({ size });
 
   return (
     <Box

--- a/packages/react-styled-ui/src/Modal/ModalFooter.js
+++ b/packages/react-styled-ui/src/Modal/ModalFooter.js
@@ -1,27 +1,16 @@
 import React, { forwardRef } from 'react';
-import Flex from '../Flex';
-import useColorMode from '../useColorMode';
+import PseudoBox from '../PseudoBox';
+import {
+  useModalFooterStyle,
+} from './styles';
 
 const ModalFooter = forwardRef((props, ref) => {
-  const { colorMode } = useColorMode();
-  const borderColor = {
-    dark: 'gray:80',
-    light: 'gray:20', // TBD: light mode is not ready yet
-  }[colorMode];
+  const styleProps = useModalFooterStyle();
 
   return (
-    <Flex
+    <PseudoBox
       ref={ref}
-      justify="flex-end"
-      px="6x"
-      py="4x"
-      borderTop={1}
-      borderTopColor={borderColor}
-      css={{
-        '&:first-child': {
-          marginTop: (16 + 28 + 12),
-        },
-      }}
+      {...styleProps}
       {...props}
     />
   );

--- a/packages/react-styled-ui/src/Modal/ModalHeader.js
+++ b/packages/react-styled-ui/src/Modal/ModalHeader.js
@@ -1,17 +1,16 @@
 import React, { forwardRef } from 'react';
-import Box from '../Box';
+import PseudoBox from '../PseudoBox';
+import {
+  useModalHeaderStyle,
+} from './styles';
 
 const ModalHeader = forwardRef((props, ref) => {
+  const styleProps = useModalHeaderStyle();
+
   return (
-    <Box
+    <PseudoBox
       ref={ref}
-      pt="4x"
-      pb="3x"
-      pl="6x"
-      pr="12x"
-      position="relative"
-      fontSize="xl"
-      lineHeight="xl"
+      {...styleProps}
       {...props}
     />
   );

--- a/packages/react-styled-ui/src/Modal/styles.js
+++ b/packages/react-styled-ui/src/Modal/styles.js
@@ -95,7 +95,7 @@ const useModalCloseButtonStyle = () => {
   };
 };
 
-const useModalContentStyles = ({ size }) => {
+const useModalContentStyle = ({ size }) => {
   const { colorMode } = useColorMode();
   const baseStyle = {
     mx: 'auto',
@@ -104,7 +104,7 @@ const useModalContentStyles = ({ size }) => {
     display: 'flex',
     flexDirection: 'column',
   };
-  const colorModeStyles = {
+  const colorModeStyle = {
     light: {
       color: 'black:primary',
       bg: 'white',
@@ -126,12 +126,49 @@ const useModalContentStyles = ({ size }) => {
 
   return {
     ...baseStyle,
-    ...colorModeStyles,
+    ...colorModeStyle,
     ...sizeProps,
+  };
+};
+
+const useModalBodyStyle = () => {
+  const { sizes, lineHeights } = useTheme();
+
+  return {
+    px: '6x',
+    pb: '6x',
+    flex: 1,
+    height: 'auto',
+    overflowY: 'auto',
+    _firstOfType: {
+      marginTop: `calc(${sizes['4x']} + ${lineHeights['xl']} + ${sizes['3x']})`,
+    },
+  };
+};
+
+const useModalFooterStyle = () => {
+  const { colorMode } = useColorMode();
+  const { sizes, lineHeights } = useTheme();
+  const borderColor = {
+    dark: 'gray:80',
+    light: 'gray:20', // TBD: light mode is not ready yet
+  }[colorMode];
+
+  return {
+    justifyContent: 'flex-end',
+    px: '6x',
+    py: '4x',
+    borderTop: 1,
+    borderTopColor: borderColor,
+    _firstOfType: {
+      marginTop: `calc(${sizes['4x']} + ${lineHeights['xl']} + ${sizes['3x']})`,
+    },
   };
 };
 
 export {
   useModalCloseButtonStyle,
-  useModalContentStyles,
+  useModalContentStyle,
+  useModalBodyStyle,
+  useModalFooterStyle,
 };

--- a/packages/react-styled-ui/src/Modal/styles.js
+++ b/packages/react-styled-ui/src/Modal/styles.js
@@ -141,7 +141,7 @@ const useModalBodyStyle = () => {
     height: 'auto',
     overflowY: 'auto',
     _firstOfType: {
-      marginTop: `calc(${sizes['4x']} + ${lineHeights['xl']} + ${sizes['3x']})`,
+      marginTop: `calc(${get(sizes, '4x')} + ${get(lineHeights, 'xl')} + ${get(sizes, '3x')})`,
     },
   };
 };
@@ -161,7 +161,7 @@ const useModalFooterStyle = () => {
     borderTop: 1,
     borderTopColor: borderColor,
     _firstOfType: {
-      marginTop: `calc(${sizes['4x']} + ${lineHeights['xl']} + ${sizes['3x']})`,
+      marginTop: `calc(${get(sizes, '4x')} + ${get(lineHeights, 'xl')} + ${get(sizes, '3x')})`,
     },
   };
 };

--- a/packages/react-styled-ui/src/Modal/styles.js
+++ b/packages/react-styled-ui/src/Modal/styles.js
@@ -131,6 +131,18 @@ const useModalContentStyle = ({ size }) => {
   };
 };
 
+const useModalHeaderStyle = () => {
+  return {
+    pt: '4x',
+    pb: '3x',
+    pl: '6x',
+    pr: '12x',
+    position: 'relative',
+    fontSize: 'xl',
+    lineHeight: 'xl',
+  };
+};
+
 const useModalBodyStyle = () => {
   const { sizes, lineHeights } = useTheme();
 
@@ -170,6 +182,7 @@ const useModalFooterStyle = () => {
 export {
   useModalCloseButtonStyle,
   useModalContentStyle,
+  useModalHeaderStyle,
   useModalBodyStyle,
   useModalFooterStyle,
 };

--- a/packages/react-styled-ui/src/Modal/styles.js
+++ b/packages/react-styled-ui/src/Modal/styles.js
@@ -155,6 +155,7 @@ const useModalFooterStyle = () => {
   }[colorMode];
 
   return {
+    display: 'flex',
     justifyContent: 'flex-end',
     px: '6x',
     py: '4x',

--- a/packages/styled-ui-docs/components/Main.jsx
+++ b/packages/styled-ui-docs/components/Main.jsx
@@ -18,7 +18,7 @@ const Main = React.forwardRef(({ children, ...props }, ref) => {
       px="6x"
       backgroundColor={backgroundColor}
       css={css`
-        >:first-child {
+        >:first-of-type {
           margin-top: 0!important;
         }
         >:last-child {

--- a/packages/styled-ui-docs/pages/buttongroup.mdx
+++ b/packages/styled-ui-docs/pages/buttongroup.mdx
@@ -85,7 +85,7 @@ function Example() {
       <ButtonGroup
         variant="secondary"
         css={{
-          '> *:not(:first-child)': {
+          '> *:not(:first-of-type)': {
             marginLeft: -1
           }
         }}
@@ -97,7 +97,7 @@ function Example() {
       <ButtonGroup
         variant="ghost"
         css={{
-          '> *:not(:first-child)': {
+          '> *:not(:first-of-type)': {
             marginLeft: -1
           }
         }}
@@ -161,7 +161,7 @@ function Example() {
           size="sm"
           variant="secondary"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginLeft: -1
             }
           }}
@@ -174,7 +174,7 @@ function Example() {
           size="md"
           variant="secondary"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginLeft: -1
             }
           }}
@@ -187,7 +187,7 @@ function Example() {
           size="lg"
           variant="secondary"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginLeft: -1
             }
           }}
@@ -202,7 +202,7 @@ function Example() {
           size="sm"
           variant="ghost"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginLeft: -1
             }
           }}
@@ -217,7 +217,7 @@ function Example() {
           size="md"
           variant="ghost"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginLeft: -1
             }
           }}
@@ -232,7 +232,7 @@ function Example() {
           size="lg"
           variant="ghost"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginLeft: -1
             }
           }}
@@ -288,7 +288,7 @@ function Example() {
         <ButtonGroup
           variant="secondary"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginLeft: -1
             }
           }}
@@ -301,7 +301,7 @@ function Example() {
           orientation="vertical"
           variant="secondary"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginTop: -1
             }
           }}
@@ -315,7 +315,7 @@ function Example() {
         <ButtonGroup
           variant="ghost"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginLeft: -1
             }
           }}
@@ -330,7 +330,7 @@ function Example() {
           orientation="vertical"
           variant="ghost"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginTop: -1
             }
           }}
@@ -530,7 +530,7 @@ function SwitchButton() {
       <ButtonGroup
         variant="secondary"
         css={{
-          '> *:not(:first-child)': {
+          '> *:not(:first-of-type)': {
             marginLeft: -1
           }
         }}
@@ -555,7 +555,7 @@ function SwitchButton() {
       <ButtonGroup
         variant="ghost"
         css={{
-          '> *:not(:first-child)': {
+          '> *:not(:first-of-type)': {
             marginLeft: -1
           }
         }}

--- a/packages/styled-ui-docs/pages/drawer.mdx
+++ b/packages/styled-ui-docs/pages/drawer.mdx
@@ -170,14 +170,21 @@ function Example() {
       </FormGroup>
       <FormGroup>
         <TextLabel display="flex" alignItems="center">
-          <Checkbox checked={ensureFocus} onChange={toggleEnsureFocus} />
+          <Checkbox
+            checked={ensureFocus}
+            onChange={toggleEnsureFocus}
+          />
           <Space width="2x" />
           <Text fontFamily="mono" whiteSpace="nowrap">ensureFocus</Text>
         </TextLabel>
       </FormGroup>
       <FormGroup>
         <TextLabel display="flex" alignItems="center">
-          <Checkbox checked={autoFocus} onChange={toggleAutoFocus} />
+          <Checkbox
+            checked={autoFocus}
+            disabled={!ensureFocus}
+            onChange={toggleAutoFocus}
+          />
           <Space width="2x" />
           <Text fontFamily="mono" whiteSpace="nowrap">autoFocus</Text>
         </TextLabel>

--- a/packages/styled-ui-docs/pages/drawer.mdx
+++ b/packages/styled-ui-docs/pages/drawer.mdx
@@ -523,12 +523,12 @@ function Example() {
 
 ### DrawerHeader
 
-`DrawerHeader` composes the [`Box`](./box) component.
+`DrawerHeader` composes the [`PseudoBox`](./pseudobox) component.
 
 ### DrawerBody
 
-`DrawerBody` composes the [`PseudoBox`](./pseudoBox) component.
+`DrawerBody` composes the [`PseudoBox`](./pseudobox) component.
 
 ### DrawerFooter
 
-`DrawerFooter` composes the [`PseudoBox`](./pseudoBox) component.
+`DrawerFooter` composes the [`PseudoBox`](./pseudobox) component.

--- a/packages/styled-ui-docs/pages/drawer.mdx
+++ b/packages/styled-ui-docs/pages/drawer.mdx
@@ -129,7 +129,7 @@ function Example() {
         <ButtonGroup
           variant="secondary"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginLeft: -1
             }
           }}
@@ -150,7 +150,7 @@ function Example() {
         <ButtonGroup
           variant="secondary"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginLeft: -1
             }
           }}
@@ -527,8 +527,8 @@ function Example() {
 
 ### DrawerBody
 
-`DrawerBody` composes the [`Box`](./box) component.
+`DrawerBody` composes the [`PseudoBox`](./pseudoBox) component.
 
 ### DrawerFooter
 
-`DrawerFooter` composes the [`Flex`](./flex) component.
+`DrawerFooter` composes the [`PseudoBox`](./pseudoBox) component.

--- a/packages/styled-ui-docs/pages/input.mdx
+++ b/packages/styled-ui-docs/pages/input.mdx
@@ -121,7 +121,7 @@ The value of `list` is the id attribute of the `<datalist>` of autocomplete opti
 ```jsx
 <>
   <Flex align="center">
-    <TextLabel for="browser-choice" mr="2x">
+    <TextLabel htmlFor="browser-choice" mr="2x">
       Choose a browser from the list:
     </TextLabel>
     <Input list="browsers" id="browser-choice" width="auto" />

--- a/packages/styled-ui-docs/pages/modal.mdx
+++ b/packages/styled-ui-docs/pages/modal.mdx
@@ -604,8 +604,8 @@ function Example() {
 
 ### ModalBody
 
-`ModalBody` composes the [`Box`](./box) component.
+`ModalBody` composes the [`PseudoBox`](./pseudobox) component.
 
 ### ModalFooter
 
-`ModalFooter` composes the [`Flex`](./flex) component.
+`ModalFooter` composes the [`PseudoBox`](./pseudobox) component.

--- a/packages/styled-ui-docs/pages/modal.mdx
+++ b/packages/styled-ui-docs/pages/modal.mdx
@@ -425,7 +425,7 @@ function Example() {
           <ModalBody>
             <Lorem count={2} />
           </ModalBody>
-          <ModalFooter justify="space-between">
+          <ModalFooter justifyContent="space-between">
             <Button
               disabled={isNestedOpen}
               variant="primary"

--- a/packages/styled-ui-docs/pages/modal.mdx
+++ b/packages/styled-ui-docs/pages/modal.mdx
@@ -217,14 +217,21 @@ function Example() {
       </FormGroup>
       <FormGroup>
         <TextLabel display="flex" alignItems="center">
-          <Checkbox checked={ensureFocus} onChange={toggleEnsureFocus} />
+          <Checkbox
+            checked={ensureFocus}
+            onChange={toggleEnsureFocus}
+          />
           <Space width="2x" />
           <Text fontFamily="mono" whiteSpace="nowrap">ensureFocus</Text>
         </TextLabel>
       </FormGroup>
       <FormGroup>
         <TextLabel display="flex" alignItems="center">
-          <Checkbox checked={autoFocus} onChange={toggleAutoFocus} />
+          <Checkbox
+            checked={autoFocus}
+            disabled={!ensureFocus}
+            onChange={toggleAutoFocus}
+          />
           <Space width="2x" />
           <Text fontFamily="mono" whiteSpace="nowrap">autoFocus</Text>
         </TextLabel>

--- a/packages/styled-ui-docs/pages/modal.mdx
+++ b/packages/styled-ui-docs/pages/modal.mdx
@@ -197,7 +197,7 @@ function Example() {
         <ButtonGroup
           variant="secondary"
           css={{
-            '> *:not(:first-child)': {
+            '> *:not(:first-of-type)': {
               marginLeft: -1
             }
           }}

--- a/packages/styled-ui-docs/pages/modal.mdx
+++ b/packages/styled-ui-docs/pages/modal.mdx
@@ -600,7 +600,7 @@ function Example() {
 
 ### ModalHeader
 
-`ModalHeader` composes the [`Box`](./box) component.
+`ModalHeader` composes the [`PseudoBox`](./pseudobox) component.
 
 ### ModalBody
 

--- a/packages/styled-ui-docs/pages/pagination.mdx
+++ b/packages/styled-ui-docs/pages/pagination.mdx
@@ -126,7 +126,7 @@ function Minor() {
       <ButtonGroup
         variant="secondary"
         css={{
-          '> *:not(:first-child)': {
+          '> *:not(:first-of-type)': {
             marginLeft: -1
           }
         }}
@@ -188,7 +188,7 @@ function Minor() {
       <ButtonGroup
         variant="secondary"
         css={{
-          '> *:not(:first-child)': {
+          '> *:not(:first-of-type)': {
             marginLeft: -1
           }
         }}

--- a/packages/styled-ui-docs/pages/transition.mdx
+++ b/packages/styled-ui-docs/pages/transition.mdx
@@ -131,7 +131,7 @@ function Example() {
       <ButtonGroup
         variant="secondary"
         css={{
-          '> *:not(:first-child)': {
+          '> *:not(:first-of-type)': {
             marginLeft: -1
           }
         }}


### PR DESCRIPTION
### Problem description

In emotion v10+, a new warning is thrown if you use `:first-child`, `:nth-child`, or `:nth-last-child` selectors in a styled component or css prop value. This is because, when using SSR, the style element is injected immediately above (prepended) the associated component.


**Problems surrounding SSR injection of <style> and unreliability of :first-child selectors**
https://github.com/emotion-js/emotion/issues/1178

### Suggested workaround

Changing the unreliable pseudo class `:first-child` to `:first-of-type`. This only works if all sibling elements are of the same type.