### PR TITLE
chore(styled-ui-theme): add back deprecated shadow properties for backward compatibility

### DIFF
--- a/packages/styled-ui-theme/src/foundations/shadows.js
+++ b/packages/styled-ui-theme/src/foundations/shadows.js
@@ -1,5 +1,15 @@
 const shadows = {
   none: 'none',
+  dark: {
+    sm: '0 2px 8px 0 rgba(0, 0, 0, 0.48), 0 1px 2px 0 rgba(0, 0, 0, 0.16)',
+    md: '0 4px 16px 0 rgba(0, 0, 0, 0.48), 0 2px 4px 0 rgba(0, 0, 0, 0.16)',
+    lg: '0 8px 32px 0 rgba(0, 0, 0, 0.48), 0 4px 8px 0 rgba(0, 0, 0, 0.16)',
+  },
+  light: {
+    sm: '0 2px 8px 0 rgba(0, 0, 0, 0.16), 0 1px 2px 0 rgba(0, 0, 0, 0.08)',
+    md: '0 4px 16px 0 rgba(0, 0, 0, 0.16), 0 2px 4px 0 rgba(0, 0, 0, 0.08)',
+    lg: '0 8px 32px 0 rgba(0, 0, 0, 0.16), 0 4px 8px 0 rgba(0, 0, 0, 0.08)',
+  },
 };
 
 export default shadows;

--- a/packages/styled-ui-theme/test/index.js
+++ b/packages/styled-ui-theme/test/index.js
@@ -226,6 +226,16 @@ test('absolute length units: px', () => {
 
   expect(shadows).toEqual({
     none: 'none',
+    dark: {
+      sm: '0 2px 8px 0 rgba(0, 0, 0, 0.48), 0 1px 2px 0 rgba(0, 0, 0, 0.16)',
+      md: '0 4px 16px 0 rgba(0, 0, 0, 0.48), 0 2px 4px 0 rgba(0, 0, 0, 0.16)',
+      lg: '0 8px 32px 0 rgba(0, 0, 0, 0.48), 0 4px 8px 0 rgba(0, 0, 0, 0.16)',
+    },
+    light: {
+      sm: '0 2px 8px 0 rgba(0, 0, 0, 0.16), 0 1px 2px 0 rgba(0, 0, 0, 0.08)',
+      md: '0 4px 16px 0 rgba(0, 0, 0, 0.16), 0 2px 4px 0 rgba(0, 0, 0, 0.08)',
+      lg: '0 8px 32px 0 rgba(0, 0, 0, 0.16), 0 4px 8px 0 rgba(0, 0, 0, 0.08)',
+    },
   });
 
   expect(sizes).toEqual(space);
@@ -532,6 +542,16 @@ test('relative length units: rem', () => {
 
   expect(shadows).toEqual({
     none: 'none',
+    dark: {
+      sm: '0 2px 8px 0 rgba(0, 0, 0, 0.48), 0 1px 2px 0 rgba(0, 0, 0, 0.16)',
+      md: '0 4px 16px 0 rgba(0, 0, 0, 0.48), 0 2px 4px 0 rgba(0, 0, 0, 0.16)',
+      lg: '0 8px 32px 0 rgba(0, 0, 0, 0.48), 0 4px 8px 0 rgba(0, 0, 0, 0.16)',
+    },
+    light: {
+      sm: '0 2px 8px 0 rgba(0, 0, 0, 0.16), 0 1px 2px 0 rgba(0, 0, 0, 0.08)',
+      md: '0 4px 16px 0 rgba(0, 0, 0, 0.16), 0 2px 4px 0 rgba(0, 0, 0, 0.08)',
+      lg: '0 8px 32px 0 rgba(0, 0, 0, 0.16), 0 4px 8px 0 rgba(0, 0, 0, 0.08)',
+    },
   });
 
   expect(sizes).toEqual(space);


### PR DESCRIPTION
Add back deprecated shadow properties that were firstly removed in [@trendmicro/styled-ui-theme@0.12.0](https://github.com/trendmicro-frontend/styled-ui/releases/tag/%40trendmicro%2Fstyled-ui-theme%400.12.0)

All the deprecated properties will be removed in the v1 release.