### PR TITLE
fix(tab): fix incorrect border color for the selected tab that receives focus (part 1)

### DIFF
--- a/packages/react-styled-ui/src/Tabs/styles.js
+++ b/packages/react-styled-ui/src/Tabs/styles.js
@@ -153,7 +153,7 @@ const enclosedStyle = ({ size, colorMode, theme }) => {
       },
 
       _focusSelected: {
-        borderColor: _focusBorderColor,
+        borderColor: _selectedBorder,
         zIndex: 3
       },
 


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/447801/114044288-adf7c500-98b9-11eb-9051-680da185970c.png)

After
![image](https://user-images.githubusercontent.com/447801/114044323-b7812d00-98b9-11eb-9ec1-92ac4313ee88.png)
