### PR TITLE
feat: support function as children for TabPanel

### DIFF
--- a/packages/react-styled-ui/src/Tabs/TabList.js
+++ b/packages/react-styled-ui/src/Tabs/TabList.js
@@ -12,7 +12,8 @@ const TabList = forwardRef((props, ref) => {
     index: selectedIndex,
     manualIndex,
     onManualTabChange,
-    activateOnKeypress,
+    activateOnKeypress, // TODO: activateOnKeypress is deprecated and will be removed in the v1 release
+    isManual,
     onChangeTab,
     onFocusPanel,
     orientation,
@@ -71,7 +72,7 @@ const TabList = forwardRef((props, ref) => {
   };
 
   const clones = validChildren.map((child, index) => {
-    let isSelected = activateOnKeypress ? index === manualIndex : index === selectedIndex;
+    let isSelected = (activateOnKeypress || isManual) ? index === manualIndex : index === selectedIndex;
 
     const handleClick = (event) => {
       // Hack for Safari. Buttons don't receive focus on click on Safari

--- a/packages/react-styled-ui/src/Tabs/TabList.js
+++ b/packages/react-styled-ui/src/Tabs/TabList.js
@@ -72,7 +72,8 @@ const TabList = forwardRef((props, ref) => {
   };
 
   const clones = validChildren.map((child, index) => {
-    let isSelected = (activateOnKeypress || isManual) ? index === manualIndex : index === selectedIndex;
+    const isActiveManually = activateOnKeypress || isManual;
+    let isSelected = isActiveManually ? index === manualIndex : index === selectedIndex;
 
     const handleClick = (event) => {
       // Hack for Safari. Buttons don't receive focus on click on Safari

--- a/packages/react-styled-ui/src/Tabs/TabPanel.js
+++ b/packages/react-styled-ui/src/Tabs/TabPanel.js
@@ -22,7 +22,9 @@ const TabPanel = forwardRef(
         outline={0}
         {...rest}
       >
-        {children}
+        {typeof children === 'function'
+          ? children({ isActive: isSelected })
+          : children}
       </Box>
     );
   },

--- a/packages/react-styled-ui/src/Tabs/TabPanels.js
+++ b/packages/react-styled-ui/src/Tabs/TabPanels.js
@@ -12,7 +12,8 @@ const TabPanels = forwardRef(({ children, ...rest }, ref) => {
     index: selectedIndex,
     selectedPanelRef,
     id,
-    activateOnKeypress,
+    activateOnKeypress, // TODO: activateOnKeypress is deprecated and will be removed in the v1 release
+    isManual,
     manualIndex,
   } = useContext(TabContext);
 
@@ -20,7 +21,7 @@ const TabPanels = forwardRef(({ children, ...rest }, ref) => {
 
   const clones = validChildren.map((child, index) => {
     return cloneElement(child, {
-      isSelected: activateOnKeypress ? index === manualIndex : index === selectedIndex,
+      isSelected: (activateOnKeypress || isManual) ? index === manualIndex : index === selectedIndex,
       selectedPanelRef,
       id: `${id}-${index}`,
     });

--- a/packages/react-styled-ui/src/Tabs/TabPanels.js
+++ b/packages/react-styled-ui/src/Tabs/TabPanels.js
@@ -18,10 +18,10 @@ const TabPanels = forwardRef(({ children, ...rest }, ref) => {
   } = useContext(TabContext);
 
   const validChildren = cleanChildren(children);
-
+  const isActiveManually = activateOnKeypress || isManual;
   const clones = validChildren.map((child, index) => {
     return cloneElement(child, {
-      isSelected: (activateOnKeypress || isManual) ? index === manualIndex : index === selectedIndex,
+      isSelected: isActiveManually ? index === manualIndex : index === selectedIndex,
       selectedPanelRef,
       id: `${id}-${index}`,
     });

--- a/packages/react-styled-ui/src/Tabs/Tabs.js
+++ b/packages/react-styled-ui/src/Tabs/Tabs.js
@@ -14,7 +14,8 @@ const Tabs = forwardRef(
       onChange,
       index: controlledIndex,
       defaultIndex,
-      activateOnKeypress,
+      activateOnKeypress, // TODO: activateOnKeypress is deprecated and will be removed in the v1 release
+      isManual,
       variant = 'line',
       align = 'left',
       size = 'md',
@@ -28,7 +29,7 @@ const Tabs = forwardRef(
     const selectedPanelRef = useRef();
 
     const getInitialIndex = () => {
-      if (!activateOnKeypress) {
+      if (!(activateOnKeypress || isManual)) {
         return defaultIndex || 0;
       } else {
         return controlledIndex || defaultIndex || 0;
@@ -36,7 +37,7 @@ const Tabs = forwardRef(
     };
 
     const getActualIdx = () => {
-      if (activateOnKeypress) {
+      if (activateOnKeypress || isManual) {
         return selectedIndex;
       } else {
         return isControlled ? controlledIndex : selectedIndex;
@@ -56,11 +57,11 @@ const Tabs = forwardRef(
         setSelectedIndex(index);
       }
 
-      if (isControlled && activateOnKeypress) {
+      if (isControlled && (activateOnKeypress || isManual)) {
         setSelectedIndex(index);
       }
 
-      if (!activateOnKeypress) {
+      if (!(activateOnKeypress || isManual)) {
         onChange && onChange(index);
       }
     };
@@ -70,7 +71,7 @@ const Tabs = forwardRef(
         setManualIndex(index);
       }
 
-      if (activateOnKeypress) {
+      if (activateOnKeypress || isManual) {
         onChange && onChange(index);
       }
     };
@@ -88,7 +89,8 @@ const Tabs = forwardRef(
       index: actualIdx,
       manualIndex: manualIdx,
       onManualTabChange,
-      activateOnKeypress,
+      activateOnKeypress, // TODO: activateOnKeypress is deprecated and will be removed in the v1 release
+      isManual,
       onChangeTab,
       selectedPanelRef,
       onFocusPanel,

--- a/packages/react-styled-ui/src/Tabs/Tabs.js
+++ b/packages/react-styled-ui/src/Tabs/Tabs.js
@@ -27,9 +27,10 @@ const Tabs = forwardRef(
   ) => {
     const { current: isControlled } = useRef(controlledIndex != null);
     const selectedPanelRef = useRef();
+    const isActiveManually = activateOnKeypress || isManual;
 
     const getInitialIndex = () => {
-      if (!(activateOnKeypress || isManual)) {
+      if (!isActiveManually) {
         return defaultIndex || 0;
       } else {
         return controlledIndex || defaultIndex || 0;
@@ -37,7 +38,7 @@ const Tabs = forwardRef(
     };
 
     const getActualIdx = () => {
-      if (activateOnKeypress || isManual) {
+      if (isActiveManually) {
         return selectedIndex;
       } else {
         return isControlled ? controlledIndex : selectedIndex;
@@ -57,11 +58,11 @@ const Tabs = forwardRef(
         setSelectedIndex(index);
       }
 
-      if (isControlled && (activateOnKeypress || isManual)) {
+      if (isControlled && isActiveManually) {
         setSelectedIndex(index);
       }
 
-      if (!(activateOnKeypress || isManual)) {
+      if (!isActiveManually) {
         onChange && onChange(index);
       }
     };
@@ -71,7 +72,7 @@ const Tabs = forwardRef(
         setManualIndex(index);
       }
 
-      if (activateOnKeypress || isManual) {
+      if (isActiveManually) {
         onChange && onChange(index);
       }
     };

--- a/packages/styled-ui-docs/pages/tabs.mdx
+++ b/packages/styled-ui-docs/pages/tabs.mdx
@@ -51,7 +51,7 @@ you can have tabs at the top, at the bottom, or both.
 
 ## Accessing Internal state
 
-`<TabPanel>` provides access to one internal states:  `isActive`. Use the render prop pattern to access the internal states.
+`<TabPanel>` provides access to one internal state:  `isActive`. Use the render prop pattern to access the internal states.
 
 ```jsx
 <Tabs>

--- a/packages/styled-ui-docs/pages/tabs.mdx
+++ b/packages/styled-ui-docs/pages/tabs.mdx
@@ -49,6 +49,32 @@ you can have tabs at the top, at the bottom, or both.
 </Tabs>
 ```
 
+## Accessing Internal state
+
+`<TabPanel>` provides access to one internal states:  `isActive`. Use the render prop pattern to access the internal states.
+
+```jsx
+<Tabs>
+  <TabList>
+    <Tab>One</Tab>
+    <Tab>Two</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      <p>one!</p>
+    </TabPanel>
+    <TabPanel>
+      {({ isActive }) => {
+        if (isActive) {
+          return (<p>two!</p>);
+        }
+        return null;
+      }}
+    </TabPanel>
+  </TabPanels>
+</Tabs>
+```
+
 ### Tab variants and color
 
 Tabs come in 3 different variants to style the tabs: `line`,`enclosed`, `unstyled`
@@ -163,6 +189,166 @@ to `unstyled`, and use the `_selected`, `_hover`, `_active` style props.
 </Tabs>
 ```
 
+### AutoSizer Table in the tab
+
+```jsx noInline
+function FullWidthTable() {
+  const columns = React.useMemo(() => [
+    {
+      Header: 'Event Type',
+      id: 'eventType',
+      accessor: 'eventType',
+      width: 'auto',
+    },
+    {
+      Header: 'Affected Devices',
+      id: 'affectedDevices',
+      accessor: 'affectedDevices',
+      width: 160,
+    },
+    {
+      Header: 'Detections',
+      id: 'detections',
+      accessor: 'detections',
+      width: '10%',
+    },
+  ], []);
+
+  const data = React.useMemo(() => [
+    { id: 1, eventType: 'Virus/Malware', affectedDevices: 20, detections: 634 },
+    { id: 2, eventType: 'Spyware/Grayware', affectedDevices: 20, detections: 634 },
+  ], []);
+
+  const getCalculatedColumns = ({ initColumns, tableWidth }) => {
+    const columns = initColumns.map(column => {
+      let columnWidth = column.width;
+      if (typeof columnWidth === 'string') {
+        const lastChar = columnWidth.substr(columnWidth.length - 1);
+        if (lastChar === '%') {
+          columnWidth = tableWidth * (parseFloat(columnWidth) / 100);
+          return {
+            ...column,
+            width: columnWidth
+          };
+        }
+        if (columnWidth === 'auto') {
+          return {
+            ...column,
+            width: 0
+          };
+        }
+      }
+      return column;
+    });
+    const customWidthColumns = columns.filter(column => !!column.width);
+    const totalCustomWidth = customWidthColumns.reduce((accumulator, column) => accumulator + column.width, 0);
+    let defaultCellWidth = (tableWidth - totalCustomWidth) / (columns.length - customWidthColumns.length);
+    defaultCellWidth = defaultCellWidth <= 0 ? 150 : defaultCellWidth;
+    return columns.map(column => {
+      if (!!column.width) {
+        return column;
+      }
+      return {
+        ...column,
+        width: defaultCellWidth
+      };
+    });
+  };
+
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+  } = useTable(
+    {
+      columns,
+      data,
+    },
+    useBlockLayout,
+  );
+
+  return (
+    <AutoSizer>
+      {({ height, width }) => {
+        if (height === 0 || width === 0) {
+          return null;
+        }
+        const newColumns = getCalculatedColumns({ initColumns: columns, tableWidth: width });
+        return (
+          <Table
+            isHoverable
+            {...getTableProps()}
+          >
+            <TableHeader>
+              {headerGroups.map(headerGroup => (
+                <TableHeaderRow {...headerGroup.getHeaderGroupProps()}>
+                  {headerGroup.headers.map(column => {
+                    const columnId = column.id;
+                    const _column = newColumns.filter(column => column.id === columnId);
+                    const _columnWidth = _column[0].width;
+                    return (
+                      <TableHeaderCell
+                        width={_columnWidth}
+                        {...column.getHeaderProps()}
+                      >
+                        {column.render('Header')}
+                      </TableHeaderCell>
+                    );
+                  })}
+                </TableHeaderRow>
+              ))}
+            </TableHeader>
+            <TableBody {...getTableBodyProps()}>
+              {rows.map((row, i) => {
+                prepareRow(row);
+                return (
+                  <TableRow {...row.getRowProps()}>
+                    {
+                      row.cells.map(cell => {
+                        const columnId = cell.column.id;
+                        const _column = newColumns.filter(column => column.id === columnId);
+                        const _columnWidth = _column[0].width;
+                        return (
+                          <TableCell
+                            width={_columnWidth}
+                            {...cell.getCellProps()}
+                          >
+                            {cell.render('Cell')}
+                          </TableCell>
+                        );
+                      })
+                    }
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        );
+      }}
+    </AutoSizer>
+  );
+}
+
+render(
+  <Tabs height="300px">
+    <TabList>
+      <Tab>Auto height Panel</Tab>
+      <Tab>Full height Panel</Tab>
+    </TabList>
+    <TabPanels height="calc(100% - 40px)">
+      <TabPanel border="1" borderColor="green" marginTop="1x" padding="1x">
+        Hi~~~
+      </TabPanel>
+      <TabPanel height="100%" border="1" borderColor="green" marginTop="1x" padding="1x">
+        <FullWidthTable />
+      </TabPanel>
+    </TabPanels>
+  </Tabs>
+);
+```
+
 ### Manually Activated Tabs
 
 By default, `Tabs` are activated automatically. This means when you use the
@@ -175,7 +361,7 @@ without activating the tabs. With focus on a specifc tab, users can activate a
 tab by pressing <kbd>Space</kbd> or <kbd>Enter</kbd>.
 
 ```jsx
-<Tabs activateOnKeypress variant="line">
+<Tabs isManual variant="line">
   <TabList>
     <Tab>One</Tab>
     <Tab>Two</Tab>
@@ -272,7 +458,8 @@ Tabs composes `Box` so you call pass all `Box` related props.
 | `onChange`     | `(index: number) => void`                                                         |              | The callback to update the active tab index.                                                                                    |
 | `index`        | `number`                                                                          |              | The controlled index of the tabs.                                                                                               |
 | `defaultIndex` | `number`                                                                          |              | The index of the initial active tab.                                                                                            |
-| `activateOnKeypress`     | `boolean`                                                                         |              | If `true`, keyboard navigation changes focus between tabs but doens't activate it. User will have to press `Enter` to active it |
+| `activateOnKeypress`     | `boolean`                                                               |              | If `true`, keyboard navigation changes focus between tabs but doens't activate it. User will have to press `Enter` or `Space` to active it. This is deprecated and will be removed in the v1 release |
+| `isManual`     | `boolean`                                                                         |              | If `true`, keyboard navigation changes focus between tabs but doens't activate it. User will have to press `Enter` or `Space` to active it |
 | `children`     | `React.ReactNode`                                                                 |              | The children of the switch.                                                                                                     |
 | `variant`      | `line`,`enclosed`, `unstyled`                                                     | `line`       | The visual style of the tab.                                                                                                    |
 | `orientation`  | `horizontal`, `vertical`                                                          | `horizontal` | The orientation of the tabs                                                                                                     |
@@ -283,3 +470,10 @@ Tabs composes `Box` so you call pass all `Box` related props.
 | Name         | Type      | Default | Description                         |
 | ------------ | --------- | ------- | ----------------------------------- |
 | `disabled`   | `boolean` |         | If `true`, the user cannot interact with the control. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
+
+
+### TabPanel Props
+
+| Name         | Type      | Default | Description                         |
+| ------------ | --------- | ------- | ----------------------------------- |
+| children | React.ReactNode, (props: InternalState) => React.ReactNode | | The children of the `TabPanel`. |


### PR DESCRIPTION
### 1. Add render prop for children of `TabPanel`
![image](https://user-images.githubusercontent.com/24446505/116493629-b0a27480-a8d1-11eb-950b-e943594ccfd3.png)

### 2. Add the example for AutoSizer Table
#### 2-1. Auto height
![image](https://user-images.githubusercontent.com/24446505/116493668-c57f0800-a8d1-11eb-9b55-44a39aca3a98.png)

#### 2-2. Full height
![image](https://user-images.githubusercontent.com/24446505/116493680-cca61600-a8d1-11eb-89d4-2376b5161ce7.png)

### 3. Add `isManual` prop
Use `isManual` to replace of `activateOnKeypress`
![image](https://user-images.githubusercontent.com/24446505/116493516-7fc23f80-a8d1-11eb-8f4c-721ec65680a7.png)

