### PR TITLE
feat: change useColorMode Hook usage

### DIFF
--- a/packages/react-styled-ui/src/Alert/styles.js
+++ b/packages/react-styled-ui/src/Alert/styles.js
@@ -90,7 +90,7 @@ const getSeverityProps = ({ severity, ...props }) => {
 const useAlertRootStyle = ({
   severity,
 }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _props = {
     colorMode,
     severity,
@@ -121,7 +121,7 @@ const useAlertMessageStyle = () => {
 };
 
 const useAlertCloseButtonStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { colors } = useTheme();
   const color = {
     dark: 'black:tertiary',

--- a/packages/react-styled-ui/src/Badge/styles.js
+++ b/packages/react-styled-ui/src/Badge/styles.js
@@ -74,7 +74,7 @@ const variantProps = props => {
 
 const useBadgeStyle = props => {
   const theme = useTheme();
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _props = { ...props, theme, colorMode };
 
   return variantProps(_props);

--- a/packages/react-styled-ui/src/Button/styles.js
+++ b/packages/react-styled-ui/src/Button/styles.js
@@ -324,7 +324,7 @@ const baseProps = {
 ////////////////////////////////////////////////////////////
 
 const useButtonStyle = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const theme = useTheme();
   const _props = { ...props, colorMode, theme };
   return {

--- a/packages/react-styled-ui/src/Checkbox/styles.js
+++ b/packages/react-styled-ui/src/Checkbox/styles.js
@@ -172,7 +172,7 @@ const interactionProps = ({ color, colorMode }) => {
 };
 
 const useCheckboxStyle = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _props = { ...props, colorMode };
   return {
     ...baseProps,

--- a/packages/react-styled-ui/src/Divider/index.js
+++ b/packages/react-styled-ui/src/Divider/index.js
@@ -7,7 +7,7 @@ const Divider = forwardRef(({
   orientation = 'horizontal',
   ...props
 }, ref) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const dividerColor = color || {
     dark: 'gray:60',
     light: 'gray:20',

--- a/packages/react-styled-ui/src/Drawer/DrawerOverlay.js
+++ b/packages/react-styled-ui/src/Drawer/DrawerOverlay.js
@@ -3,7 +3,7 @@ import Box from '../Box';
 import useColorMode from '../useColorMode';
 
 const DrawerOverlay = forwardRef((props, ref) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const backgroundColor = {
     dark: 'rgba(0, 0, 0, .7)', // TBD
     light: 'rgba(0, 0, 0, .7)', // TBD: light mode is not defined yet

--- a/packages/react-styled-ui/src/Drawer/styles.js
+++ b/packages/react-styled-ui/src/Drawer/styles.js
@@ -46,7 +46,7 @@ const getSizeProps = (size) => {
 };
 
 const useDrawerCloseButtonStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { colors } = useTheme();
   const color = {
     dark: 'white:tertiary',
@@ -102,7 +102,7 @@ const useDrawerContentStyle = ({
   placement,
   size,
 }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
   const baseStyle = {
     mx: 'auto',
@@ -169,7 +169,7 @@ const useDrawerBodyStyle = () => {
 };
 
 const useDrawerFooterStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { sizes, lineHeights } = useTheme();
   const borderColor = {
     dark: 'gray:80',

--- a/packages/react-styled-ui/src/FlatButton/styles.js
+++ b/packages/react-styled-ui/src/FlatButton/styles.js
@@ -112,7 +112,7 @@ const baseProps = {
 ////////////////////////////////////////////////////////////
 
 const useButtonStyle = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const theme = useTheme();
   const _props = { ...props, colorMode, theme };
   return {

--- a/packages/react-styled-ui/src/Input/styles.js
+++ b/packages/react-styled-ui/src/Input/styles.js
@@ -191,7 +191,7 @@ const useInputStyle = ({
   size,
   variant,
 }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _props = {
     colorMode,
     size,

--- a/packages/react-styled-ui/src/InputGroupAddon/styles.js
+++ b/packages/react-styled-ui/src/InputGroupAddon/styles.js
@@ -110,7 +110,7 @@ const useInputGroupAddonStyle = ({
   size,
   variant,
 }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _props = {
     colorMode,
     size,

--- a/packages/react-styled-ui/src/Link/index.js
+++ b/packages/react-styled-ui/src/Link/index.js
@@ -37,7 +37,7 @@ const baseStyleProps = ({ colorMode, disabled, textDecoration }) => {
 };
 
 const Link = forwardRef(({ disabled, onClick, textDecoration, ...props }, ref) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   return (
     <PseudoBox
       as="a"

--- a/packages/react-styled-ui/src/Menu/styles.js
+++ b/packages/react-styled-ui/src/Menu/styles.js
@@ -4,7 +4,7 @@ import useColorMode from '../useColorMode';
 import useColorStyle from '../useColorStyle';
 
 export const useMenuListStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
   const colorModeStyle = {
     light: {
@@ -32,7 +32,7 @@ export const useMenuListStyle = () => {
 */
 
 export const useMenuGroupStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = {
     dark: 'white:secondary',
     light: 'black:secondary',
@@ -93,7 +93,7 @@ const menuItemProps = ({ colorMode }) => {
 
 export const useMenuItemStyle = () => {
   const theme = useTheme();
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const props = { theme, colorMode };
 
   return {

--- a/packages/react-styled-ui/src/MenuButton/styles.js
+++ b/packages/react-styled-ui/src/MenuButton/styles.js
@@ -46,7 +46,7 @@ const menuButtonProps = ({ colorMode, color }) => {
 };
 
 const useMenuButtonStyle = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const theme = useTheme();
   const _props = { ...props, colorMode, theme, color: 'blue' };
 

--- a/packages/react-styled-ui/src/Modal/ModalOverlay.js
+++ b/packages/react-styled-ui/src/Modal/ModalOverlay.js
@@ -3,7 +3,7 @@ import Box from '../Box';
 import useColorMode from '../useColorMode';
 
 const ModalOverlay = forwardRef((props, ref) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const backgroundColor = {
     dark: 'rgba(0, 0, 0, .7)', // TBD
     light: 'rgba(0, 0, 0, .7)', // TBD: light mode is not defined yet

--- a/packages/react-styled-ui/src/Modal/styles.js
+++ b/packages/react-styled-ui/src/Modal/styles.js
@@ -44,7 +44,7 @@ const getSizeProps = (size) => {
 };
 
 const useModalCloseButtonStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { colors } = useTheme();
   const color = {
     dark: 'white:tertiary',
@@ -97,7 +97,7 @@ const useModalCloseButtonStyle = () => {
 };
 
 const useModalContentStyle = ({ size }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
   const baseStyle = {
     mx: 'auto',
@@ -161,7 +161,7 @@ const useModalBodyStyle = () => {
 };
 
 const useModalFooterStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { sizes, lineHeights } = useTheme();
   const borderColor = {
     dark: 'gray:80',

--- a/packages/react-styled-ui/src/Pagination/index.js
+++ b/packages/react-styled-ui/src/Pagination/index.js
@@ -7,7 +7,7 @@ import useTheme from '../useTheme';
 import { setColorWithOpacity } from '../theme/colors';
 
 const SelectableButton = ({ selected, ...props }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const activeColor = {
     dark: 'blue:40',
     light: 'blue:60',
@@ -48,7 +48,7 @@ const Pagination = (props, ref) => {
     showFirstButton: !!firstButton,
     showLastButton: !!lastButton,
   });
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { sizes } = useTheme();
   return (
     <React.Fragment>

--- a/packages/react-styled-ui/src/Popover/styles.js
+++ b/packages/react-styled-ui/src/Popover/styles.js
@@ -7,7 +7,7 @@ const baseProps = {
 };
 
 const usePopoverContentStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
   const backgroundColor = {
     dark: 'gray:80',
@@ -31,7 +31,7 @@ const usePopoverContentStyle = () => {
 };
 
 const usePopoverHeaderStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = { dark: 'white:emphasis', light: 'black:primary' }[colorMode];
   return {
     ...baseProps,
@@ -48,7 +48,7 @@ const usePopoverHeaderStyle = () => {
 };
 
 const usePopoverBodyStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = { dark: 'white:primary', light: 'black:primary' }[colorMode];
   return {
     color,

--- a/packages/react-styled-ui/src/Radio/styles.js
+++ b/packages/react-styled-ui/src/Radio/styles.js
@@ -80,7 +80,7 @@ const interactionProps = ({ color, colorMode, theme: { colors } }) => {
 
 const useRadioStyle = props => {
   const theme = useTheme();
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _props = { ...props, colorMode, theme };
   return {
     ...baseProps,

--- a/packages/react-styled-ui/src/SearchInput/index.js
+++ b/packages/react-styled-ui/src/SearchInput/index.js
@@ -55,7 +55,7 @@ const SearchInput = React.forwardRef((
   const inputRef = useRef();
   const combinedRef = useForkRef(inputRef, ref);
   const [rootProps, inputProps] = splitProps(rest);
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const primaryColor = {
     dark: 'white:primary',
     light: 'black:primary',

--- a/packages/react-styled-ui/src/Select/styles.js
+++ b/packages/react-styled-ui/src/Select/styles.js
@@ -179,7 +179,7 @@ const useSelectStyle = ({
   variant,
   multiple,
 }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _props = {
     colorMode,
     variant,
@@ -200,7 +200,7 @@ const useSelectStyle = ({
 };
 
 const useOptionStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const backgroundColor = {
     dark: 'gray:100',
     light: 'white',

--- a/packages/react-styled-ui/src/Skeleton/styles.js
+++ b/packages/react-styled-ui/src/Skeleton/styles.js
@@ -110,7 +110,7 @@ const useSkeletonStyle = ({
   animation,
   variant,
 }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const backgroundColor = {
     dark: 'gray:80',
     light: 'gray:20',

--- a/packages/react-styled-ui/src/Spinner/index.js
+++ b/packages/react-styled-ui/src/Spinner/index.js
@@ -71,7 +71,7 @@ const Spinner = forwardRef(
     const _dashSpeed = Math.floor(_speed * 0.75 * 100) / 100;
 
     /***** full circle color *****/
-    const { colorMode } = useColorMode();
+    const [colorMode] = useColorMode();
     const _secondCircleColor = {
       light: setColorWithOpacity('black', 0.12),
       dark: setColorWithOpacity('white', 0.12),

--- a/packages/react-styled-ui/src/Table/Table.js
+++ b/packages/react-styled-ui/src/Table/Table.js
@@ -45,7 +45,7 @@ const Table = forwardRef((
 });
 
 const VerticalLine = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const isDark = colorMode === 'dark';
   return (
     <Box
@@ -58,7 +58,7 @@ const VerticalLine = (props) => {
   );
 };
 const HorizontalLine = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const isDark = colorMode === 'dark';
   return (
     <Box

--- a/packages/react-styled-ui/src/Table/TableRow.js
+++ b/packages/react-styled-ui/src/Table/TableRow.js
@@ -9,7 +9,7 @@ const TableRow = forwardRef(({
   ...props
 }, ref) => {
   const { isHoverable } = useTableContext();
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const isDark = colorMode === 'dark';
   const bg = isDark ? 'white' : 'black';
   return (

--- a/packages/react-styled-ui/src/Table/styles.js
+++ b/packages/react-styled-ui/src/Table/styles.js
@@ -33,7 +33,7 @@ const colorProps = {
 ////////////////////////////////////////////////////////////
 
 const useTableCellStyle = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   return {
     borderBottom: 1,
     ...props.variant === 'outline' && { borderRight: 1 },
@@ -45,7 +45,7 @@ const useTableCellStyle = props => {
 ////////////////////////////////////////////////////////////
 
 const useTableHeaderCellStyle = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   return {
     borderBottom: 2,
     fontWeight: 'semibold',

--- a/packages/react-styled-ui/src/Tabs/styles.js
+++ b/packages/react-styled-ui/src/Tabs/styles.js
@@ -218,7 +218,7 @@ export const useTabStyle = () => {
   const { variant, size, isFitted, orientation } = useContext(
     TabContext,
   );
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _variantStyle = variantStyle({ size, variant, theme, colorMode });
   const _orientationStyle = orientationStyle({ orientation });
 

--- a/packages/react-styled-ui/src/Tag/styles.js
+++ b/packages/react-styled-ui/src/Tag/styles.js
@@ -318,7 +318,7 @@ const baseProps = {
 
 const useTagStyle = ({ borderRadius, ...props }) => {
   const theme = useTheme();
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _props = { ...props, theme, colorMode };
   return {
     ...baseProps,

--- a/packages/react-styled-ui/src/TextLabel/index.js
+++ b/packages/react-styled-ui/src/TextLabel/index.js
@@ -3,7 +3,7 @@ import Text from '../Text';
 import useColorMode from '../useColorMode';
 
 const TextLabel = forwardRef((props, ref) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const colorProps = {
     dark: {
       color: 'white:secondary',

--- a/packages/react-styled-ui/src/Textarea/styles.js
+++ b/packages/react-styled-ui/src/Textarea/styles.js
@@ -149,7 +149,7 @@ const getVariantProps = (props) => {
 const useTextareaStyle = ({
   variant,
 }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _props = {
     colorMode,
     variant,

--- a/packages/react-styled-ui/src/Toast/styles.js
+++ b/packages/react-styled-ui/src/Toast/styles.js
@@ -56,7 +56,7 @@ const useToastRootStyle = ({
   appearance,
 }) => {
   const theme = useTheme();
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _props = {
     theme,
     colorMode,
@@ -96,7 +96,7 @@ const useToastMessageStyle = () => {
 };
 
 const useToastCloseButtonStyle = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { colors } = useTheme();
   const color = {
     dark: 'black:tertiary',

--- a/packages/react-styled-ui/src/ToggleSwitch/styles.js
+++ b/packages/react-styled-ui/src/ToggleSwitch/styles.js
@@ -148,7 +148,7 @@ const switchThumbProps = ({
 
 
 const useToggleSwitchStyle = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const size = switchSizes[props.size] ?? switchSizes[defaultSize];
   const { width, height, radius } = size;
   const switchMaxWidth = width + 6; //The border and halo width of the one side switching track is 1 and 2, so the sum of both sides is 6

--- a/packages/react-styled-ui/src/Tooltip/styles.js
+++ b/packages/react-styled-ui/src/Tooltip/styles.js
@@ -12,7 +12,7 @@ const baseProps = {
 };
 
 const useTooltipStyle = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
   const colorModeStyle = {
     dark: {

--- a/packages/styled-ui-docs/components/AnimatedCubeDemo.jsx
+++ b/packages/styled-ui-docs/components/AnimatedCubeDemo.jsx
@@ -9,7 +9,7 @@ const cubeSpin = keyframes`
 `;
 
 const AnimatedCubeDemo = ({ size = 128, ...rest }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const textShadow = colorMode === 'dark'
     ? `
       -1px -1px 2px rgba(0,0,0,.4),

--- a/packages/styled-ui-docs/components/Code.jsx
+++ b/packages/styled-ui-docs/components/Code.jsx
@@ -2,7 +2,7 @@ import { Box, useColorMode } from '@trendmicro/react-styled-ui';
 import React, { forwardRef } from 'react';
 
 const Code = forwardRef((props, ref) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const backgroundColor = {
     light: 'gray:10', // FIXME
     dark: 'gray:70',

--- a/packages/styled-ui-docs/components/CodeBlock.jsx
+++ b/packages/styled-ui-docs/components/CodeBlock.jsx
@@ -61,7 +61,7 @@ const tmicons = tmicon.iconsets.map(group => {
 });
 
 const LiveCodePreview = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const borderColor = {
     light: 'gray:20', // FIXME
     dark: 'gray:70',
@@ -130,7 +130,7 @@ const CodeBlock = ({
   const handleCodeChange = useCallback(newCode => {
     setEditorCode(newCode.trim());
   }, []);
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const themes = {
     light: codeBlockLight,
     dark: codeBlockDark,

--- a/packages/styled-ui-docs/components/ColorStyleBlock.jsx
+++ b/packages/styled-ui-docs/components/ColorStyleBlock.jsx
@@ -92,6 +92,7 @@ const ColorStyleBlock = ({
 
               return (
                 <Tag
+                  key={colorToken}
                   variant="solid"
                   fontFamily="mono"
                   fontSize="sm"
@@ -110,6 +111,7 @@ const ColorStyleBlock = ({
           >
             {colorValues.map(colorValue => (
               <Text
+                key={colorValue}
                 color={secondaryTextColor}
                 fontFamily="mono"
                 fontSize="sm"

--- a/packages/styled-ui-docs/components/Cube.jsx
+++ b/packages/styled-ui-docs/components/Cube.jsx
@@ -38,7 +38,7 @@ const CubeObject = (props) => {
 };
 
 const CubePlane = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const backgroundColor = colorMode === 'dark'
     ? 'rgba(255,255,255,.05)'
     : 'rgba(0,0,0,.05)';

--- a/packages/styled-ui-docs/components/EditableTag.jsx
+++ b/packages/styled-ui-docs/components/EditableTag.jsx
@@ -17,7 +17,7 @@ const EditableTag = React.forwardRef((
   },
   ref,
 ) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const tagInputRef = React.useRef();
   const tagHiddenSpanRef = React.useRef();
   const { sizes } = useTheme();

--- a/packages/styled-ui-docs/components/FontAwesomeIcon.jsx
+++ b/packages/styled-ui-docs/components/FontAwesomeIcon.jsx
@@ -34,7 +34,7 @@ export default React.forwardRef(({
   spinReverse,
   ...props
 }, ref) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = {
     light: '#666666',
     dark: '#bbbbbb',

--- a/packages/styled-ui-docs/components/MDXComponents.jsx
+++ b/packages/styled-ui-docs/components/MDXComponents.jsx
@@ -32,7 +32,7 @@ const p = props => (
 );
 
 const H1 = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = mapColorModeToHeadingColor(colorMode);
   const borderColor = {
     light: 'gray:40', //FIX ME
@@ -57,7 +57,7 @@ const H1 = props => {
 };
 
 const H2 = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = mapColorModeToHeadingColor(colorMode);
   const borderColor = {
     light: 'gray:40', //FIX ME
@@ -82,7 +82,7 @@ const H2 = props => {
 };
 
 const H3 = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = mapColorModeToHeadingColor(colorMode);
 
   return (
@@ -100,7 +100,7 @@ const H3 = props => {
 };
 
 const H4 = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = mapColorModeToHeadingColor(colorMode);
 
   return (
@@ -117,7 +117,7 @@ const H4 = props => {
 };
 
 const H5 = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = mapColorModeToHeadingColor(colorMode);
 
   return (
@@ -135,7 +135,7 @@ const H5 = props => {
 };
 
 const H6 = props => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = mapColorModeToHeadingColor(colorMode);
 
   return (
@@ -228,7 +228,7 @@ const tr = props => (
 );
 
 const TH = ({ align, ...props }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const borderColor = mapColorModeToTableBorderColor(colorMode);
 
   return (
@@ -248,7 +248,7 @@ const TH = ({ align, ...props }) => {
 };
 
 const TD = ({ align, ...props }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const borderColor = mapColorModeToTableBorderColor(colorMode);
 
   return (

--- a/packages/styled-ui-docs/components/Main.jsx
+++ b/packages/styled-ui-docs/components/Main.jsx
@@ -4,7 +4,7 @@ import { Box, useColorMode } from '@trendmicro/react-styled-ui';
 import React from 'react';
 
 const Main = React.forwardRef(({ children, ...props }, ref) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const backgroundColor = {
     light: 'white',
     dark: 'gray:100',

--- a/packages/styled-ui-docs/components/SideNav.jsx
+++ b/packages/styled-ui-docs/components/SideNav.jsx
@@ -20,7 +20,7 @@ const publicUrl = process.env.PUBLIC_URL;
 const NavLink = React.forwardRef(({ href, children, ...rest }, ref) => {
   const router = useRouter();
   const isRouteActive = href.replace('.', '') === router.pathname;
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = {
     light: 'gray:90', // FIXME
     dark: 'white:primary',
@@ -77,7 +77,7 @@ const NavLink = React.forwardRef(({ href, children, ...rest }, ref) => {
 
 const SideNav = React.forwardRef((props, ref) => {
   const theme = useTheme();
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const backgroundColor = {
     light: 'white',
     dark: 'gray:90',

--- a/packages/styled-ui-docs/components/ThemeParser.jsx
+++ b/packages/styled-ui-docs/components/ThemeParser.jsx
@@ -7,7 +7,7 @@ import jsonPrettify from './json-prettify';
 const ThemeParser = ({ theme, mode, ...props }) => {
   const themes = useTheme();
   const indent = !!mode;
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const _mode = mode ?? colorMode;
   let token = _get(colorStyle[_mode], theme) || themes[theme];
   if (!token) {

--- a/packages/styled-ui-docs/components/useToast.js
+++ b/packages/styled-ui-docs/components/useToast.js
@@ -4,7 +4,7 @@ import { ColorModeProvider, ThemeProvider, useColorMode, useTheme } from '@trend
 
 const useToast = () => {
   const theme = useTheme();
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const notify = useCallback(
     ({
       position = 'top',

--- a/packages/styled-ui-docs/components/useToast.js
+++ b/packages/styled-ui-docs/components/useToast.js
@@ -1,6 +1,12 @@
 import React, { useCallback } from 'react';
 import toaster from 'toasted-notes';
-import { ColorModeProvider, ThemeProvider, useColorMode, useTheme } from '@trendmicro/react-styled-ui';
+import {
+  ColorModeProvider,
+  ColorStyleProvider,
+  ThemeProvider,
+  useColorMode,
+  useTheme,
+} from '@trendmicro/react-styled-ui';
 
 const useToast = () => {
   const theme = useTheme();
@@ -24,7 +30,9 @@ const useToast = () => {
         ({ id, onClose }) => (
           <ThemeProvider theme={theme}>
             <ColorModeProvider value={colorMode}>
-              {render({ id, onClose, position, duration })}
+              <ColorStyleProvider>
+                {render({ id, onClose, position, duration })}
+              </ColorStyleProvider>
             </ColorModeProvider>
           </ThemeProvider>
         ),

--- a/packages/styled-ui-docs/pages/_app.js
+++ b/packages/styled-ui-docs/pages/_app.js
@@ -29,7 +29,7 @@ const customTheme = {
 };
 
 const Layout = ({ children }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { fontSizes, lineHeights } = useTheme();
   const backgroundColor = {
     light: 'white',

--- a/packages/styled-ui-docs/pages/buttonbase.mdx
+++ b/packages/styled-ui-docs/pages/buttonbase.mdx
@@ -38,7 +38,7 @@ Standard button attributes are supported, e.g., `type`, `disabled`, etc.
 
 ```jsx noInline
 const IconButton = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { colors } = useTheme();
   const color = {
     dark: 'white:secondary',

--- a/packages/styled-ui-docs/pages/buttongroup.mdx
+++ b/packages/styled-ui-docs/pages/buttongroup.mdx
@@ -16,7 +16,7 @@ import { ButtonGroup } from '@trendmicro/react-styled-ui';
 
 ```jsx noInline
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const dividerColor ={
     dark: 'gray:70',
     light: 'gray:30',
@@ -41,7 +41,7 @@ Use the `variant` prop to change the visual style of every button in a group. Yo
 
 ```jsx noInline
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const emphasisDividerColor ={
     dark: 'red:80',
     light: 'red:80',
@@ -121,7 +121,7 @@ Use the `size` prop to change the size of the `ButtonGroup`. You can set the val
 
 ```jsx noInline
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const defaultDividerColor ={
     dark: 'gray:70',
     light: 'gray:30',
@@ -257,7 +257,7 @@ Make a set of buttons appear vertically stacked rather than horizontally, by add
 
 ```jsx noInline
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const defaultDividerColor ={
     dark: 'gray:70',
     light: 'gray:30',
@@ -353,7 +353,7 @@ render(<Example />);
 
 ```jsx noInline
 const SelectableButton = ({ selected, selectedColor, ...props }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { colors } = useTheme();
   const focusColor = colors['blue:60'];
   let _selectedColor = selectedColor || {
@@ -398,7 +398,7 @@ const SelectableButton = ({ selected, selectedColor, ...props }) => {
 };
 
 function SwitchButton() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const emphasisDividerColor = {
     dark: 'red:80',
     light: 'red:80',

--- a/packages/styled-ui-docs/pages/color-mode.mdx
+++ b/packages/styled-ui-docs/pages/color-mode.mdx
@@ -26,7 +26,15 @@ import React from 'react';
 import { Button, useColorMode } from '@trendmicro/react-styled-ui';
 
 const App = () => {
-  const { colorMode, toggleColorMode } = useColorMode();
+  const [colorMode, setColorMode] = useColorMode();
+  const toggleColorMode = () => {
+    const nextColorMode = {
+      'dark': 'light',
+      'light': 'dark',
+    }[colorMode];
+    setColorMode(nextColorMode);
+  };
+
   return (
     <Button onClick={toggleColorMode}>
       Toggle Color Mode

--- a/packages/styled-ui-docs/pages/color-mode.mdx
+++ b/packages/styled-ui-docs/pages/color-mode.mdx
@@ -22,8 +22,8 @@ To handle color mode manually in your application, use the `useColorMode` Hook t
 
 ```jsx disabled
 // App.jsx
-import React from 'react';
 import { Button, useColorMode } from '@trendmicro/react-styled-ui';
+import React from 'react';
 
 const App = () => {
   const [colorMode, setColorMode] = useColorMode();

--- a/packages/styled-ui-docs/pages/color-style.mdx
+++ b/packages/styled-ui-docs/pages/color-style.mdx
@@ -1,5 +1,6 @@
 import {
   colorStyle,
+  Box,
   DarkMode,
   Divider,
   Flex,

--- a/packages/styled-ui-docs/pages/drawer.mdx
+++ b/packages/styled-ui-docs/pages/drawer.mdx
@@ -25,7 +25,7 @@ Click the button below to toggle a drawer. The drawer will show up on either sid
 
 ```jsx noInline
 const SelectableButton = ({ selected, ...props }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { colors } = useTheme();
   const focusColor = colors['blue:60'];
   let _selectedColor = {
@@ -82,7 +82,7 @@ const useToggle = (defaultValue) => {
 };
 
 const Divider = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const dividerColor = {
     dark: 'white:secondary',
     light: 'black:secondary',
@@ -99,7 +99,7 @@ const FormGroup = (props) => (
 );
 
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const iconColor = {
     dark: 'white:tertiary',
     light: 'black:tertiary',

--- a/packages/styled-ui-docs/pages/getting-started.mdx
+++ b/packages/styled-ui-docs/pages/getting-started.mdx
@@ -95,7 +95,7 @@ import {
 import App from './App';
 
 const Layout = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
   const { fontSizes, lineHeights } = useTheme();
   const backgroundColor = colorStyle.background.primary;

--- a/packages/styled-ui-docs/pages/icon.mdx
+++ b/packages/styled-ui-docs/pages/icon.mdx
@@ -129,7 +129,7 @@ const renderIconGroup = (iconSet, keyword, showCharCode, color) => {
 function Example() {
   const [keyword, setKeyword] = React.useState('');
   const [showCharCode, setShowCharCode] = React.useState(false);
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const color = {
     light: 'black:secondary',
     dark: 'white:secondary',

--- a/packages/styled-ui-docs/pages/input.mdx
+++ b/packages/styled-ui-docs/pages/input.mdx
@@ -201,7 +201,7 @@ const InputAdornmentAppend = (props) => (
 function Example() {
   const [view, setView] = React.useState(false);
   const toggleView = () => setView(view => !view);
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const adornmentColor = {
     dark: 'white:tertiary',
     light: 'black:tertiary',

--- a/packages/styled-ui-docs/pages/inputgroup.mdx
+++ b/packages/styled-ui-docs/pages/inputgroup.mdx
@@ -208,7 +208,7 @@ While multiple `<Input />`s are supported visually, validation styles are only a
 
 ```jsx noInline
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const dividerColor ={
     dark: 'gray:70',
     light: 'gray:30',

--- a/packages/styled-ui-docs/pages/modal.mdx
+++ b/packages/styled-ui-docs/pages/modal.mdx
@@ -95,7 +95,7 @@ Click the button below to toggle a modal. The modal will show up in the center o
 
 ```jsx noInline
 const SelectableButton = ({ selected, ...props }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { colors } = useTheme();
   const focusColor = colors['blue:60'];
   let _selectedColor = {
@@ -152,7 +152,7 @@ const useToggle = (defaultValue) => {
 };
 
 const Divider = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const dividerColor = {
     dark: 'white:secondary',
     light: 'black:secondary',
@@ -169,7 +169,7 @@ const FormGroup = (props) => (
 );
 
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const iconColor = {
     dark: 'white:tertiary',
     light: 'black:tertiary',

--- a/packages/styled-ui-docs/pages/pseudobox.mdx
+++ b/packages/styled-ui-docs/pages/pseudobox.mdx
@@ -188,7 +188,7 @@ Add the `_firstChild` prop to style an element that is the first element among i
 
 ```jsx
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
 
   return (
@@ -220,7 +220,7 @@ Add the `_lastChild` prop to style an element that is the last element among its
 
 ```jsx
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
 
   return (
@@ -296,7 +296,7 @@ render(<Example />);
 
 ```jsx
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
 
   return (
@@ -323,7 +323,7 @@ function Example() {
 
 ```jsx
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
 
   return (

--- a/packages/styled-ui-docs/pages/shadows.mdx
+++ b/packages/styled-ui-docs/pages/shadows.mdx
@@ -9,7 +9,7 @@ Add or remove shadows to elements with box-shadow utilities.
 
 ```jsx noInline
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   return (
     <Stack direction="row" spacing="6x" justifyContent="center">
       <Box width="56x" height="24x" p="2x" bg="gray:70" boxShadow={`${colorMode}.sm`}>boxShadow=sm</Box>

--- a/packages/styled-ui-docs/pages/stack.mdx
+++ b/packages/styled-ui-docs/pages/stack.mdx
@@ -25,7 +25,7 @@ By default, each item is stacked vertically. Stack clones it's children and pass
 
 ```jsx noInline
 const Item = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const boxShadow = `${colorMode}.sm`;
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (
@@ -50,7 +50,7 @@ render(<Example />);
 
 ```jsx noInline
 const Item = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const boxShadow = `${colorMode}.sm`;
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (
@@ -75,7 +75,7 @@ render(<Example />);
 
 ```jsx noInline
 const Item = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const boxShadow = `${colorMode}.sm`;
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (
@@ -101,7 +101,7 @@ render(<Example />);
 
 ```jsx noInline
 const Item = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const boxShadow = `${colorMode}.sm`;
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
   return (

--- a/packages/styled-ui-docs/pages/table.mdx
+++ b/packages/styled-ui-docs/pages/table.mdx
@@ -560,7 +560,7 @@ In this example, we use [`react-custom-scrollbars`](https://github.com/malte-wes
 
 ```jsx noInline
 function StickyTable() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const scrollbarColor = colorMode === 'dark' ? 'white:tertiary' : 'black:tertiary';
 
   const columns = React.useMemo(() => [

--- a/packages/styled-ui-docs/pages/tag.mdx
+++ b/packages/styled-ui-docs/pages/tag.mdx
@@ -133,7 +133,7 @@ const EditableTag = React.forwardRef((
   },
   ref,
 ) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const tagInputRef = React.useRef();
   const tagHiddenSpanRef = React.useRef();
   const { sizes } = useTheme();
@@ -363,7 +363,7 @@ render(<Tags />);
 const useWrapperStyle = ({
   isFocused,
 }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { sizes } = useTheme();
   const borderColor = {
     dark: 'gray:60',
@@ -399,7 +399,7 @@ const useWrapperStyle = ({
 };
 
 const Tags = () => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const tagCreatorRef = React.useRef();
   const [inputValue, setInputValue] = React.useState('');
   const [tags, setTags] = React.useState([]);

--- a/packages/styled-ui-docs/pages/text.mdx
+++ b/packages/styled-ui-docs/pages/text.mdx
@@ -67,7 +67,7 @@ You can format the `Text` component by passing `fontSize`, `lineHeight`, or othe
 
 ```jsx
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const bg = colorMode === 'dark' ? 'gray:80' : 'gray:20';
 
   return (
@@ -103,7 +103,7 @@ function Example() {
 
 ```jsx noInline
 const TextBlock = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const borderColor = colorMode === 'dark' ? 'gray:70' : 'gray:20';
 
   return (

--- a/packages/styled-ui-docs/pages/toast.mdx
+++ b/packages/styled-ui-docs/pages/toast.mdx
@@ -21,7 +21,7 @@ import {
 
 const useToast = () => {
   const theme = useTheme();
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const notify = useCallback(
     ({
       position = 'top',
@@ -161,7 +161,7 @@ const ToastWithAllTogether = ({ onClose }) => (
 );
 
 const ToastLayout = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const boxShadow = {
     dark: 'dark.sm',
     light: 'light.sm',
@@ -327,7 +327,7 @@ const ToastError = ({ onClose }) => (
 );
 
 const ToastLayout = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const boxShadow = {
     dark: 'dark.sm',
     light: 'light.sm',
@@ -446,7 +446,7 @@ const ToastWithoutIcon = ({ onClose }) => (
 );
 
 const ToastLayout = (props) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const boxShadow = {
     dark: 'dark.sm',
     light: 'light.sm',

--- a/packages/styled-ui-docs/pages/tooltip.mdx
+++ b/packages/styled-ui-docs/pages/tooltip.mdx
@@ -50,7 +50,7 @@ If the children of Tooltip are focusable elements, Tooltip will show when you fo
 
 ```jsx
 function Example() {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const inputRef = React.useRef();
   const [menuItem, setMenuItem] = React.useState('hostname');
   const handleMenuClick = (event) => {

--- a/packages/styled-ui-docs/pages/transition.mdx
+++ b/packages/styled-ui-docs/pages/transition.mdx
@@ -52,7 +52,7 @@ render(<Example />);
 
 ```jsx noInline
 const SelectableButton = ({ selected, ...props }) => {
-  const { colorMode } = useColorMode();
+  const [colorMode] = useColorMode();
   const { colors } = useTheme();
   const focusColor = colors['blue:60'];
   let _selectedColor = {


### PR DESCRIPTION
#### Before

```js
const { colorMode, setColorMode, toggleColorMode } = useColorMode();
```

#### After

`toggleColorMode` is removed when using the array destructuring assignment.

```js
const [colorMode, setColorMode] = useColorMode();
```

or

```js
 // this usage is deprecated and will discontinue in v1 release
const { colorMode, setColorMode, toggleColorMode } = useColorMode();
```


### Notice

This PR will not lead to a breaking change. A trick was used in the useColorMode Hook to keep backward compatibility.


```js
const useColorMode = () => {
  if (!useContext) {
    throw new Error('The `useContext` hook is not available with your React version.');
  }

  const {
    colorMode,
    setColorMode,
    toggleColorMode, // TODO: toggleColorMode is deprecated and will be removed in the v1 release
  } = useContext(ColorModeContext);

  if (colorMode === undefined) {
    throw new Error('The `useColorMode` hook must be called from a descendent of the `ColorModeProvider`.');
  }

  const value = [colorMode, setColorMode];

  // TODO: returning object is deprecated and will be removed in the v1 release
  value.colorMode = colorMode;
  value.setColorMode = setColorMode;
  value.toggleColorMode = toggleColorMode;

  return value;
};
```