### PR TITLE
fix: uncaught Error: [ThemeProvider] Please make your theme prop a plain object

### DIFF
--- a/packages/react-styled-ui/src/ThemeProvider/index.js
+++ b/packages/react-styled-ui/src/ThemeProvider/index.js
@@ -1,6 +1,6 @@
 import { ThemeProvider as EmotionThemeProvider } from 'emotion-theming';
 import React from 'react';
-import { theme } from '../theme';
+import theme from '../theme';
 
 const ThemeProvider = ({
   theme: customTheme = theme,


### PR DESCRIPTION
## Fix issue

The root cause of this runtime error is expecting a named export but got a default export object.
![Screen Shot 2021-03-18 at 3 32 53 PM](https://user-images.githubusercontent.com/9994905/111601395-447e1c80-880d-11eb-8469-b6cf4d1c9f33.png)
