### PR TITLE
fix: remove unwanted border radius corner around the input when using an input group

### DIFF
--- a/packages/react-styled-ui/src/Input/styles.js
+++ b/packages/react-styled-ui/src/Input/styles.js
@@ -172,7 +172,7 @@ const getInputGroupCSS = ({
   const useNegativeMargin = (variant === 'outline' || variant === 'filled');
 
   return {
-    '&:not(:first-of-type)': {
+    '&:not(:first-child)': {
       borderTopLeftRadius: 0,
       borderBottomLeftRadius: 0,
     },


### PR DESCRIPTION
https://trendmicro-frontend.github.io/styled-ui-demo/pr-331/inputgroup

### Before
![image](https://user-images.githubusercontent.com/447801/125260456-ee406680-e332-11eb-8dd4-7e6f8d821098.png)

### After
![image](https://user-images.githubusercontent.com/447801/125260222-b20d0600-e332-11eb-9e9d-7d1a314cdf8d.png)