### PR TITLE
fix: fix an issue that cannot pass the z-index value to DrawerContent and ModalContent components

### DIFF
--- a/packages/react-styled-ui/src/Drawer/DrawerContent.js
+++ b/packages/react-styled-ui/src/Drawer/DrawerContent.js
@@ -37,7 +37,6 @@ const DrawerContentBackdrop = forwardRef((props, ref) => {
       display="flex"
       justifyContent="center"
       alignItems="center"
-      zIndex="drawer"
       onClick={event => {
         event.stopPropagation();
         if (closeOnOutsideClick) {
@@ -92,7 +91,11 @@ const DrawerContentFront = forwardRef(({ children, ...props }, ref) => {
   );
 });
 
-const DrawerContent = React.forwardRef(({ children, ...props }, ref) => {
+const DrawerContent = React.forwardRef(({
+  children,
+  zIndex = 'drawer',
+  ...props
+}, ref) => {
   const context = useDrawer(); // context might be an undefined value
   const {
     backdrop,
@@ -111,7 +114,7 @@ const DrawerContent = React.forwardRef(({ children, ...props }, ref) => {
       <DrawerContentFront
         ref={ref}
         position="fixed"
-        zIndex="drawer"
+        zIndex={zIndex}
         top={0}
         height="100%"
         {...props}
@@ -122,7 +125,7 @@ const DrawerContent = React.forwardRef(({ children, ...props }, ref) => {
   }
 
   return (
-    <DrawerContentBackdrop>
+    <DrawerContentBackdrop zIndex={zIndex}>
       <DrawerContentFront ref={ref} {...props}>
         {children}
       </DrawerContentFront>

--- a/packages/react-styled-ui/src/Modal/ModalContent.js
+++ b/packages/react-styled-ui/src/Modal/ModalContent.js
@@ -37,7 +37,6 @@ const ModalContentBackdrop = forwardRef((props, ref) => {
       display="flex"
       justifyContent="center"
       alignItems="center"
-      zIndex="modal"
       onClick={event => {
         event.stopPropagation();
         if (closeOnOutsideClick) {
@@ -91,7 +90,11 @@ const ModalContentFront = forwardRef(({ children, ...props }, ref) => {
   );
 });
 
-const ModalContent = React.forwardRef(({ children, ...props }, ref) => {
+const ModalContent = React.forwardRef(({
+  children,
+  zIndex = 'modal',
+  ...props
+}, ref) => {
   const context = useModal(); // context might be an undefined value
 
   if (!context) {
@@ -103,7 +106,7 @@ const ModalContent = React.forwardRef(({ children, ...props }, ref) => {
   }
 
   return (
-    <ModalContentBackdrop>
+    <ModalContentBackdrop zIndex={zIndex}>
       <ModalContentFront ref={ref} {...props}>
         {children}
       </ModalContentFront>


### PR DESCRIPTION
#### How to set the z-index value for Drawer and Modal components?

```jsx
<Drawer>
  <DrawerOverlay zIndex="9527" />
  <DrawerContent zIndex="9527">
    <DrawerBody />
  </DrawerContent>
</Drawer>
```

```jsx
<Modal>
  <ModalOverlay zIndex="9527" />
  <ModalContent zIndex="9527">
    <ModalBody />
  </ModalContent>
</Modal>
```