### PR TITLE
fix: fix misspelled import and ensure safety when accessing deeply nested values

### DIFF
--- a/packages/react-styled-ui/src/Badge/styles.js
+++ b/packages/react-styled-ui/src/Badge/styles.js
@@ -1,5 +1,5 @@
 import { ensureArray } from 'ensure-type';
-import _get from 'lodash/get';
+import _get from 'lodash.get';
 import useColorMode from '../useColorMode';
 import useTheme from '../useTheme';
 

--- a/packages/react-styled-ui/src/CSSBaseline/base-css.js
+++ b/packages/react-styled-ui/src/CSSBaseline/base-css.js
@@ -1,4 +1,5 @@
 import { css } from '@emotion/core';
+import _get from 'lodash.get';
 
 const baseCSS = theme => {
   return css`
@@ -13,14 +14,14 @@ const baseCSS = theme => {
     }
 
     html {
-      font-family: ${theme.fonts.base};
+      font-family: ${_get(theme, 'fonts.base')};
     }
 
     pre,
     code,
     kbd,
     samp {
-      font-family: ${theme.fonts.mono};
+      font-family: ${_get(theme, 'fonts.mono')};
     }
   `;
 };

--- a/packages/react-styled-ui/src/Checkbox/index.js
+++ b/packages/react-styled-ui/src/Checkbox/index.js
@@ -1,6 +1,6 @@
 import chainedFunction from 'chained-function';
 import { ensureArray } from 'ensure-type';
-import _get from 'lodash/get';
+import _get from 'lodash.get';
 import React, { forwardRef } from 'react';
 import Box from '../Box';
 import { useCheckboxGroup } from '../CheckboxGroup/context';


### PR DESCRIPTION
This issue is somehow related to https://github.com/trendmicro-frontend/styled-ui/pull/251

The `theme` object is `undefined` when installing the following packages with incompatible versions:
* `@emotion/babel-preset-css-prop`
* `@emotion/core`
* `@emotion/styled`

![image](https://user-images.githubusercontent.com/447801/98437861-d15af000-2120-11eb-9676-bbdfc152dd36.png)