### PR TITLE
docs: update Tooltip examples and API props

### DIFF
--- a/packages/styled-ui-docs/pages/menu.mdx
+++ b/packages/styled-ui-docs/pages/menu.mdx
@@ -272,44 +272,44 @@ Add `skidding` or `distance` to customize menu offset position
 
 ### Menu Props
 
-| Name          | Type               | Default | Description                                                  |
-| ------------- | ------------------ | ------- | ------------------------------------------------------------ |
-| children      | React.ReactNode    |         | The children of the menu must be `MenuButton` or `MenuList`  |
-| isOpen        | boolean            |         | If `true`, the menu will be opened                           |
-| autoSelect    | boolean            | `false` | The menu will select the first enabled item when it opens, the trigger item must be `MenuButton`    |
-| closeOnBlur   | boolean            | `true`  | If `true`, the menu will close on outside click or blur      |
-| closeOnSelect | boolean            | `true`  | If `true`, the menu will close on menu item select           |
-| placement     | PopperJS.placement | `bottom-start` | The placement of the `MenuList`. One of: `'top'`, `'bottom'`, `'right'`, `'left'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`, `'right-start'`, `'right-end'`, `'left-start'`, `'left-end'`  |
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| children | ReactNode | | The children of the menu must be `MenuButton` or `MenuList` |
+| isOpen | boolean | | If `true`, the menu will be opened |
+| autoSelect | boolean | `false` | The menu will select the first enabled item when it opens, the trigger item must be `MenuButton` |
+| closeOnBlur | boolean | `true` | If `true`, the menu will close on outside click or blur |
+| closeOnSelect | boolean | `true` | If `true`, the menu will close on menu item select |
+| placement | PopperJS.placement | `bottom-start` | The placement of the `MenuList`. One of: `'top'`, `'bottom'`, `'right'`, `'left'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`, `'right-start'`, `'right-end'`, `'left-start'`, `'left-end'` |
 
 ### MenuButton Props
 
-| Name      | Type                       |
-| --------- | -------------------------- |
-| children  | React.ReactNode            |
-| onClick   | React.MouseEventHandler    |
+| Name | Type |
+| :--- | :--- |
+| children | ReactNode |
+| onClick | React.MouseEventHandler |
 | onKeyDown | React.KeyboardEventHandler |
 
 ### MenuList Props
 
