### PR TITLE
feat: add LinkButton component

### DIFF
--- a/packages/react-styled-ui/src/LinkButton/index.js
+++ b/packages/react-styled-ui/src/LinkButton/index.js
@@ -1,0 +1,17 @@
+import React, { forwardRef } from 'react';
+import ButtonBase from '../ButtonBase';
+import Link from '../Link';
+
+const LinkButton = forwardRef((props, ref) => {
+  return (
+    <Link
+      as={ButtonBase}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+LinkButton.displayName = 'LinkButton';
+
+export default LinkButton;

--- a/packages/react-styled-ui/src/index.js
+++ b/packages/react-styled-ui/src/index.js
@@ -27,6 +27,7 @@ import InputGroupAppend from './InputGroupAppend';
 import InputGroupPrepend from './InputGroupPrepend';
 import LightMode from './LightMode';
 import Link from './Link';
+import LinkButton from './LinkButton';
 import MenuButton from './MenuButton';
 import Pagination from './Pagination';
 import PseudoBox from './PseudoBox';
@@ -88,6 +89,7 @@ export {
   InputGroupPrepend,
   LightMode,
   Link,
+  LinkButton,
   MenuButton,
   Pagination,
   PseudoBox,

--- a/packages/styled-ui-docs/components/nav-links.js
+++ b/packages/styled-ui-docs/components/nav-links.js
@@ -38,6 +38,7 @@ export const componentLinks = [
   'InputBase',
   'InputGroup',
   'Link',
+  'LinkButton',
   'Menu',
   'Modal',
   'Pagination',

--- a/packages/styled-ui-docs/pages/linkbutton.mdx
+++ b/packages/styled-ui-docs/pages/linkbutton.mdx
@@ -1,0 +1,46 @@
+# LinkButton
+
+This component provides an element resembling an anchor that purely acts as a click target with no navigation as result. It can also be used inline in text.
+
+## Import
+
+```js
+import { LinkButton } from '@trendmicro/react-styled-ui';
+```
+
+## Usage
+
+```jsx
+function Example() {
+  const [timeLeft, setTimeLeft] = React.useState(180);
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      if (timeLeft > 0) {
+        setTimeLeft(timeLeft - 1);
+      }
+    }, 1000);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [timeLeft]);
+  const handleClick = () => {
+    setTimeLeft(180);
+  };
+
+  return (
+    <Text>
+      If the email does not arrive in your inbox or spam folder, <LinkButton onClick={handleClick}>click here to resend ({timeLeft}s)</LinkButton>.
+    </Text>
+  );
+}
+```
+
+## Props
+
+A `LinkButton` element is composed of the [`ButtonBase`](./buttonbase) component.
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| disabled | boolean | | If `true`, the link button will be disabled. This sets `aria-disabled=true` and you can style this state by using the `_disabled` prop. |
+| onClick | function | | A callback called when the link button is clicked. |


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/styled-ui-demo/pr-330/linkbutton

# LinkButton

This component provides an element resembling an anchor that purely acts as a click target with no navigation as result. It can also be used inline in text.

## Import

```js
import { LinkButton } from '@trendmicro/react-styled-ui';
```

## Usage

```jsx
function Example() {
  const [timeLeft, setTimeLeft] = React.useState(180);
  React.useEffect(() => {
    const timer = setTimeout(() => {
      if (timeLeft > 0) {
        setTimeLeft(timeLeft - 1);
      }
    }, 1000);

    return () => {
      clearTimeout(timer);
    };
  }, [timeLeft]);
  const handleClick = () => {
    setTimeLeft(180);
  };

  return (
    <Text>
      If the email does not arrive in your inbox or spam folder, <LinkButton onClick={handleClick}>click here to resend ({timeLeft}s)</LinkButton>.
    </Text>
  );
}
```

## Props

A `LinkButton` element is composed of the [`ButtonBase`](./buttonbase) component.

| Name | Type | Default | Description |
| :--- | :--- | :------ | :---------- |
| disabled | boolean | | If `true`, the link button will be disabled. This sets `aria-disabled=true` and you can style this state by using the `_disabled` prop. |
| onClick | function | | A callback called when the link button is clicked. |