### PR TITLE
feat: add a variant prop to the Alert component that provides different variants to be chosen

### DIFF
--- a/packages/react-styled-ui/src/Alert/index.js
+++ b/packages/react-styled-ui/src/Alert/index.js
@@ -5,7 +5,7 @@ import Flex from '../Flex';
 import Icon from '../Icon';
 import Space from '../Space';
 import {
-  useAlertRootStyle,
+  useAlertStyle,
   useAlertIconStyle,
   useAlertMessageStyle,
   useAlertCloseButtonStyle,
@@ -55,8 +55,8 @@ const Alert = forwardRef((
   },
   ref,
 ) => {
-  const rootStyleProps = useAlertRootStyle({ variant, severity });
-  const iconStyleProps = useAlertIconStyle();
+  const styleProps = useAlertStyle({ variant, severity });
+  const iconStyleProps = useAlertIconStyle({ variant, severity });
   const messageStyleProps = useAlertMessageStyle();
   const closeButtonStyleProps = useAlertCloseButtonStyle({ variant });
 
@@ -72,7 +72,7 @@ const Alert = forwardRef((
       ref={ref}
       align="flex-start"
       justify="space-between"
-      {...rootStyleProps}
+      {...styleProps}
       {...rest}
     >
       {!!icon && (

--- a/packages/react-styled-ui/src/Alert/index.js
+++ b/packages/react-styled-ui/src/Alert/index.js
@@ -11,6 +11,7 @@ import {
   useAlertCloseButtonStyle,
 } from './styles';
 
+const defaultVariant = 'solid';
 const defaultSeverity = 'success';
 
 const getIconBySeverity = (severity) => {
@@ -46,6 +47,7 @@ const Alert = forwardRef((
   {
     isCloseButtonVisible,
     onClose,
+    variant = defaultVariant,
     severity = defaultSeverity,
     icon,
     children,
@@ -53,10 +55,10 @@ const Alert = forwardRef((
   },
   ref,
 ) => {
-  const rootStyleProps = useAlertRootStyle({ severity });
-  const iconStyleProps = useAlertIconStyle({ severity });
+  const rootStyleProps = useAlertRootStyle({ variant, severity });
+  const iconStyleProps = useAlertIconStyle();
   const messageStyleProps = useAlertMessageStyle();
-  const closeButtonStyleProps = useAlertCloseButtonStyle();
+  const closeButtonStyleProps = useAlertCloseButtonStyle({ variant });
 
   if (typeof icon === 'string') {
     icon = (<Icon icon={icon} />);

--- a/packages/react-styled-ui/src/Alert/styles.js
+++ b/packages/react-styled-ui/src/Alert/styles.js
@@ -190,8 +190,8 @@ const getOutlineSuccessIconStyle = ({
   colorMode,
 }) => {
   const color = {
-    dark: 'green:50',
-    light: 'green:50',
+    dark: 'green:40',
+    light: 'green:40',
   }[colorMode];
 
   return {
@@ -203,8 +203,8 @@ const getOutlineInfoIconStyle = ({
   colorMode,
 }) => {
   const color = {
-    dark: 'blue:40',
-    light: 'blue:40',
+    dark: 'blue:50',
+    light: 'blue:50',
   }[colorMode];
 
   return {
@@ -229,8 +229,8 @@ const getOutlineErrorIconStyle = ({
   colorMode,
 }) => {
   const color = {
-    dark: 'red:40',
-    light: 'red:40',
+    dark: 'red:50',
+    light: 'red:50',
   }[colorMode];
 
   return {

--- a/packages/react-styled-ui/src/Alert/styles.js
+++ b/packages/react-styled-ui/src/Alert/styles.js
@@ -7,7 +7,7 @@ const baseProps = {
   py: '2x',
 };
 
-const getSuccessStyle = ({
+const getSolidSuccessStyle = ({
   colorMode,
 }) => {
   const backgroundColor = {
@@ -22,7 +22,7 @@ const getSuccessStyle = ({
   };
 };
 
-const getInfoStyle = ({
+const getSolidInfoStyle = ({
   colorMode,
 }) => {
   const backgroundColor = {
@@ -37,7 +37,7 @@ const getInfoStyle = ({
   };
 };
 
-const getWarningStyle = ({
+const getSolidWarningStyle = ({
   colorMode,
 }) => {
   const backgroundColor = {
@@ -52,7 +52,7 @@ const getWarningStyle = ({
   };
 };
 
-const getErrorStyle = ({
+const getSolidErrorStyle = ({
   colorMode,
 }) => {
   const backgroundColor = {
@@ -67,45 +67,145 @@ const getErrorStyle = ({
   };
 };
 
-const getSeverityProps = ({ severity, ...props }) => {
+const getSolidVariantProps = props => {
+  const { severity, colorMode } = props;
+
   if (severity === 'success') {
-    return getSuccessStyle(props);
+    return getSolidSuccessStyle({ colorMode });
   }
 
   if (severity === 'info') {
-    return getInfoStyle(props);
+    return getSolidInfoStyle({ colorMode });
   }
 
   if (severity === 'warning') {
-    return getWarningStyle(props);
+    return getSolidWarningStyle({ colorMode });
   }
 
   if (severity === 'error') {
-    return getErrorStyle(props);
+    return getSolidErrorStyle({ colorMode });
   }
 
   return {};
 };
 
+// FIXME
+const getOutlineSuccessStyle = ({
+  colorMode,
+}) => {
+  const backgroundColor = {
+    dark: 'green:50',
+    light: 'green:50',
+  }[colorMode];
+  const color = 'black:primary';
+
+  return {
+    backgroundColor,
+    color,
+  };
+};
+
+// FIXME
+const getOutlineInfoStyle = ({
+  colorMode,
+}) => {
+  const backgroundColor = {
+    dark: 'blue:40',
+    light: 'blue:40',
+  }[colorMode];
+  const color = 'black:primary';
+
+  return {
+    backgroundColor,
+    color,
+  };
+};
+
+// FIXME
+const getOutlineWarningStyle = ({
+  colorMode,
+}) => {
+  const backgroundColor = {
+    dark: 'yellow:50',
+    light: 'yellow:50',
+  }[colorMode];
+  const color = 'black:primary';
+
+  return {
+    backgroundColor,
+    color,
+  };
+};
+
+// FIXME
+const getOutlineErrorStyle = ({
+  colorMode,
+}) => {
+  const backgroundColor = {
+    dark: 'red:40',
+    light: 'red:40',
+  }[colorMode];
+  const color = 'black:primary';
+
+  return {
+    backgroundColor,
+    color,
+  };
+};
+
+const getOutlineVariantProps = props => {
+  const { severity, colorMode } = props;
+
+  if (severity === 'success') {
+    return getOutlineSuccessStyle({ colorMode });
+  }
+
+  if (severity === 'info') {
+    return getOutlineInfoStyle({ colorMode });
+  }
+
+  if (severity === 'warning') {
+    return getOutlineWarningStyle({ colorMode });
+  }
+
+  if (severity === 'error') {
+    return getOutlineErrorStyle({ colorMode });
+  }
+
+  return {};
+};
+
+const getVariantProps = props => {
+  const { variant } = props;
+
+  switch (variant) {
+  case 'solid':
+    return getSolidVariantProps(props);
+  case 'outline':
+    return getOutlineVariantProps(props);
+  default:
+    return {};
+  }
+};
+
 const useAlertRootStyle = ({
+  variant,
   severity,
 }) => {
   const [colorMode] = useColorMode();
   const _props = {
-    colorMode,
+    variant,
     severity,
+    colorMode,
   };
-  const severityProps = getSeverityProps(_props);
 
   return {
     ...baseProps,
-    ...severityProps,
+    ...getVariantProps(_props),
   };
 };
 
-const useAlertIconStyle = ({
-  severity,
-}) => {
+const useAlertIconStyle = () => {
   return {
     py: '1x',
     lineHeight: 1, // exactly the same height as the icon's height
@@ -120,9 +220,10 @@ const useAlertMessageStyle = () => {
   };
 };
 
-const useAlertCloseButtonStyle = () => {
-  const [colorMode] = useColorMode();
-  const { colors } = useTheme();
+const getSolidCloseButtonStyle = ({
+  colorMode,
+  colors,
+}) => {
   const color = {
     dark: 'black:tertiary',
     light: 'black:tertiary',
@@ -171,6 +272,78 @@ const useAlertCloseButtonStyle = () => {
       color: focusActiveColor,
     },
   };
+};
+
+// FIXME
+const getOutlineCloseButtonStyle = ({
+  colorMode,
+  colors,
+}) => {
+  const color = {
+    dark: 'black:tertiary',
+    light: 'black:tertiary',
+  }[colorMode];
+  const hoverColor = {
+    dark: 'black:primary',
+    light: 'black:primary',
+  }[colorMode];
+  const activeColor = color;
+  const focusColor = color;
+  const focusHoverColor = hoverColor;
+  const focusActiveColor = activeColor;
+  const focusBorderColor = get(colors, 'blue:60');
+
+  return {
+    border: 1,
+    borderColor: 'transparent',
+    color: color,
+    transition: 'all .2s',
+    lineHeight: 1,
+    height: '8x',
+    width: '8x',
+    minWidth: '8x', // ensure a minimum width for the close button
+    mt: -4,
+    mb: -4,
+    mr: -8,
+    px: 0,
+    py: 0,
+    _hover: {
+      color: hoverColor,
+    },
+    _active: {
+      color: activeColor,
+    },
+    _focus: {
+      borderColor: focusBorderColor,
+      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
+      color: focusColor,
+    },
+    _focusHover: {
+      color: focusHoverColor,
+    },
+    _focusActive: {
+      borderColor: focusBorderColor,
+      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
+      color: focusActiveColor,
+    },
+  };
+};
+
+const useAlertCloseButtonStyle = ({
+  variant,
+}) => {
+  const [colorMode] = useColorMode();
+  const { colors } = useTheme();
+
+  if (variant === 'solid') {
+    return getSolidCloseButtonStyle({ colorMode, colors });
+  }
+
+  if (variant === 'outline') {
+    return getOutlineCloseButtonStyle({ colorMode, colors });
+  }
+
+  return {};
 };
 
 export {

--- a/packages/react-styled-ui/src/Alert/styles.js
+++ b/packages/react-styled-ui/src/Alert/styles.js
@@ -2,11 +2,6 @@ import { get } from '@styled-system/core';
 import useColorMode from '../useColorMode';
 import useTheme from '../useTheme';
 
-const baseProps = {
-  px: '4x',
-  py: '2x',
-};
-
 const getSolidSuccessStyle = ({
   colorMode,
 }) => {
@@ -67,7 +62,183 @@ const getSolidErrorStyle = ({
   };
 };
 
-const getSolidVariantProps = props => {
+const getOutlineSuccessStyle = ({
+  colorMode,
+}) => {
+  const borderColor = {
+    dark: 'green:50',
+    light: 'green:50',
+  }[colorMode];
+  const color = {
+    dark: 'white:primary',
+    light: 'black:primary',
+  }[colorMode];
+
+  return {
+    borderColor,
+    color,
+  };
+};
+
+const getOutlineInfoStyle = ({
+  colorMode,
+}) => {
+  const borderColor = {
+    dark: 'blue:40',
+    light: 'blue:40',
+  }[colorMode];
+  const color = {
+    dark: 'white:primary',
+    light: 'black:primary',
+  }[colorMode];
+
+  return {
+    borderColor,
+    color,
+  };
+};
+
+const getOutlineWarningStyle = ({
+  colorMode,
+}) => {
+  const borderColor = {
+    dark: 'yellow:50',
+    light: 'yellow:50',
+  }[colorMode];
+  const color = {
+    dark: 'white:primary',
+    light: 'black:primary',
+  }[colorMode];
+
+  return {
+    borderColor,
+    color,
+  };
+};
+
+const getOutlineErrorStyle = ({
+  colorMode,
+}) => {
+  const borderColor = {
+    dark: 'red:40',
+    light: 'red:40',
+  }[colorMode];
+  const color = {
+    dark: 'white:primary',
+    light: 'black:primary',
+  }[colorMode];
+
+  return {
+    borderColor,
+    color,
+  };
+};
+
+const getSolidSuccessIconStyle = ({
+  colorMode,
+}) => {
+  const color = {
+    dark: 'black:primary',
+    light: 'black:primary',
+  }[colorMode];
+
+  return {
+    color,
+  };
+};
+
+const getSolidInfoIconStyle = ({
+  colorMode,
+}) => {
+  const color = {
+    dark: 'black:primary',
+    light: 'black:primary',
+  }[colorMode];
+
+  return {
+    color,
+  };
+};
+
+const getSolidWarningIconStyle = ({
+  colorMode,
+}) => {
+  const color = {
+    dark: 'black:primary',
+    light: 'black:primary',
+  }[colorMode];
+
+  return {
+    color,
+  };
+};
+
+const getSolidErrorIconStyle = ({
+  colorMode,
+}) => {
+  const color = {
+    dark: 'black:primary',
+    light: 'black:primary',
+  }[colorMode];
+
+  return {
+    color,
+  };
+};
+
+const getOutlineSuccessIconStyle = ({
+  colorMode,
+}) => {
+  const color = {
+    dark: 'green:50',
+    light: 'green:50',
+  }[colorMode];
+
+  return {
+    color,
+  };
+};
+
+const getOutlineInfoIconStyle = ({
+  colorMode,
+}) => {
+  const color = {
+    dark: 'blue:40',
+    light: 'blue:40',
+  }[colorMode];
+
+  return {
+    color,
+  };
+};
+
+const getOutlineWarningIconStyle = ({
+  colorMode,
+}) => {
+  const color = {
+    dark: 'yellow:50',
+    light: 'yellow:50',
+  }[colorMode];
+
+  return {
+    color,
+  };
+};
+
+const getOutlineErrorIconStyle = ({
+  colorMode,
+}) => {
+  const color = {
+    dark: 'red:40',
+    light: 'red:40',
+  }[colorMode];
+
+  return {
+    color,
+  };
+};
+
+const getSolidStyle = props => {
   const { severity, colorMode } = props;
 
   if (severity === 'success') {
@@ -89,71 +260,7 @@ const getSolidVariantProps = props => {
   return {};
 };
 
-// FIXME
-const getOutlineSuccessStyle = ({
-  colorMode,
-}) => {
-  const backgroundColor = {
-    dark: 'green:50',
-    light: 'green:50',
-  }[colorMode];
-  const color = 'black:primary';
-
-  return {
-    backgroundColor,
-    color,
-  };
-};
-
-// FIXME
-const getOutlineInfoStyle = ({
-  colorMode,
-}) => {
-  const backgroundColor = {
-    dark: 'blue:40',
-    light: 'blue:40',
-  }[colorMode];
-  const color = 'black:primary';
-
-  return {
-    backgroundColor,
-    color,
-  };
-};
-
-// FIXME
-const getOutlineWarningStyle = ({
-  colorMode,
-}) => {
-  const backgroundColor = {
-    dark: 'yellow:50',
-    light: 'yellow:50',
-  }[colorMode];
-  const color = 'black:primary';
-
-  return {
-    backgroundColor,
-    color,
-  };
-};
-
-// FIXME
-const getOutlineErrorStyle = ({
-  colorMode,
-}) => {
-  const backgroundColor = {
-    dark: 'red:40',
-    light: 'red:40',
-  }[colorMode];
-  const color = 'black:primary';
-
-  return {
-    backgroundColor,
-    color,
-  };
-};
-
-const getOutlineVariantProps = props => {
+const getOutlineStyle = props => {
   const { severity, colorMode } = props;
 
   if (severity === 'success') {
@@ -175,54 +282,136 @@ const getOutlineVariantProps = props => {
   return {};
 };
 
-const getVariantProps = props => {
-  const { variant } = props;
+const useAlertStyle = ({
+  variant,
+  severity,
+}) => {
+  const [colorMode] = useColorMode();
+  const { sizes } = useTheme();
+  const _props = {
+    severity,
+    colorMode,
+  };
+  const borderWidth = sizes['1q'];
+  const px = sizes['4x'];
+  const py = `calc(${sizes['2x']} - ${borderWidth})`;
+  const baseStyle = {
+    borderColor: 'transparent',
+    borderStyle: 'solid',
+    borderWidth,
+    px,
+    py,
+  };
 
-  switch (variant) {
-  case 'solid':
-    return getSolidVariantProps(props);
-  case 'outline':
-    return getOutlineVariantProps(props);
-  default:
-    return {};
+  if (variant === 'solid') {
+    return {
+      ...baseStyle,
+      ...getSolidStyle(_props),
+    };
   }
+
+  if (variant === 'outline') {
+    return {
+      ...baseStyle,
+      ...getOutlineStyle(_props),
+    };
+  }
+
+  return {
+    ...baseStyle,
+  };
 };
 
-const useAlertRootStyle = ({
+const getSolidIconStyle = props => {
+  const { severity, colorMode } = props;
+
+  if (severity === 'success') {
+    return getSolidSuccessIconStyle({ colorMode });
+  }
+
+  if (severity === 'info') {
+    return getSolidInfoIconStyle({ colorMode });
+  }
+
+  if (severity === 'warning') {
+    return getSolidWarningIconStyle({ colorMode });
+  }
+
+  if (severity === 'error') {
+    return getSolidErrorIconStyle({ colorMode });
+  }
+
+  return {};
+};
+
+const getOutlineIconStyle = props => {
+  const { severity, colorMode } = props;
+
+  if (severity === 'success') {
+    return getOutlineSuccessIconStyle({ colorMode });
+  }
+
+  if (severity === 'info') {
+    return getOutlineInfoIconStyle({ colorMode });
+  }
+
+  if (severity === 'warning') {
+    return getOutlineWarningIconStyle({ colorMode });
+  }
+
+  if (severity === 'error') {
+    return getOutlineErrorIconStyle({ colorMode });
+  }
+
+  return {};
+};
+
+const useAlertIconStyle = ({
   variant,
   severity,
 }) => {
   const [colorMode] = useColorMode();
   const _props = {
-    variant,
     severity,
     colorMode,
   };
-
-  return {
-    ...baseProps,
-    ...getVariantProps(_props),
-  };
-};
-
-const useAlertIconStyle = () => {
-  return {
+  const iconStyle = {
     py: '1x',
     lineHeight: 1, // exactly the same height as the icon's height
+  };
+
+  if (variant === 'solid') {
+    return {
+      ...iconStyle,
+      ...getSolidIconStyle(_props),
+    };
+  }
+
+  if (variant === 'outline') {
+    return {
+      ...iconStyle,
+      ...getOutlineIconStyle(_props),
+    };
+  }
+
+  return {
+    ...iconStyle,
   };
 };
 
 const useAlertMessageStyle = () => {
+  const theme = useTheme();
+
   return {
-    py: 2,
-    mt: -1,
+    py: theme?.sizes['1h'],
+    mt: theme?.sizes['-1q'],
     width: '100%',
   };
 };
 
 const getSolidCloseButtonStyle = ({
   colorMode,
-  colors,
+  theme,
 }) => {
   const color = {
     dark: 'black:tertiary',
@@ -236,20 +425,21 @@ const getSolidCloseButtonStyle = ({
   const focusColor = color;
   const focusHoverColor = hoverColor;
   const focusActiveColor = activeColor;
-  const focusBorderColor = get(colors, 'blue:60');
+  const focusBorderColor = get(theme?.colors, 'blue:60');
 
   return {
-    border: 1,
     borderColor: 'transparent',
-    color: color,
+    borderStyle: 'solid',
+    borderWidth: theme?.sizes['1q'],
+    color,
     transition: 'all .2s',
     lineHeight: 1,
     height: '8x',
     width: '8x',
     minWidth: '8x', // ensure a minimum width for the close button
-    mt: -4,
-    mb: -4,
-    mr: -8,
+    mt: '-1x',
+    mb: '-1x',
+    mr: '-2x',
     px: 0,
     py: 0,
     _hover: {
@@ -274,37 +464,37 @@ const getSolidCloseButtonStyle = ({
   };
 };
 
-// FIXME
 const getOutlineCloseButtonStyle = ({
   colorMode,
-  colors,
+  theme,
 }) => {
   const color = {
-    dark: 'black:tertiary',
+    dark: 'white:tertiary',
     light: 'black:tertiary',
   }[colorMode];
   const hoverColor = {
-    dark: 'black:primary',
+    dark: 'white:emphasis',
     light: 'black:primary',
   }[colorMode];
   const activeColor = color;
   const focusColor = color;
   const focusHoverColor = hoverColor;
   const focusActiveColor = activeColor;
-  const focusBorderColor = get(colors, 'blue:60');
+  const focusBorderColor = get(theme?.colors, 'blue:60');
 
   return {
-    border: 1,
     borderColor: 'transparent',
-    color: color,
+    borderStyle: 'solid',
+    borderWidth: theme?.sizes['1q'],
+    color,
     transition: 'all .2s',
     lineHeight: 1,
     height: '8x',
     width: '8x',
     minWidth: '8x', // ensure a minimum width for the close button
-    mt: -4,
-    mb: -4,
-    mr: -8,
+    mt: '-1x',
+    mb: '-1x',
+    mr: '-2x',
     px: 0,
     py: 0,
     _hover: {
@@ -333,21 +523,21 @@ const useAlertCloseButtonStyle = ({
   variant,
 }) => {
   const [colorMode] = useColorMode();
-  const { colors } = useTheme();
+  const theme = useTheme();
 
   if (variant === 'solid') {
-    return getSolidCloseButtonStyle({ colorMode, colors });
+    return getSolidCloseButtonStyle({ colorMode, theme });
   }
 
   if (variant === 'outline') {
-    return getOutlineCloseButtonStyle({ colorMode, colors });
+    return getOutlineCloseButtonStyle({ colorMode, theme });
   }
 
   return {};
 };
 
 export {
-  useAlertRootStyle,
+  useAlertStyle,
   useAlertIconStyle,
   useAlertMessageStyle,
   useAlertCloseButtonStyle,

--- a/packages/styled-ui-docs/pages/alert.mdx
+++ b/packages/styled-ui-docs/pages/alert.mdx
@@ -12,29 +12,31 @@ import { Alert } from '@trendmicro/react-styled-ui';
 
 ### Variants
 
-You can use the `variant` prop to specify the visual style to use. The default variants come in 2 variations: `solid` and `outline`.
+You can use the `variant` prop to change the appearance of the alert. The variants come in two variations: `solid` and `outline`.
 
 #### Solid
 
+The `solid` variant is used to indicate an important message.
+
 ```jsx
 <Alert variant="solid" severity="info">
-  <Text>This is an info alert with the solid variant.</Text>
+  <Text>This is an important message.</Text>
 </Alert>
 ```
 
 #### Outline
 
-The `outline` variant inverts the style of an alert, inheriting the currently applied color to the text annd border, and making its background transparent.
+The `outline` variant is useful for displaying a contextual alert that is not a part of the primary flow of the application.
 
 ```jsx
 <Alert variant="outline" severity="info">
-  <Text>This is an info alert with the outline variant.</Text>
+  <Text>This is a contextual alert.</Text>
 </Alert>
 ```
 
 ### Severity levels
 
-The `severity` prop provides 4 different alert styles: `success`, `info`, `warning`, and `error`. Each of these styles provides a default icon and color.
+The `severity` prop can be used to specify the severity level of the alert. The severity levels are: `success`, `info`, `warning`, and `error`. The default severity level is `success`.
 
 ```jsx
 <Stack direction="column" spacing="6x">
@@ -69,48 +71,10 @@ The `severity` prop provides 4 different alert styles: `success`, `info`, `warni
 </Stack>
 ```
 
-### With close button
+### `icon` prop
 
-Set `isClosable` to `true` to include a close button on the right-hand side of an alert.
-
-```jsx
-<Stack direction="column" spacing="6x">
-  <Stack direction="column" spacing="2x">
-    <Alert variant="solid" severity="success" isClosable>
-      <Text>This is a success alert.</Text>
-    </Alert>
-    <Alert variant="solid" severity="info" isClosable>
-      <Text>This is an info alert.</Text>
-    </Alert>
-    <Alert variant="solid" severity="warning" isClosable>
-      <Text>This is a warning alert.</Text>
-    </Alert>
-    <Alert variant="solid" severity="error" isClosable>
-      <Text>This is an error alert.</Text>
-    </Alert>
-  </Stack>
-  <Stack direction="column" spacing="2x">
-    <Alert variant="outline" severity="success" isClosable>
-      <Text>This is a success alert.</Text>
-    </Alert>
-    <Alert variant="outline" severity="info" isClosable>
-      <Text>This is an info alert.</Text>
-    </Alert>
-    <Alert variant="outline" severity="warning" isClosable>
-      <Text>This is a warning alert.</Text>
-    </Alert>
-    <Alert variant="outline" severity="error" isClosable>
-      <Text>This is an error alert.</Text>
-    </Alert>
-  </Stack>
-</Stack>
-```
-
-### Icons
-
-The `icon` prop allows you to override the default icon for the specified severity.
-
-Setting the `icon` prop to `false` will remove the icon altogether.
+The `icon` prop allows you to specify an icon to be displayed in the alert.
+If not specified, the default icon will be used based on the `severity` prop.
 
 ```jsx
 <Stack direction="column" spacing="6x">
@@ -145,11 +109,48 @@ Setting the `icon` prop to `false` will remove the icon altogether.
 </Stack>
 ```
 
-### Actions
+### `isClosable` prop
 
-An alert can have an action, such as a close or action button. It is rendered after the message, at the end of the alert.
+Set `isClosable` to `true` to make the alert closable. The default value is `false`.
 
-You can wrap components with a `Flex` and use `justify="space-between"` to evenly distribute items. The first item is at the start of the container while the last one is at the end.
+```jsx
+<Stack direction="column" spacing="6x">
+  <Stack direction="column" spacing="2x">
+    <Alert variant="solid" severity="success" isClosable>
+      <Text>This is a success alert.</Text>
+    </Alert>
+    <Alert variant="solid" severity="info" isClosable>
+      <Text>This is an info alert.</Text>
+    </Alert>
+    <Alert variant="solid" severity="warning" isClosable>
+      <Text>This is a warning alert.</Text>
+    </Alert>
+    <Alert variant="solid" severity="error" isClosable>
+      <Text>This is an error alert.</Text>
+    </Alert>
+  </Stack>
+  <Stack direction="column" spacing="2x">
+    <Alert variant="outline" severity="success" isClosable>
+      <Text>This is a success alert.</Text>
+    </Alert>
+    <Alert variant="outline" severity="info" isClosable>
+      <Text>This is an info alert.</Text>
+    </Alert>
+    <Alert variant="outline" severity="warning" isClosable>
+      <Text>This is a warning alert.</Text>
+    </Alert>
+    <Alert variant="outline" severity="error" isClosable>
+      <Text>This is an error alert.</Text>
+    </Alert>
+  </Stack>
+</Stack>
+```
+
+### Alert actions
+
+An alert action is a button or link to trigger an action. It is used to provide additional context to the user.
+
+The action button is usually aligned to the right of the alert. You can use `justifyContent` to align the action button to the right.
 
 ```jsx
 <Stack direction="column" spacing="6x">
@@ -188,9 +189,9 @@ You can wrap components with a `Flex` and use `justify="space-between"` to evenl
 </Stack>
 ```
 
-### Formatted title
+### Formatted text
 
-You can use the `Text` component with `fontWeight` to display a formatted title above the content.
+You can use the `Text` component to format text.
 
 ```jsx
 <Stack direction="column" spacing="2x">
@@ -229,29 +230,9 @@ You can use the `Text` component with `fontWeight` to display a formatted title 
 </Stack>
 ```
 
-### Multiline text
-
-```jsx noInline
-const Paragraph = (props) => (
-  <PseudoBox mb="1x" _lastChild={{ mb: 0 }} {...props} />
-);
-
-function Example() {
-  return (
-    <Alert severity="warning" isClosable>
-      <Paragraph>This is the first paragraph.</Paragraph>
-      <Paragraph>This is the second paragraph.</Paragraph>
-      <Paragraph>This is the third paragraph.</Paragraph>
-    </Alert>
-  );
-}
-
-render(<Example />);
-```
-
 ### Transition effects
 
-You can use a transition component such as `Collapse` to give the appearance of a smooth transition.
+To animate the alert, you can use a transition component to apply an animation effect.
 
 ```jsx
 function Example() {

--- a/packages/styled-ui-docs/pages/alert.mdx
+++ b/packages/styled-ui-docs/pages/alert.mdx
@@ -145,19 +145,24 @@ Setting the `icon` prop to `false` will remove the icon altogether.
 </Stack>
 ```
 
-### Action buttons
+### Actions
 
-An alert can have an action button (such close). It is rendered after the message, at the end of the alert.
+An alert can have an action, such as a close or action button. It is rendered after the message, at the end of the alert.
+
+You can wrap components with a `Flex` and use `justify="space-between"` to evenly distribute items. The first item is at the start of the container while the last one is at the end.
 
 ```jsx
 <Stack direction="column" spacing="6x">
   <Stack direction="column" spacing="2x">
-    <Alert variant="solid" severity="warning" isCloseButtonVisible>
-      <Text>Your browser is currently not supported. <Link>More Information</Link></Text>
+    <Alert variant="solid" severity="warning">
+      <Flex justify="space-between">
+        <Text>This is a warning alert.</Text>
+        <LinkButton>Learn More</LinkButton>
+      </Flex>
     </Alert>
-    <Alert variant="solid" severity="error" isCloseButtonVisible>
+    <Alert variant="solid" severity="error">
       <Flex justify="space-between" mt={-1} mb={-2}>
-        <Text>Your license will expire in 7 days.</Text>
+        <Text>This is an error alert.</Text>
         <FlatButton size="sm" variant="outline" variantColor="black:primary">
           Action Button
         </FlatButton>
@@ -165,12 +170,15 @@ An alert can have an action button (such close). It is rendered after the messag
     </Alert>
   </Stack>
   <Stack direction="column" spacing="2x">
-    <Alert variant="outline" severity="warning" isCloseButtonVisible>
-      <Text>Your browser is currently not supported. <Link>More Information</Link></Text>
+    <Alert variant="outline" severity="warning">
+      <Flex justify="space-between">
+        <Text>This is a warning alert.</Text>
+        <LinkButton>Learn More</LinkButton>
+      </Flex>
     </Alert>
-    <Alert variant="outline" severity="error" isCloseButtonVisible>
+    <Alert variant="outline" severity="error">
       <Flex justify="space-between" mt={-1} mb={-2}>
-        <Text>Your license will expire in 7 days.</Text>
+        <Text>This is an error alert.</Text>
         <Button size="sm" variant="secondary">
           Action Button
         </Button>

--- a/packages/styled-ui-docs/pages/alert.mdx
+++ b/packages/styled-ui-docs/pages/alert.mdx
@@ -37,31 +37,35 @@ The `outline` variant inverts the style of an alert, inheriting the currently ap
 The `severity` prop provides 4 different alert styles: `success`, `info`, `warning`, and `error`. Each of these styles provides a default icon and color.
 
 ```jsx
-<Stack direction="column" spacing="4x">
-  <Alert variant="solid" severity="success">
-    <Text>This is a success alert.</Text>
-  </Alert>
-  <Alert variant="solid" severity="info">
-    <Text>This is an info alert.</Text>
-  </Alert>
-  <Alert variant="solid" severity="warning">
-    <Text>This is a warning alert.</Text>
-  </Alert>
-  <Alert variant="solid" severity="error">
-    <Text>This is an error alert.</Text>
-  </Alert>
-  <Alert variant="outline" severity="success">
-    <Text>This is a success alert.</Text>
-  </Alert>
-  <Alert variant="outline" severity="info">
-    <Text>This is an info alert.</Text>
-  </Alert>
-  <Alert variant="outline" severity="warning">
-    <Text>This is a warning alert.</Text>
-  </Alert>
-  <Alert variant="outline" severity="error">
-    <Text>This is an error alert.</Text>
-  </Alert>
+<Stack direction="column" spacing="6x">
+  <Stack direction="column" spacing="2x">
+    <Alert variant="solid" severity="success">
+      <Text>This is a success alert.</Text>
+    </Alert>
+    <Alert variant="solid" severity="info">
+      <Text>This is an info alert.</Text>
+    </Alert>
+    <Alert variant="solid" severity="warning">
+      <Text>This is a warning alert.</Text>
+    </Alert>
+    <Alert variant="solid" severity="error">
+      <Text>This is an error alert.</Text>
+    </Alert>
+  </Stack>
+  <Stack direction="column" spacing="2x">
+    <Alert variant="outline" severity="success">
+      <Text>This is a success alert.</Text>
+    </Alert>
+    <Alert variant="outline" severity="info">
+      <Text>This is an info alert.</Text>
+    </Alert>
+    <Alert variant="outline" severity="warning">
+      <Text>This is a warning alert.</Text>
+    </Alert>
+    <Alert variant="outline" severity="error">
+      <Text>This is an error alert.</Text>
+    </Alert>
+  </Stack>
 </Stack>
 ```
 
@@ -70,31 +74,35 @@ The `severity` prop provides 4 different alert styles: `success`, `info`, `warni
 Set `isCloseButtonVisible` to `true` to include a close button on the right-hand side of an alert.
 
 ```jsx
-<Stack direction="column" spacing="4x">
-  <Alert variant="solid" severity="success" isCloseButtonVisible>
-    <Text>This is a success alert.</Text>
-  </Alert>
-  <Alert variant="solid" severity="info" isCloseButtonVisible>
-    <Text>This is an info alert.</Text>
-  </Alert>
-  <Alert variant="solid" severity="warning" isCloseButtonVisible>
-    <Text>This is a warning alert.</Text>
-  </Alert>
-  <Alert variant="solid" severity="error" isCloseButtonVisible>
-    <Text>This is an error alert.</Text>
-  </Alert>
-  <Alert variant="outline" severity="success" isCloseButtonVisible>
-    <Text>This is a success alert.</Text>
-  </Alert>
-  <Alert variant="outline" severity="info" isCloseButtonVisible>
-    <Text>This is an info alert.</Text>
-  </Alert>
-  <Alert variant="outline" severity="warning" isCloseButtonVisible>
-    <Text>This is a warning alert.</Text>
-  </Alert>
-  <Alert variant="outline" severity="error" isCloseButtonVisible>
-    <Text>This is an error alert.</Text>
-  </Alert>
+<Stack direction="column" spacing="6x">
+  <Stack direction="column" spacing="2x">
+    <Alert variant="solid" severity="success" isCloseButtonVisible>
+      <Text>This is a success alert.</Text>
+    </Alert>
+    <Alert variant="solid" severity="info" isCloseButtonVisible>
+      <Text>This is an info alert.</Text>
+    </Alert>
+    <Alert variant="solid" severity="warning" isCloseButtonVisible>
+      <Text>This is a warning alert.</Text>
+    </Alert>
+    <Alert variant="solid" severity="error" isCloseButtonVisible>
+      <Text>This is an error alert.</Text>
+    </Alert>
+  </Stack>
+  <Stack direction="column" spacing="2x">
+    <Alert variant="outline" severity="success" isCloseButtonVisible>
+      <Text>This is a success alert.</Text>
+    </Alert>
+    <Alert variant="outline" severity="info" isCloseButtonVisible>
+      <Text>This is an info alert.</Text>
+    </Alert>
+    <Alert variant="outline" severity="warning" isCloseButtonVisible>
+      <Text>This is a warning alert.</Text>
+    </Alert>
+    <Alert variant="outline" severity="error" isCloseButtonVisible>
+      <Text>This is an error alert.</Text>
+    </Alert>
+  </Stack>
 </Stack>
 ```
 
@@ -105,52 +113,71 @@ The `icon` prop allows you to override the default icon for the specified severi
 Setting the `icon` prop to `false` will remove the icon altogether.
 
 ```jsx
-<Stack direction="column" spacing="4x">
-  <Alert variant="solid" severity="success" isCloseButtonVisible>
-    This is a success alert.
-  </Alert>
-  <Alert variant="solid" severity="success" icon="success" isCloseButtonVisible>
-    This is a success alert.
-  </Alert>
-  <Alert variant="solid" severity="success" icon={<Icon icon="check-circle-o" color="gray:80" />} isCloseButtonVisible>
-    This is a success alert.
-  </Alert>
-  <Alert variant="solid" severity="success" icon={false} isCloseButtonVisible>
-    This is a success alert.
-  </Alert>
-  <Alert variant="outline" severity="success" isCloseButtonVisible>
-    This is a success alert.
-  </Alert>
-  <Alert variant="outline" severity="success" icon="success" isCloseButtonVisible>
-    This is a success alert.
-  </Alert>
-  <Alert variant="outline" severity="success" icon={<Icon icon="check-circle-o" color="gray:50" />} isCloseButtonVisible>
-    This is a success alert.
-  </Alert>
-  <Alert variant="outline" severity="success" icon={false} isCloseButtonVisible>
-    This is a success alert.
-  </Alert>
+<Stack direction="column" spacing="6x">
+  <Stack direction="column" spacing="2x">
+    <Alert variant="solid" severity="success" isCloseButtonVisible>
+      This is a success alert.
+    </Alert>
+    <Alert variant="solid" severity="success" icon="success" isCloseButtonVisible>
+      This is a success alert.
+    </Alert>
+    <Alert variant="solid" severity="success" icon={<Icon icon="check-circle-o" color="gray:80" />} isCloseButtonVisible>
+      This is a success alert.
+    </Alert>
+    <Alert variant="solid" severity="success" icon={false} isCloseButtonVisible>
+      This is a success alert.
+    </Alert>
+  </Stack>
+  <Stack direction="column" spacing="2x">
+    <Alert variant="outline" severity="success" isCloseButtonVisible>
+      This is a success alert.
+    </Alert>
+    <Alert variant="outline" severity="success" icon="success" isCloseButtonVisible>
+      This is a success alert.
+    </Alert>
+    <Alert variant="outline" severity="success" icon={<Icon icon="check-circle-o" color="gray:50" />} isCloseButtonVisible>
+      This is a success alert.
+    </Alert>
+    <Alert variant="outline" severity="success" icon={false} isCloseButtonVisible>
+      This is a success alert.
+    </Alert>
+  </Stack>
 </Stack>
 ```
 
-### Multiline text
+### Action buttons
 
-```jsx noInline
-const Paragraph = (props) => (
-  <PseudoBox mb="1x" _lastChild={{ mb: 0 }} {...props} />
-);
+An alert can have an action button (such close). It is rendered after the message, at the end of the alert.
 
-function Example() {
-  return (
-    <Alert isCloseButtonVisible severity="info">
-      <Paragraph>This is the first paragraph.</Paragraph>
-      <Paragraph>This is the second paragraph.</Paragraph>
-      <Paragraph>This is the third paragraph.</Paragraph>
+```jsx
+<Stack direction="column" spacing="6x">
+  <Stack direction="column" spacing="2x">
+    <Alert variant="solid" severity="warning" isCloseButtonVisible>
+      <Text>Your browser is currently not supported. <Link>More Information</Link></Text>
     </Alert>
-  );
-}
-
-render(<Example />);
+    <Alert variant="solid" severity="error" isCloseButtonVisible>
+      <Flex justify="space-between" mt={-1} mb={-2}>
+        <Text>Your license will expire in 7 days.</Text>
+        <FlatButton size="sm" variant="outline" variantColor="black:primary">
+          Action Button
+        </FlatButton>
+      </Flex>
+    </Alert>
+  </Stack>
+  <Stack direction="column" spacing="2x">
+    <Alert variant="outline" severity="warning" isCloseButtonVisible>
+      <Text>Your browser is currently not supported. <Link>More Information</Link></Text>
+    </Alert>
+    <Alert variant="outline" severity="error" isCloseButtonVisible>
+      <Flex justify="space-between" mt={-1} mb={-2}>
+        <Text>Your license will expire in 7 days.</Text>
+        <Button size="sm" variant="secondary">
+          Action Button
+        </Button>
+      </Flex>
+    </Alert>
+  </Stack>
+</Stack>
 ```
 
 ### Formatted title
@@ -158,7 +185,7 @@ render(<Example />);
 You can use the `Text` component with `fontWeight` to display a formatted title above the content.
 
 ```jsx
-<Stack direction="column" spacing="4x">
+<Stack direction="column" spacing="2x">
   <Alert isCloseButtonVisible severity="success">
     <Box mb="1x">
       <Text fontWeight="bold">Success</Text>
@@ -194,27 +221,27 @@ You can use the `Text` component with `fontWeight` to display a formatted title 
 </Stack>
 ```
 
-### Actions
+### Multiline text
 
-An alert can have an action button (such close). It is rendered after the message, at the end of the alert.
+```jsx noInline
+const Paragraph = (props) => (
+  <PseudoBox mb="1x" _lastChild={{ mb: 0 }} {...props} />
+);
 
-```jsx
-<Stack direction="column" spacing={1}>
-  <Alert isCloseButtonVisible severity="warning">
-    <Text>Your browser is currently not supported. <Link>More Information</Link></Text>
-  </Alert>
-  <Alert isCloseButtonVisible severity="error">
-    <Flex justify="space-between" mt={-1} mb={-2}>
-      <Text>Your license will expire in 7 days.</Text>
-      <FlatButton size="sm" variant="outline" variantColor="black:primary">
-        Renew Now
-      </FlatButton>
-    </Flex>
-  </Alert>
-</Stack>
+function Example() {
+  return (
+    <Alert severity="warning" isCloseButtonVisible>
+      <Paragraph>This is the first paragraph.</Paragraph>
+      <Paragraph>This is the second paragraph.</Paragraph>
+      <Paragraph>This is the third paragraph.</Paragraph>
+    </Alert>
+  );
+}
+
+render(<Example />);
 ```
 
-### Transition
+### Transition effects
 
 You can use a transition component such as `Collapse` to give the appearance of a smooth transition.
 

--- a/packages/styled-ui-docs/pages/alert.mdx
+++ b/packages/styled-ui-docs/pages/alert.mdx
@@ -121,7 +121,7 @@ Setting the `icon` prop to `false` will remove the icon altogether.
     <Alert variant="solid" severity="success" icon="success" isCloseButtonVisible>
       This is a success alert.
     </Alert>
-    <Alert variant="solid" severity="success" icon={<Icon icon="check-circle-o" color="gray:80" />} isCloseButtonVisible>
+    <Alert variant="solid" severity="success" icon={<Icon icon="check-circle-o" />} isCloseButtonVisible>
       This is a success alert.
     </Alert>
     <Alert variant="solid" severity="success" icon={false} isCloseButtonVisible>
@@ -135,7 +135,7 @@ Setting the `icon` prop to `false` will remove the icon altogether.
     <Alert variant="outline" severity="success" icon="success" isCloseButtonVisible>
       This is a success alert.
     </Alert>
-    <Alert variant="outline" severity="success" icon={<Icon icon="check-circle-o" color="gray:50" />} isCloseButtonVisible>
+    <Alert variant="outline" severity="success" icon={<Icon icon="check-circle-o" />} isCloseButtonVisible>
       This is a success alert.
     </Alert>
     <Alert variant="outline" severity="success" icon={false} isCloseButtonVisible>

--- a/packages/styled-ui-docs/pages/alert.mdx
+++ b/packages/styled-ui-docs/pages/alert.mdx
@@ -1,6 +1,6 @@
 # Alert
 
-An alert displays a short, important message in a way that attracts the user's attention without interrupting the user's task.
+An alert is used to convey important information to the user through the use of contextual types, icons, and colors.
 
 ## Import
 
@@ -10,22 +10,56 @@ import { Alert } from '@trendmicro/react-styled-ui';
 
 ## Usage
 
+### Variants
+
+You can use the `variant` prop to specify the visual style to use. The default variants come in 2 variations: `solid` and `outline`.
+
+#### Solid
+
+```jsx
+<Alert variant="solid" severity="info">
+  <Text>This is an info alert with the solid variant.</Text>
+</Alert>
+```
+
+#### Outline
+
+The `outline` variant inverts the style of an alert, inheriting the currently applied color to the text annd border, and making its background transparent.
+
+```jsx
+<Alert variant="outline" severity="info">
+  <Text>This is an info alert with the outline variant.</Text>
+</Alert>
+```
+
 ### Severity levels
 
-Alerts provide four severity levels, each with a distinctive icon and color.
+The `severity` prop provides 4 different alert styles: `success`, `info`, `warning`, and `error`. Each of these styles provides a default icon and color.
 
 ```jsx
 <Stack direction="column" spacing="4x">
-  <Alert severity="success">
+  <Alert variant="solid" severity="success">
     <Text>This is a success alert.</Text>
   </Alert>
-  <Alert severity="info">
+  <Alert variant="solid" severity="info">
     <Text>This is an info alert.</Text>
   </Alert>
-  <Alert severity="warning">
+  <Alert variant="solid" severity="warning">
     <Text>This is a warning alert.</Text>
   </Alert>
-  <Alert severity="error">
+  <Alert variant="solid" severity="error">
+    <Text>This is an error alert.</Text>
+  </Alert>
+  <Alert variant="outline" severity="success">
+    <Text>This is a success alert.</Text>
+  </Alert>
+  <Alert variant="outline" severity="info">
+    <Text>This is an info alert.</Text>
+  </Alert>
+  <Alert variant="outline" severity="warning">
+    <Text>This is a warning alert.</Text>
+  </Alert>
+  <Alert variant="outline" severity="error">
     <Text>This is an error alert.</Text>
   </Alert>
 </Stack>
@@ -37,16 +71,28 @@ Set `isCloseButtonVisible` to `true` to include a close button on the right-hand
 
 ```jsx
 <Stack direction="column" spacing="4x">
-  <Alert severity="success" isCloseButtonVisible>
+  <Alert variant="solid" severity="success" isCloseButtonVisible>
     <Text>This is a success alert.</Text>
   </Alert>
-  <Alert severity="info" isCloseButtonVisible>
+  <Alert variant="solid" severity="info" isCloseButtonVisible>
     <Text>This is an info alert.</Text>
   </Alert>
-  <Alert severity="warning" isCloseButtonVisible>
+  <Alert variant="solid" severity="warning" isCloseButtonVisible>
     <Text>This is a warning alert.</Text>
   </Alert>
-  <Alert severity="error" isCloseButtonVisible>
+  <Alert variant="solid" severity="error" isCloseButtonVisible>
+    <Text>This is an error alert.</Text>
+  </Alert>
+  <Alert variant="outline" severity="success" isCloseButtonVisible>
+    <Text>This is a success alert.</Text>
+  </Alert>
+  <Alert variant="outline" severity="info" isCloseButtonVisible>
+    <Text>This is an info alert.</Text>
+  </Alert>
+  <Alert variant="outline" severity="warning" isCloseButtonVisible>
+    <Text>This is a warning alert.</Text>
+  </Alert>
+  <Alert variant="outline" severity="error" isCloseButtonVisible>
     <Text>This is an error alert.</Text>
   </Alert>
 </Stack>
@@ -60,31 +106,28 @@ Setting the `icon` prop to `false` will remove the icon altogether.
 
 ```jsx
 <Stack direction="column" spacing="4x">
-  <Alert
-    isCloseButtonVisible
-    severity="success"
-  >
+  <Alert variant="solid" severity="success" isCloseButtonVisible>
     This is a success alert.
   </Alert>
-  <Alert
-    isCloseButtonVisible
-    severity="success"
-    icon="success"
-  >
+  <Alert variant="solid" severity="success" icon="success" isCloseButtonVisible>
     This is a success alert.
   </Alert>
-  <Alert
-    isCloseButtonVisible
-    severity="success"
-    icon={<Icon icon="check-circle-o" color="gray:80" />}
-  >
+  <Alert variant="solid" severity="success" icon={<Icon icon="check-circle-o" color="gray:80" />} isCloseButtonVisible>
     This is a success alert.
   </Alert>
-  <Alert
-    isCloseButtonVisible
-    severity="success"
-    icon={false}
-  >
+  <Alert variant="solid" severity="success" icon={false} isCloseButtonVisible>
+    This is a success alert.
+  </Alert>
+  <Alert variant="outline" severity="success" isCloseButtonVisible>
+    This is a success alert.
+  </Alert>
+  <Alert variant="outline" severity="success" icon="success" isCloseButtonVisible>
+    This is a success alert.
+  </Alert>
+  <Alert variant="outline" severity="success" icon={<Icon icon="check-circle-o" color="gray:50" />} isCloseButtonVisible>
+    This is a success alert.
+  </Alert>
+  <Alert variant="outline" severity="success" icon={false} isCloseButtonVisible>
     This is a success alert.
   </Alert>
 </Stack>
@@ -206,5 +249,6 @@ function Example() {
 | :--- | :--- | :------ | :---------- |
 | isCloseButtonVisible | boolean | | If `true`, a close button will appear on the right side. |
 | onClose | function | | A callback called when the close button is clicked. |
-| severity | string | 'success' | The severity level of the alert. One of: `'success'`, `'info'`, `'warning'`, `'error'` |
+| variant | string | 'solid' | The variant to use. One of: `'solid'`, `'outline'` |
+| severity | string | 'success' | The severity level to use. One of: `'success'`, `'info'`, `'warning'`, `'error'` |
 | icon | string \| ReactNode \| false | | Override the icon displayed before the children. Unless provided, the icon is mapped to the value of the `severity` prop. |

--- a/packages/styled-ui-docs/pages/drawer.mdx
+++ b/packages/styled-ui-docs/pages/drawer.mdx
@@ -104,6 +104,7 @@ const FormGroup = (props) => (
 );
 
 function Example() {
+  const initialFocusRef = React.useRef();
   const [colorMode] = useColorMode();
   const iconColor = {
     dark: 'white:tertiary',
@@ -111,8 +112,8 @@ function Example() {
   }[colorMode];
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [placement, changePlacementBy] = useSelection('right');
-  const [ensureFocus, toggleEnsureFocus] = useToggle(false);
-  const [autoFocus, toggleAutoFocus] = useToggle(false);
+  const [ensureFocus, toggleEnsureFocus] = useToggle(true);
+  const [autoFocus, toggleAutoFocus] = useToggle(true);
   const [backdrop, toggleBackdrop] = useToggle(true);
   const [closeOnEsc, toggleCloseOnEsc] = useToggle(true);
   const [closeOnOutsideClick, toggleCloseOnOutsideClick, setCloseOnOutsideClick] = useToggle(true);
@@ -121,6 +122,7 @@ function Example() {
   const [isHeaderVisible, toggleIsHeaderVisible] = useToggle(true);
   const [isBodyVisible, toggleIsBodyVisible] = useToggle(true);
   const [isFooterVisible, toggleIsFooterVisible] = useToggle(true);
+  const [isAlertVisible, toggleIsAlertVisible] = useToggle(true);
   const [size, changeSizeBy] = useSelection('sm');
 
   return (
@@ -277,6 +279,13 @@ function Example() {
           <Text fontFamily="mono" whiteSpace="nowrap">DrawerFooter</Text>
         </TextLabel>
       </FormGroup>
+      <FormGroup>
+        <TextLabel display="flex" alignItems="center">
+          <Checkbox checked={isAlertVisible} onChange={toggleIsAlertVisible} />
+          <Space width="2x" />
+          <Text fontFamily="mono" whiteSpace="nowrap">Alert</Text>
+        </TextLabel>
+      </FormGroup>
       <Slide
         in={isOpen}
         duration={250}
@@ -288,6 +297,7 @@ function Example() {
             ensureFocus={ensureFocus}
             autoFocus={autoFocus}
             backdrop={backdrop}
+            initialFocusRef={initialFocusRef}
             isClosable={isClosable}
             isOpen={true} // Set to `true` if a transition is active
             closeOnEsc={closeOnEsc}
@@ -302,11 +312,19 @@ function Example() {
             <DrawerContent {...styles}>
               {isHeaderVisible && (
                 <DrawerHeader>
-                  Sign In
+                  Drawer Title
                 </DrawerHeader>
               )}
               {isBodyVisible && (
                 <DrawerBody>
+                  {isAlertVisible && (
+                    <Alert variant="outline" severity="info" mb="4x" isClosable onClose={() => toggleIsAlertVisible()}>
+                      <Text>This is an info alert</Text>
+                    </Alert>
+                  )}
+                  <Text mb="4x">
+                    You can put any elements you want here.
+                  </Text>
                   <Grid
                     templateColumns="auto 1fr"
                     rowGap="2x"
@@ -314,9 +332,9 @@ function Example() {
                     alignItems="center"
                   >
                     <Icon icon="user" color={iconColor} />
-                    <Input placeholder="User name" />
-                    <Icon icon="lock" color={iconColor} />
-                    <Input type="password" placeholder="Password" />
+                    <Input ref={initialFocusRef} placeholder="User name" />
+                    <Icon icon="email" color={iconColor} />
+                    <Input placeholder="Email address" />
                   </Grid>
                 </DrawerBody>
               )}

--- a/packages/styled-ui-docs/pages/modal.mdx
+++ b/packages/styled-ui-docs/pages/modal.mdx
@@ -50,6 +50,9 @@ function Example() {
           Modal Title
         </ModalHeader>
         <ModalBody>
+          <Alert variant="outline" severity="warning" mb="4x">
+            <Text>This is a warning alert</Text>
+          </Alert>
           <Text mb="4x">
             Modal body text goes here.
           </Text>
@@ -174,6 +177,7 @@ const FormGroup = (props) => (
 );
 
 function Example() {
+  const initialFocusRef = React.useRef();
   const [colorMode] = useColorMode();
   const iconColor = {
     dark: 'white:tertiary',
@@ -189,6 +193,7 @@ function Example() {
   const [isHeaderVisible, toggleIsHeaderVisible] = useToggle(true);
   const [isBodyVisible, toggleIsBodyVisible] = useToggle(true);
   const [isFooterVisible, toggleIsFooterVisible] = useToggle(true);
+  const [isAlertVisible, toggleIsAlertVisible] = useToggle(true);
   const [size, changeSizeBy] = useSelection('sm');
 
   return (
@@ -302,6 +307,13 @@ function Example() {
           <Text fontFamily="mono" whiteSpace="nowrap">ModalFooter</Text>
         </TextLabel>
       </FormGroup>
+      <FormGroup>
+        <TextLabel display="flex" alignItems="center">
+          <Checkbox checked={isAlertVisible} onChange={toggleIsAlertVisible} />
+          <Space width="2x" />
+          <Text fontFamily="mono" whiteSpace="nowrap">Alert</Text>
+        </TextLabel>
+      </FormGroup>
       <Scale
         in={isOpen}
         duration={150}
@@ -312,6 +324,7 @@ function Example() {
             autoFocus={autoFocus}
             closeOnEsc={closeOnEsc}
             closeOnOutsideClick={closeOnOutsideClick}
+            initialFocusRef={initialFocusRef}
             isClosable={isClosable}
             isOpen={true} // Set to `true` if a transition is active
             onClose={onClose}
@@ -323,11 +336,19 @@ function Example() {
             <ModalContent {...styles}>
               {isHeaderVisible && (
                 <ModalHeader>
-                  Create an Account
+                  Modal Title
                 </ModalHeader>
               )}
               {isBodyVisible && (
                 <ModalBody>
+                  {isAlertVisible && (
+                    <Alert variant="outline" severity="info" mb="4x" isClosable onClose={() => toggleIsAlertVisible()}>
+                      <Text>This is an info alert</Text>
+                    </Alert>
+                  )}
+                  <Text mb="4x">
+                    You can put any elements you want here.
+                  </Text>
                   <Grid
                     templateColumns="auto 1fr"
                     rowGap="2x"
@@ -335,11 +356,7 @@ function Example() {
                     alignItems="center"
                   >
                     <Icon icon="user" color={iconColor} />
-                    <Input placeholder="User name" />
-                    <Icon icon="lock" color={iconColor} />
-                    <Input type="password" placeholder="Password" />
-                    <Box />
-                    <Input type="password" placeholder="Confirm password" />
+                    <Input ref={initialFocusRef} placeholder="User name" />
                     <Icon icon="email" color={iconColor} />
                     <Input placeholder="Email address" />
                   </Grid>
@@ -348,7 +365,7 @@ function Example() {
               {isFooterVisible && (
                 <ModalFooter>
                   <Button variant="primary">
-                    Confirm
+                    OK
                   </Button>
                   <Space width="2x" />
                   <Button onClick={onClose}>

--- a/packages/styled-ui-docs/pages/toast.mdx
+++ b/packages/styled-ui-docs/pages/toast.mdx
@@ -1,6 +1,6 @@
 # Toast
 
-A toast notification is a short message that displays at the  side of the screen and disappears automatically after a few seconds. A toast notification is a status update about an operation for which the current activity remains visibility and interactive. Basically, a toast notification is used inform the user of something that is not critical and that does not require specific attention, and does not prevent the user from using the app.
+A toast notification is a small popup that appears at either side of the screen, and disappears after a short time. The toast notification is used to notify the user of something that has happened, but it is not intended to be used as a permanent message.
 
 ## Import
 


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/styled-ui-demo/pr-359/alert

## What's Changed

Added a new `variant` prop to the Alert component that provides different variants to be chosen (closes #358).

### Screenshots

![image](https://user-images.githubusercontent.com/447801/139517239-158c245d-e68e-4ffc-ab85-509226bd13f6.png)

![image](https://user-images.githubusercontent.com/447801/139517257-1ad8d9c0-7a43-4845-b164-3776ffb4b62e.png)

## UI Spec

Figma: https://www.figma.com/file/bHr2zAshr0D5ROp8vCVPFR/Tonic---Dark-Mode?node-id=17567%3A135104
