### PR TITLE
feat(divider): add variant prop and change border color

### DIFF
--- a/packages/react-styled-ui/src/Divider/index.js
+++ b/packages/react-styled-ui/src/Divider/index.js
@@ -5,6 +5,7 @@ import useColorMode from '../useColorMode';
 const Divider = forwardRef(({
   color,
   orientation = 'horizontal',
+  variant = 'solid',
   ...props
 }, ref) => {
   const [colorMode] = useColorMode();
@@ -17,10 +18,12 @@ const Divider = forwardRef(({
     vertical: {
       borderLeft: 1,
       borderLeftColor: dividerColor,
+      borderLeftStyle: variant,
     },
     horizontal: {
       borderBottom: 1,
       borderBottomColor: dividerColor,
+      borderBottomStyle: variant,
     },
   }[orientation];
 

--- a/packages/react-styled-ui/src/Divider/index.js
+++ b/packages/react-styled-ui/src/Divider/index.js
@@ -10,8 +10,8 @@ const Divider = forwardRef(({
 }, ref) => {
   const [colorMode] = useColorMode();
   const dividerColor = color || {
-    dark: 'gray:60',
-    light: 'gray:20',
+    dark: 'white:disabled',
+    light: 'black:disabled',
   }[colorMode];
 
   const borderProps = {

--- a/packages/styled-ui-docs/pages/divider.mdx
+++ b/packages/styled-ui-docs/pages/divider.mdx
@@ -21,15 +21,21 @@ The `Divider` renders a thin line vertically or horizontally.
 Pass the `orientation` prop and set it to either `horizontal` or `vertical`.
 
 ```jsx
-<Divider orientation="horizontal" />
+<Stack direction="column" spacing="6x">
+  <Divider variand="solid" orientation="horizontal" />
+  <Divider variant="dashed" orientation="horizontal" />
+  <Divider variant="dotted" orientation="horizontal" />
+</Stack>
 ```
 
 If the vertical orientation is used, make sure that the parent element is assigned a height.
 
 ```jsx
-<Flex height="12x">
-  <Divider orientation="vertical" />
-</Flex>
+<Stack direction="row" spacing="6x" height="12x">
+  <Divider variant="solid" orientation="vertical" />
+  <Divider variant="dashed" orientation="vertical" />
+  <Divider variant="dotted" orientation="vertical" />
+</Stack>
 ```
 
 ## Composition
@@ -48,5 +54,6 @@ If the vertical orientation is used, make sure that the parent element is assign
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| orientation | string | 'horizontal' | The orientation of the divider. Acceptable values: `'horizontal'`, `'vertical'` |
+| variant | string | 'solid' | The variant of the divider style to use. One of: `'solid'`, `'dashed'`, `'dotted'` |
+| orientation | string | 'horizontal' | The orientation of the divider. One of: `'horizontal'`, `'vertical'` |
 

--- a/packages/styled-ui-docs/pages/divider.mdx
+++ b/packages/styled-ui-docs/pages/divider.mdx
@@ -21,7 +21,7 @@ The `Divider` renders a thin line vertically or horizontally.
 Pass the `orientation` prop and set it to either `horizontal` or `vertical`.
 
 ```jsx
-<Stack direction="column" spacing="6x">
+<Stack direction="column" spacing="4x">
   <Divider variand="solid" orientation="horizontal" />
   <Divider variant="dashed" orientation="horizontal" />
   <Divider variant="dotted" orientation="horizontal" />
@@ -31,7 +31,7 @@ Pass the `orientation` prop and set it to either `horizontal` or `vertical`.
 If the vertical orientation is used, make sure that the parent element is assigned a height.
 
 ```jsx
-<Stack direction="row" spacing="6x" height="12x">
+<Stack direction="row" spacing="4x" height="12x">
   <Divider variant="solid" orientation="vertical" />
   <Divider variant="dashed" orientation="vertical" />
   <Divider variant="dotted" orientation="vertical" />


### PR DESCRIPTION
* Add a `variant` prop that accepts one of `solid`, `dashed`, and `dotted`
* Change the border color for both of dark and light modes