### PR TITLE
fix: add borderRadius to TagCloseButton component

### DIFF
--- a/packages/react-styled-ui/src/Tag/index.js
+++ b/packages/react-styled-ui/src/Tag/index.js
@@ -50,6 +50,7 @@ const Tag = forwardRef(
         { children }
         {!!isCloseButtonVisible && (
           <TagCloseButton
+            borderRadius={borderRadius}
             size={size}
             disabled={disabled}
             onClick={onClose}


### PR DESCRIPTION
## Description
Fix `TagCloseButton` border radius

<img width="1669" alt="zm20210204-1447" src="https://user-images.githubusercontent.com/9994905/106857568-3cee3280-66fb-11eb-976a-2027ee09e4d2.png">