-| Name      | Type                    | Default        | Description                                                       |
-| --------- | ----------------------- | -------------- | ----------------------------------------------------------------- |
-| children  | React.ReactNode         |                | The content of the `MenuList`, should be the `MenuItem` component |
-| onClick   | React.MouseEventHandler |                | Function to be called when you click on the menu item             |
-| onBlur    | React.FocusEventHandler |                | Function to be called when you blur out of the menu list          |
-| skidding  | number                  | `0`            | Displaces the menu (in pixels) along the reference element. Used by [`popper.js`](https://popper.js.org/docs/v2/modifiers/offset/#skidding-1)          |
-| distance  | number                  | `0`            | Displaces the menu (in pixels) away from, or toward, the reference. Used by [`popper.js`](https://popper.js.org/docs/v2/modifiers/offset/#distance-1)  |
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| children | ReactNode | | The content of the `MenuList`, should be the `MenuItem` component |
+| onClick | React.MouseEventHandler | | Function to be called when you click on the menu item |
+| onBlur | React.FocusEventHandler | | Function to be called when you blur out of the menu list |
+| skidding | number | `0` | Displaces the menu (in pixels) along the reference element. Used by [`popper.js`](https://popper.js.org/docs/v2/modifiers/offset/#skidding-1) |
+| distance | number | `0` | Displaces the menu (in pixels) away from, or toward, the reference. Used by [`popper.js`](https://popper.js.org/docs/v2/modifiers/offset/#distance-1) |
 
 ### MenuItem Props
 
-| Name       | Type                                          | Description                                               |
-| ---------- | --------------------------------------------- | --------------------------------------------------------- |
-| disabled   | boolean                                       | If `true`, the menu item will be disabled                 |
-| onClick    | React.MouseEventHandler                       | Function that is called on click and enter/space keypress |
-| onKeyDown  | React.KeyboardEventHander                     | Function that is called on keydown                        |
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| disabled | boolean | If `true`, the menu item will be disabled |
+| onClick | React.MouseEventHandler | Function that is called on click and enter/space keypress |
+| onKeyDown | React.KeyboardEventHander | Function that is called on keydown |
 
 ### MenuGroup Props
 
-| Name     | Type            | Description                   |
-| -------- | --------------- | ----------------------------- |
-| children | React.ReactNode | The content of the menu group, should be the `MenuItem` component |
-| title    | string          | The title of the menu group   |
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| children | ReactNode | The content of the menu group, should be the `MenuItem` component |
+| title | string | The title of the menu group |

--- a/packages/styled-ui-docs/pages/popover.mdx
+++ b/packages/styled-ui-docs/pages/popover.mdx
@@ -413,7 +413,7 @@ The word _"trigger"_ refers to the children of PopoverTrigger.
 | returnFocusOnClose | boolean | true | If `true`, the popover will return the focus status to the trigger when closing. |
 | closeOnBlur | boolean | true | If `true`, the popover will close when you use the tab key or click outside the popover dialog. |
 | closeOnEsc | boolean | true | If `true`, the popover will close when you press the `esc` key. |
-| children | React.ReactNode, (props: InternalState) => React.ReactNode | | The children of the popover. |
+| children | ReactNode, (props: InternalState) => ReactNode | | The children of the popover. |
 | hideArrow | boolean | | If `true`, hide the arrow tip on the popover. |
 | skidding | number | 0 | Displaces the popover (in pixels) along the reference element. Used by [`popper.js`](https://popper.js.org/docs/v2/modifiers/offset/#skidding-1) |
 | distance | number | 4 | Displaces the popover (in pixels) away from, or toward, the reference. Used by [`popper.js`](https://popper.js.org/docs/v2/modifiers/offset/#distance-1) |

--- a/packages/styled-ui-docs/pages/tabs.mdx
+++ b/packages/styled-ui-docs/pages/tabs.mdx
@@ -427,7 +427,7 @@ function Example() {
 ### Keyboard
 
 | Key                | Action                                                                     |
-| ------------------ | -------------------------------------------------------------------------- |
+| :----------------- | :------------------------------------------------------------------------- |
 | `ArrowLeft`        | Moves focus to the next tab                                                |
 | `ArrowUp`          | Moves focus to the previous tab                                            |
 | `Tab`              | When focus moves into the tab list, places focus on the active tab element |
@@ -438,7 +438,7 @@ function Example() {
 ### ARIA roles
 
 | Component | Aria               | Usage                                                                       |
-| --------- | ------------------ | --------------------------------------------------------------------------- |
+| :-------- | :----------------- | :-------------------------------------------------------------------------- |
 | Tab       | `role="tab"`       | Indicates that it's a tab                                                   |
 |           | `aria-selected`    | Set to `true` a tab is selected and all other Tabs have it set to `false`.  |
 |           | `aria-controls`    | Set to the `id` of its associated `TabPanel`                                |
@@ -453,27 +453,27 @@ function Example() {
 
 Tabs composes `Box` so you call pass all `Box` related props.
 
-| Name           | Type                                                                              | Default      | Description                                                                                                                     |
-| -------------- | --------------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `onChange`     | `(index: number) => void`                                                         |              | The callback to update the active tab index.                                                                                    |
-| `index`        | `number`                                                                          |              | The controlled index of the tabs.                                                                                               |
-| `defaultIndex` | `number`                                                                          |              | The index of the initial active tab.                                                                                            |
-| `activateOnKeypress`     | `boolean`                                                               |              | If `true`, keyboard navigation changes focus between tabs but doens't activate it. User will have to press `Enter` or `Space` to active it. This is deprecated and will be removed in the v1 release |
-| `isManual`     | `boolean`                                                                         |              | If `true`, keyboard navigation changes focus between tabs but doens't activate it. User will have to press `Enter` or `Space` to active it |
-| `children`     | `React.ReactNode`                                                                 |              | The children of the switch.                                                                                                     |
-| `variant`      | `line`,`enclosed`, `unstyled`                                                     | `line`       | The visual style of the tab.                                                                                                    |
-| `orientation`  | `horizontal`, `vertical`                                                          | `horizontal` | The orientation of the tabs                                                                                                     |
-| `isFitted`     | `boolean`                                                                         |              | If `true`, the tabs will stretch to fill the available space                                                                    |
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| `onChange` | `(index: number) => void` | | The callback to update the active tab index. |
+| `index` | `number` | | The controlled index of the tabs. |
+| `defaultIndex` | `number` | | The index of the initial active tab. |
+| `activateOnKeypress` | `boolean` | | If `true`, keyboard navigation changes focus between tabs but doens't activate it. User will have to press `Enter` or `Space` to active it. This is deprecated and will be removed in the v1 release |
+| `isManual` | `boolean` | | If `true`, keyboard navigation changes focus between tabs but doens't activate it. User will have to press `Enter` or `Space` to active it |
+| `children` | `ReactNode` | | The children of the switch. |
+| `variant` | `line`,`enclosed`, `unstyled` | `line` | The visual style of the tab. |
+| `orientation` | `horizontal`, `vertical` | `horizontal` | The orientation of the tabs |
+| `isFitted` | `boolean` | | If `true`, the tabs will stretch to fill the available space |
 
 ### Tab Props
 
-| Name         | Type      | Default | Description                         |
-| ------------ | --------- | ------- | ----------------------------------- |
-| `disabled`   | `boolean` |         | If `true`, the user cannot interact with the control. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| `disabled` | `boolean` | | If `true`, the user cannot interact with the control. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
 
 
 ### TabPanel Props
 
-| Name         | Type      | Default | Description                         |
-| ------------ | --------- | ------- | ----------------------------------- |
-| children | React.ReactNode, (props: InternalState) => React.ReactNode | | The children of the `TabPanel`. |
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| children | ReactNode, (props: InternalState) => ReactNode | | The children of the `TabPanel`. |

--- a/packages/styled-ui-docs/pages/toggleswitch.mdx
+++ b/packages/styled-ui-docs/pages/toggleswitch.mdx
@@ -47,15 +47,15 @@ Pass the `size` prop to change the size of the `ToggleSwitch`.
 
 ## Props
 
-| Name               | Type                | Default | Description                                          |
-| ------------------ | ------------------- | ------- | ---------------------------------------------------- |
-| `size`             | `sm`, `md`, `lg`    |  `md`   | The size of the switch.                              |
-| `variantColor`     | `string`            |  blue   | The background color of the switch when checked.     |
-| `name`             | `string`            |         | The input name of the switch when used in a form.    |
-| `value`            | `string`, `boolean` |         | The value of the switch.                             |
-| `children`         | `React.ReactNode`   |         | The children of the switch.                          |
-| `aria-label`       | `string`            |         | The aria-label of the switch for accessibility.      |
-| `aria-labelledby`  | `string`            |         | The aria-labelledby of the switch for accessibility. |
-| `checked`          | `boolean`           |         | If `true`, set the switch to the checked state.      |
-| `defaultChecked`   | `boolean`           |         | If `true`, the checkbox will be initially checked.   |
-| `disabled`         | `boolean`           |         | If `true`, set the disabled to the invalid state.    |
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| size | string | 'md' | The size of the switch. One of: `'sm'`, `'md'`, `'lg'`|
+| variantColor | string | blue | The background color of the switch when checked. |
+| name | string | | The input name of the switch when used in a form. |
+| value | string \| boolean | | The value of the switch. |
+| children | ReactNode | | The children of the switch. |
+| aria-label | string | | The aria-label of the switch for accessibility. |
+| aria-labelledby | string | | The aria-labelledby of the switch for accessibility. |
+| checked | boolean | | If `true`, set the switch to the checked state. |
+| defaultChecked | boolean | | If `true`, the checkbox will be initially checked. |
+| disabled | boolean | | If `true`, set the disabled to the invalid state. |

--- a/packages/styled-ui-docs/pages/tooltip.mdx
+++ b/packages/styled-ui-docs/pages/tooltip.mdx
@@ -44,6 +44,28 @@ If the children of Tooltip are focusable elements, Tooltip will show when you fo
 </Tooltip>
 ```
 
+### Customized tooltips
+
+```jsx
+<Tooltip
+  hideArrow
+  backgroundColor="gray:90"
+  color="white"
+  p="4x"
+  placement="right"
+  width="auto"
+  label={
+    <Stack direction="column">
+      <Text fontSize="lg" lineHeight="lg">Tooltip with HTML</Text>
+      <Box><em>{"And here's"}</em> <b>{'some'}</b> <u>{'amazing content'}</u>.{' '}</Box>
+      <Text>{"It's very engaging. Right?"}</Text>
+    </Stack>
+  }
+>
+  <Button variant="ghost">HTML</Button>
+</Tooltip>
+```
+
 ### Tooltip with `Menu`
 
 ```jsx

--- a/packages/styled-ui-docs/pages/tooltip.mdx
+++ b/packages/styled-ui-docs/pages/tooltip.mdx
@@ -172,7 +172,7 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 | :--- | :--- | :------ | :---------- |
 | isOpen | boolean | | If `true`, the tooltip is shown. |
 | defaultIsOpen | boolean | | If `true`, the tooltip is shown initially. |
-| label | string | | The label of the tooltip.|
+| label | string \| ReactNode | | The label of the tooltip.|
 | aria-label | string | | An alternate label for screen readers. |
 | placement | PopperJS.Placement | 'bottom' | Position the tooltip relative to the trigger element as well as surrounding elements. Possible values: `'top'`, `'bottom'`, `'right'`, `'left'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`, `'right-start'`, `'right-end'`, `'left-start'`, `'left-end'` |
 | children | ReactNode | | The `ReactNode` element to be used as the trigger of the tooltip. |


### PR DESCRIPTION
Related to #310 

* the label prop should accept either a string or ReactNode
* add customized tooltip example
![image](https://user-images.githubusercontent.com/447801/120627401-38157180-c496-11eb-8ca4-8d9a58e4d1c7.png)
