### PR TITLE
feat: add `isClosable` shorthand and deprecate the legacy `isCloseButtonVisible` prop

### DIFF
--- a/packages/react-styled-ui/src/Alert/index.js
+++ b/packages/react-styled-ui/src/Alert/index.js
@@ -44,7 +44,8 @@ const AlertCloseButton = (props) => (
 
 const Alert = forwardRef((
   {
-    isCloseButtonVisible,
+    isClosable: _isClosable = false,
+    isCloseButtonVisible: LEGACY_isCloseButtonVisible = false, // eslint-disable-line camelcase
     onClose,
     severity = defaultSeverity,
     icon,
@@ -53,6 +54,7 @@ const Alert = forwardRef((
   },
   ref,
 ) => {
+  const isClosable = _isClosable || LEGACY_isCloseButtonVisible; // eslint-disable-line camelcase
   const rootStyleProps = useAlertRootStyle({ severity });
   const iconStyleProps = useAlertIconStyle({ severity });
   const messageStyleProps = useAlertMessageStyle();
@@ -84,7 +86,7 @@ const Alert = forwardRef((
       <AlertMessage {...messageStyleProps}>
         {children}
       </AlertMessage>
-      {!!isCloseButtonVisible && (
+      {!!isClosable && (
         <>
           <Space minWidth="4x" />
           <AlertCloseButton {...closeButtonStyleProps} onClick={onClose}>

--- a/packages/react-styled-ui/src/Drawer/Drawer.js
+++ b/packages/react-styled-ui/src/Drawer/Drawer.js
@@ -15,7 +15,8 @@ const Drawer = ({
   placement = 'right',
   size = 'auto',
   isOpen = false,
-  isCloseButtonVisible = false,
+  isClosable: _isClosable = false,
+  isCloseButtonVisible: LEGACY_isCloseButtonVisible = false, // eslint-disable-line camelcase
   closeOnEsc = false,
   closeOnOutsideClick = false,
   onClose,
@@ -26,6 +27,7 @@ const Drawer = ({
   id,
   children,
 }) => {
+  const isClosable = _isClosable || LEGACY_isCloseButtonVisible; // eslint-disable-line camelcase
   const defaultId = useId();
   const contentRef = useRef(null);
   const drawerState = getMemoizedState({
@@ -33,7 +35,7 @@ const Drawer = ({
     placement,
     size,
     isOpen,
-    isCloseButtonVisible,
+    isClosable,
     closeOnEsc,
     closeOnOutsideClick,
     onClose,

--- a/packages/react-styled-ui/src/Drawer/DrawerContent.js
+++ b/packages/react-styled-ui/src/Drawer/DrawerContent.js
@@ -52,7 +52,7 @@ const DrawerContentFront = forwardRef(({ children, ...props }, ref) => {
   const context = useDrawer(); // context might be an undefined value
   const {
     closeOnEsc,
-    isCloseButtonVisible,
+    isClosable,
     onClose,
     placement,
     size,
@@ -84,7 +84,7 @@ const DrawerContentFront = forwardRef(({ children, ...props }, ref) => {
       {...props}
     >
       {children}
-      {!!isCloseButtonVisible && (
+      {!!isClosable && (
         <DrawerCloseButton onClick={onClose} />
       )}
     </Box>

--- a/packages/react-styled-ui/src/Modal/Modal.js
+++ b/packages/react-styled-ui/src/Modal/Modal.js
@@ -13,7 +13,8 @@ const getMemoizedState = memoize(state => ({ ...state }));
 const Modal = ({
   size = 'auto',
   isOpen = false,
-  isCloseButtonVisible = false,
+  isClosable: _isClosable = false,
+  isCloseButtonVisible: LEGACY_isCloseButtonVisible = false, // eslint-disable-line camelcase
   closeOnEsc = false,
   closeOnOutsideClick = false,
   onClose,
@@ -24,12 +25,13 @@ const Modal = ({
   id,
   children,
 }) => {
+  const isClosable = _isClosable || LEGACY_isCloseButtonVisible; // eslint-disable-line camelcase
   const defaultId = useId();
   const contentRef = useRef(null);
   const modalState = getMemoizedState({
     size,
     isOpen,
-    isCloseButtonVisible,
+    isClosable,
     closeOnEsc,
     closeOnOutsideClick,
     onClose,

--- a/packages/react-styled-ui/src/Modal/ModalContent.js
+++ b/packages/react-styled-ui/src/Modal/ModalContent.js
@@ -52,7 +52,7 @@ const ModalContentFront = forwardRef(({ children, ...props }, ref) => {
   const context = useModal(); // context might be an undefined value
   const {
     closeOnEsc,
-    isCloseButtonVisible,
+    isClosable,
     onClose,
     size,
 
@@ -83,7 +83,7 @@ const ModalContentFront = forwardRef(({ children, ...props }, ref) => {
       {...props}
     >
       {children}
-      {!!isCloseButtonVisible && (
+      {!!isClosable && (
         <ModalCloseButton onClick={onClose} />
       )}
     </Box>

--- a/packages/react-styled-ui/src/Tag/index.js
+++ b/packages/react-styled-ui/src/Tag/index.js
@@ -19,7 +19,8 @@ const Tag = forwardRef(
       variant = 'solid',
       variantColor = 'gray',
       isInvalid,
-      isCloseButtonVisible,
+      isClosable: _isClosable = false,
+      isCloseButtonVisible: LEGACY_isCloseButtonVisible = false, // eslint-disable-line camelcase
       disabled,
       children,
       onClose,
@@ -27,12 +28,14 @@ const Tag = forwardRef(
     },
     ref,
   ) => {
+    const isClosable = _isClosable || LEGACY_isCloseButtonVisible; // eslint-disable-line camelcase
+    const canFocus = isClosable;
     const tagStyleProps = useTagStyle({
       color: variantColor,
       size,
       variant,
-      canFocus: isCloseButtonVisible,
-      isCloseButtonVisible,
+      canFocus,
+      isClosable,
       borderRadius,
     });
 
@@ -48,7 +51,7 @@ const Tag = forwardRef(
         {...rest}
       >
         { children }
-        {!!isCloseButtonVisible && (
+        {!!isClosable && (
           <TagCloseButton
             borderRadius={borderRadius}
             size={size}

--- a/packages/react-styled-ui/src/Tag/styles.js
+++ b/packages/react-styled-ui/src/Tag/styles.js
@@ -290,10 +290,10 @@ const closeButtonSizes = {
   lg: '8x',
 };
 
-const sizeProps = ({ size, isCloseButtonVisible, theme: { sizes } }) => {
+const sizeProps = ({ size, isClosable, theme: { sizes } }) => {
   const space = sizes['1x'];
   const closeButtonSize = sizes[closeButtonSizes[size]];
-  const pr = isCloseButtonVisible
+  const pr = isClosable
     ? `calc(${space} + ${closeButtonSize})`
     : '2x';
   return {

--- a/packages/react-styled-ui/src/Toast/index.js
+++ b/packages/react-styled-ui/src/Toast/index.js
@@ -44,7 +44,8 @@ const ToastCloseButton = (props) => (
 
 const Toast = forwardRef((
   {
-    isCloseButtonVisible,
+    isClosable: _isClosable = false,
+    isCloseButtonVisible: LEGACY_isCloseButtonVisible = false, // eslint-disable-line camelcase
     onClose,
     appearance = defaultAppearance,
     icon,
@@ -53,6 +54,7 @@ const Toast = forwardRef((
   },
   ref,
 ) => {
+  const isClosable = _isClosable || LEGACY_isCloseButtonVisible; // eslint-disable-line camelcase
   const rootStyleProps = useToastRootStyle({ appearance });
   const iconStyleProps = useToastIconStyle({ appearance });
   const messageStyleProps = useToastMessageStyle();
@@ -84,7 +86,7 @@ const Toast = forwardRef((
       <ToastMessage {...messageStyleProps}>
         {children}
       </ToastMessage>
-      {!!isCloseButtonVisible && (
+      {!!isClosable && (
         <>
           <Space minWidth="4x" />
           <ToastCloseButton {...closeButtonStyleProps} onClick={onClose}>

--- a/packages/styled-ui-docs/components/EditableTag.jsx
+++ b/packages/styled-ui-docs/components/EditableTag.jsx
@@ -103,7 +103,7 @@ const EditableTag = React.forwardRef((
   return (
     <Tag
       ref={ref}
-      isCloseButtonVisible
+      isClosable
       isInvalid={isInvalid}
       mr="2x"
       mt={mt}

--- a/packages/styled-ui-docs/pages/alert.mdx
+++ b/packages/styled-ui-docs/pages/alert.mdx
@@ -33,20 +33,20 @@ Alerts provide four severity levels, each with a distinctive icon and color.
 
 ### With close button
 
-Set `isCloseButtonVisible` to `true` to include a close button on the right-hand side of an alert.
+Set `isClosable` to `true` to include a close button on the right-hand side of an alert.
 
 ```jsx
 <Stack direction="column" spacing="4x">
-  <Alert severity="success" isCloseButtonVisible>
+  <Alert severity="success" isClosable>
     <Text>This is a success alert.</Text>
   </Alert>
-  <Alert severity="info" isCloseButtonVisible>
+  <Alert severity="info" isClosable>
     <Text>This is an info alert.</Text>
   </Alert>
-  <Alert severity="warning" isCloseButtonVisible>
+  <Alert severity="warning" isClosable>
     <Text>This is a warning alert.</Text>
   </Alert>
-  <Alert severity="error" isCloseButtonVisible>
+  <Alert severity="error" isClosable>
     <Text>This is an error alert.</Text>
   </Alert>
 </Stack>
@@ -61,27 +61,27 @@ Setting the `icon` prop to `false` will remove the icon altogether.
 ```jsx
 <Stack direction="column" spacing="4x">
   <Alert
-    isCloseButtonVisible
+    isClosable
     severity="success"
   >
     This is a success alert.
   </Alert>
   <Alert
-    isCloseButtonVisible
+    isClosable
     severity="success"
     icon="success"
   >
     This is a success alert.
   </Alert>
   <Alert
-    isCloseButtonVisible
+    isClosable
     severity="success"
     icon={<Icon icon="check-circle-o" color="gray:80" />}
   >
     This is a success alert.
   </Alert>
   <Alert
-    isCloseButtonVisible
+    isClosable
     severity="success"
     icon={false}
   >
@@ -99,7 +99,7 @@ const Paragraph = (props) => (
 
 function Example() {
   return (
-    <Alert isCloseButtonVisible severity="info">
+    <Alert isClosable severity="info">
       <Paragraph>This is the first paragraph.</Paragraph>
       <Paragraph>This is the second paragraph.</Paragraph>
       <Paragraph>This is the third paragraph.</Paragraph>
@@ -116,7 +116,7 @@ You can use the `Text` component with `fontWeight` to display a formatted title 
 
 ```jsx
 <Stack direction="column" spacing="4x">
-  <Alert isCloseButtonVisible severity="success">
+  <Alert isClosable severity="success">
     <Box mb="1x">
       <Text fontWeight="bold">Success</Text>
     </Box>
@@ -124,7 +124,7 @@ You can use the `Text` component with `fontWeight` to display a formatted title 
       This is a success alert.
     </Text>
   </Alert>
-  <Alert isCloseButtonVisible severity="info">
+  <Alert isClosable severity="info">
     <Box mb="1x">
       <Text fontWeight="bold">Info</Text>
     </Box>
@@ -132,7 +132,7 @@ You can use the `Text` component with `fontWeight` to display a formatted title 
       This is an info alert.
     </Text>
   </Alert>
-  <Alert isCloseButtonVisible severity="warning">
+  <Alert isClosable severity="warning">
     <Box mb="1x">
       <Text fontWeight="bold">Warning</Text>
     </Box>
@@ -140,7 +140,7 @@ You can use the `Text` component with `fontWeight` to display a formatted title 
       This is a warning alert.
     </Text>
   </Alert>
-  <Alert isCloseButtonVisible severity="error">
+  <Alert isClosable severity="error">
     <Box mb="1x">
       <Text fontWeight="bold">Error</Text>
     </Box>
@@ -157,10 +157,10 @@ An alert can have an action button (such close). It is rendered after the messag
 
 ```jsx
 <Stack direction="column" spacing={1}>
-  <Alert isCloseButtonVisible severity="warning">
+  <Alert isClosable severity="warning">
     <Text>Your browser is currently not supported. <Link>More Information</Link></Text>
   </Alert>
-  <Alert isCloseButtonVisible severity="error">
+  <Alert isClosable severity="error">
     <Flex justify="space-between" mt={-1} mb={-2}>
       <Text>Your license will expire in 7 days.</Text>
       <FlatButton size="sm" variant="outline" variantColor="black:primary">
@@ -184,7 +184,7 @@ function Example() {
   return (
     <>
       <Collapse isOpen={isOpen}>
-        <Alert isCloseButtonVisible severity="info" onClose={handleClose}>
+        <Alert isClosable severity="info" onClose={handleClose}>
           Click the close button on the right side.
         </Alert>
       </Collapse>
@@ -204,7 +204,7 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| isCloseButtonVisible | boolean | | If `true`, a close button will appear on the right side. |
+| isClosable | boolean | | If `true`, a close button will appear on the right side. |
 | onClose | function | | A callback called when the close button is clicked. |
 | severity | string | 'success' | The severity level of the alert. One of: `'success'`, `'info'`, `'warning'`, `'error'` |
 | icon | string \| ReactNode \| false | | Override the icon displayed before the children. Unless provided, the icon is mapped to the value of the `severity` prop. |

--- a/packages/styled-ui-docs/pages/drawer.mdx
+++ b/packages/styled-ui-docs/pages/drawer.mdx
@@ -116,7 +116,7 @@ function Example() {
   const [backdrop, toggleBackdrop] = useToggle(true);
   const [closeOnEsc, toggleCloseOnEsc] = useToggle(true);
   const [closeOnOutsideClick, toggleCloseOnOutsideClick, setCloseOnOutsideClick] = useToggle(true);
-  const [isCloseButtonVisible, toggleIsCloseButtonVisible] = useToggle(true);
+  const [isClosable, toggleIsClosable] = useToggle(true);
   const [isOverlayVisible, toggleIsOverlayVisible, setIsOverlayVisible] = useToggle(true);
   const [isHeaderVisible, toggleIsHeaderVisible] = useToggle(true);
   const [isBodyVisible, toggleIsBodyVisible] = useToggle(true);
@@ -215,19 +215,19 @@ function Example() {
       <FormGroup>
         <TextLabel display="flex" alignItems="center">
           <Checkbox
-            checked={isCloseButtonVisible}
+            checked={isClosable}
             disabled={!closeOnEsc && !closeOnOutsideClick}
-            onChange={toggleIsCloseButtonVisible}
+            onChange={toggleIsClosable}
           />
           <Space width="2x" />
-          <Text fontFamily="mono" whiteSpace="nowrap">isCloseButtonVisible</Text>
+          <Text fontFamily="mono" whiteSpace="nowrap">isClosable</Text>
         </TextLabel>
       </FormGroup>
       <FormGroup>
         <TextLabel display="flex" alignItems="center">
           <Checkbox
             checked={closeOnEsc}
-            disabled={!isCloseButtonVisible && !closeOnOutsideClick}
+            disabled={!isClosable && !closeOnOutsideClick}
             onChange={toggleCloseOnEsc}
           />
           <Space width="2x" />
@@ -238,7 +238,7 @@ function Example() {
         <TextLabel display="flex" alignItems="center">
           <Checkbox
             checked={closeOnOutsideClick}
-            disabled={(!isCloseButtonVisible && !closeOnEsc) || !backdrop}
+            disabled={(!isClosable && !closeOnEsc) || !backdrop}
             onChange={toggleCloseOnOutsideClick}
           />
           <Space width="2x" />
@@ -288,7 +288,7 @@ function Example() {
             ensureFocus={ensureFocus}
             autoFocus={autoFocus}
             backdrop={backdrop}
-            isCloseButtonVisible={isCloseButtonVisible}
+            isClosable={isClosable}
             isOpen={true} // Set to `true` if a transition is active
             closeOnEsc={closeOnEsc}
             closeOnOutsideClick={closeOnOutsideClick}
@@ -375,7 +375,7 @@ function Example() {
         ensureFocus
         autoFocus
         backdrop
-        isCloseButtonVisible
+        isClosable
         isOpen={isOpen}
         closeOnEsc
         closeOnOutsideClick
@@ -429,7 +429,7 @@ function Example() {
         ensureFocus
         autoFocus
         backdrop
-        isCloseButtonVisible
+        isClosable
         isOpen={isOpen}
         closeOnEsc
         closeOnOutsideClick
@@ -485,7 +485,7 @@ function Example() {
         {styles => (
           <Drawer
             backdrop
-            isCloseButtonVisible
+            isClosable
             isOpen={true} // Set to `true` if a transition is active
             closeOnEsc
             closeOnOutsideClick
@@ -529,7 +529,7 @@ function Example() {
 | finalFocusRef | React.ref | | The `ref` of element to receive focus when the drawer closes. |
 | initialFocusRef | React.ref | | The `ref` of the element to receive focus when the drawer opens. |
 | isOpen | boolean | false | If `true`, the drawer is shown. |
-| isCloseButtonVisible | boolean | false | If `true`, a close button will appear on the right side. |
+| isClosable | boolean | false | If `true`, a close button will appear on the right side. |
 | closeOnEsc | boolean | false | If `true`, close the drawer when the `esc` key is pressed. |
 | closeOnOutsideClick | boolean | false | If `true`, close the drawer when click outside of the drawer. Note that this value will not have any effect when `backdrop` is set to `true`. |
 | onClose | function | | Callback fired when the drawer closes. |

--- a/packages/styled-ui-docs/pages/modal.mdx
+++ b/packages/styled-ui-docs/pages/modal.mdx
@@ -184,7 +184,7 @@ function Example() {
   const [autoFocus, toggleAutoFocus] = useToggle(true);
   const [closeOnEsc, toggleCloseOnEsc] = useToggle(true);
   const [closeOnOutsideClick, toggleCloseOnOutsideClick] = useToggle(true);
-  const [isCloseButtonVisible, toggleIsCloseButtonVisible] = useToggle(true);
+  const [isClosable, toggleIsClosable] = useToggle(true);
   const [isOverlayVisible, toggleIsOverlayVisible] = useToggle(true);
   const [isHeaderVisible, toggleIsHeaderVisible] = useToggle(true);
   const [isBodyVisible, toggleIsBodyVisible] = useToggle(true);
@@ -245,7 +245,7 @@ function Example() {
         <TextLabel display="flex" alignItems="center">
           <Checkbox
             checked={closeOnEsc}
-            disabled={!isCloseButtonVisible && !closeOnOutsideClick}
+            disabled={!isClosable && !closeOnOutsideClick}
             onChange={toggleCloseOnEsc}
           />
           <Space width="2x" />
@@ -256,7 +256,7 @@ function Example() {
         <TextLabel display="flex" alignItems="center">
           <Checkbox
             checked={closeOnOutsideClick}
-            disabled={!isCloseButtonVisible && !closeOnEsc}
+            disabled={!isClosable && !closeOnEsc}
             onChange={toggleCloseOnOutsideClick}
           />
           <Space width="2x" />
@@ -266,12 +266,12 @@ function Example() {
       <FormGroup>
         <TextLabel display="flex" alignItems="center">
           <Checkbox
-            checked={isCloseButtonVisible}
+            checked={isClosable}
             disabled={!closeOnEsc && !closeOnOutsideClick}
-            onChange={toggleIsCloseButtonVisible}
+            onChange={toggleIsClosable}
           />
           <Space width="2x" />
-          <Text fontFamily="mono" whiteSpace="nowrap">isCloseButtonVisible</Text>
+          <Text fontFamily="mono" whiteSpace="nowrap">isClosable</Text>
         </TextLabel>
       </FormGroup>
       <FormGroup>
@@ -312,7 +312,7 @@ function Example() {
             autoFocus={autoFocus}
             closeOnEsc={closeOnEsc}
             closeOnOutsideClick={closeOnOutsideClick}
-            isCloseButtonVisible={isCloseButtonVisible}
+            isClosable={isClosable}
             isOpen={true} // Set to `true` if a transition is active
             onClose={onClose}
             size={size}
@@ -396,7 +396,7 @@ function Example() {
         autoFocus
         closeOnEsc
         closeOnOutsideClick
-        isCloseButtonVisible
+        isClosable
         isOpen={isOpen}
         onClose={onClose}
         size={size}
@@ -434,7 +434,7 @@ function Example() {
       <Modal
         closeOnEsc
         closeOnOutsideClick
-        isCloseButtonVisible
+        isClosable
         isOpen={isOpen}
         onClose={onClose}
         size="auto"
@@ -466,7 +466,7 @@ function Example() {
       <Modal
         closeOnEsc
         closeOnOutsideClick
-        isCloseButtonVisible
+        isClosable
         isOpen={isNestedOpen}
         onClose={onNestedClose}
       >
@@ -522,7 +522,7 @@ function Example() {
             autoFocus
             closeOnEsc
             closeOnOutsideClick
-            isCloseButtonVisible
+            isClosable
             isOpen={true} // Set to `true` if a transition is active
             onClose={onClose}
           >
@@ -570,7 +570,7 @@ function Example() {
             autoFocus
             closeOnEsc
             closeOnOutsideClick
-            isCloseButtonVisible
+            isClosable
             isOpen={true} // Set to `true` if a transition is active
             onClose={onClose}
           >
@@ -608,7 +608,7 @@ function Example() {
 | autoFocus | boolean | false | If `true` and `ensureFocus` is `true` and `initialFocusRef` is not set, it will automatically set focus on the first focusable element. |
 | finalFocusRef | React.ref | | The `ref` of element to receive focus when the modal closes. |
 | initialFocusRef | React.ref | | The `ref` of the element to receive focus when the modal opens. |
-| isCloseButtonVisible | boolean | false | If `true`, a close button will appear on the right side. |
+| isClosable | boolean | false | If `true`, a close button will appear on the right side. |
 | isOpen | boolean | false | If `true`, the modal is shown. |
 | closeOnEsc | boolean | false | If `true`, close the modal when the `esc` key is pressed. |
 | closeOnOutsideClick | boolean | false | If `true`, close the modal when click outside of the modal. |

--- a/packages/styled-ui-docs/pages/tag.mdx
+++ b/packages/styled-ui-docs/pages/tag.mdx
@@ -106,14 +106,14 @@ Use the `size` prop to change the size of the `Tag`. You can set the value to `s
 ```jsx
 <Stack spacing="4x">
   <Stack direction="row" spacing="4x" shouldWrapChildren>
-    <Tag isCloseButtonVisible>Normal</Tag>
-    <Tag isCloseButtonVisible disabled>Disabled</Tag>
-    <Tag isCloseButtonVisible isInvalid>Invalid</Tag>
+    <Tag isClosable>Normal</Tag>
+    <Tag isClosable disabled>Disabled</Tag>
+    <Tag isClosable isInvalid>Invalid</Tag>
   </Stack>
   <Stack direction="row" spacing="4x" shouldWrapChildren>
-    <Tag variant="outline" isCloseButtonVisible>Normal</Tag>
-    <Tag variant="outline" isCloseButtonVisible disabled>Disabled</Tag>
-    <Tag variant="outline" isCloseButtonVisible isInvalid>Invalid</Tag>
+    <Tag variant="outline" isClosable>Normal</Tag>
+    <Tag variant="outline" isClosable disabled>Disabled</Tag>
+    <Tag variant="outline" isClosable isInvalid>Invalid</Tag>
   </Stack>
 </Stack>
 ```
@@ -483,7 +483,7 @@ render(<Tags />);
 | :--- | :--- | :------ | :---------- |
 | disabled | boolean | | If `true`, the tag will be disabled. This sets `aria-disabled=true` and you can style this state by passing the `_disabled` prop. |
 | isInvalid | boolean | | If `true`, the tag will indicate an error. You can style this state by passing the `_invalid` prop. |
-| isCloseButtonVisible | boolean | | If `true`, a close button will appear on the right side. |
+| isClosable | boolean | | If `true`, a close button will appear on the right side. |
 | onClose | function | | A callback called when the close button is clicked. |
 | size | string | 'md' | The size of the tag component. One of: `'sm'`, `'md'`, `'lg'` |
 | variant | string | 'solid' | The variant style of the tag component. One of: `'solid'`, `'outline'` |

--- a/packages/styled-ui-docs/pages/toast.mdx
+++ b/packages/styled-ui-docs/pages/toast.mdx
@@ -51,13 +51,13 @@ function Example() {
 
 ```jsx noInline
 const ToastSimple = ({ onClose }) => (
-  <Toast isCloseButtonVisible onClose={onClose}>
+  <Toast isClosable onClose={onClose}>
     <Text>This is a toast notification.</Text>
   </Toast>
 );
 
 const ToastWithIcon = ({ onClose }) => (
-  <Toast isCloseButtonVisible onClose={onClose} py="4x">
+  <Toast isClosable onClose={onClose} py="4x">
     <Flex align="flex-start">
       <Box
         bg="gray:40"
@@ -71,7 +71,7 @@ const ToastWithIcon = ({ onClose }) => (
 );
 
 const ToastWithTitle = ({ onClose }) => (
-  <Toast isCloseButtonVisible onClose={onClose} py="4x">
+  <Toast isClosable onClose={onClose} py="4x">
     <Box mb="2x">
       <Text fontWeight="bold">Notification Title</Text>
     </Box>
@@ -82,7 +82,7 @@ const ToastWithTitle = ({ onClose }) => (
 );
 
 const ToastWithActionButton = ({ onClose }) => (
-  <Toast isCloseButtonVisible onClose={onClose} py="4x">
+  <Toast isClosable onClose={onClose} py="4x">
     <Box mb="6x">
       <Text>This is a toast notification.</Text>
     </Box>
@@ -95,7 +95,7 @@ const ToastWithActionButton = ({ onClose }) => (
 );
 
 const ToastWithActionLink = ({ onClose }) => (
-  <Toast isCloseButtonVisible onClose={onClose} py="4x">
+  <Toast isClosable onClose={onClose} py="4x">
     <Box mb="6x">
       <Text>This is a toast notification.</Text>
     </Box>
@@ -106,7 +106,7 @@ const ToastWithActionLink = ({ onClose }) => (
 );
 
 const ToastWithAllTogether = ({ onClose }) => (
-  <Toast isCloseButtonVisible onClose={onClose} py="4x">
+  <Toast isClosable onClose={onClose} py="4x">
     <Box mb="2x">
       <Text fontWeight="bold">Notification Title</Text>
     </Box>
@@ -252,7 +252,7 @@ You can control the appearance of a toast notification. If specified, the value 
 ```jsx noInline
 const ToastSuccess = ({ onClose }) => (
   <Toast
-    isCloseButtonVisible
+    isClosable
     onClose={onClose}
     appearance="success"
   >
@@ -262,7 +262,7 @@ const ToastSuccess = ({ onClose }) => (
 
 const ToastInfo = ({ onClose }) => (
   <Toast
-    isCloseButtonVisible
+    isClosable
     onClose={onClose}
     appearance="info"
   >
@@ -272,7 +272,7 @@ const ToastInfo = ({ onClose }) => (
 
 const ToastWarning = ({ onClose }) => (
   <Toast
-    isCloseButtonVisible
+    isClosable
     onClose={onClose}
     appearance="warning"
   >
@@ -282,7 +282,7 @@ const ToastWarning = ({ onClose }) => (
 
 const ToastError = ({ onClose }) => (
   <Toast
-    isCloseButtonVisible
+    isClosable
     onClose={onClose}
     appearance="error"
   >
@@ -365,7 +365,7 @@ Setting the `icon` prop to `false` will remove the icon altogether.
 ```jsx noInline
 const ToastWithDefaultIcon = ({ onClose }) => (
   <Toast
-    isCloseButtonVisible
+    isClosable
     onClose={onClose}
     appearance="success"
   >
@@ -375,7 +375,7 @@ const ToastWithDefaultIcon = ({ onClose }) => (
 
 const ToastWithAnotherIcon = ({ onClose }) => (
   <Toast
-    isCloseButtonVisible
+    isClosable
     onClose={onClose}
     appearance="success"
     icon="success"
@@ -386,7 +386,7 @@ const ToastWithAnotherIcon = ({ onClose }) => (
 
 const ToastWithProprietaryIcon = ({ onClose }) => (
   <Toast
-    isCloseButtonVisible
+    isClosable
     onClose={onClose}
     appearance="success"
     icon={<Icon icon="check-circle-o" color="gray:80" />}
@@ -397,7 +397,7 @@ const ToastWithProprietaryIcon = ({ onClose }) => (
 
 const ToastWithoutIcon = ({ onClose }) => (
   <Toast
-    isCloseButtonVisible
+    isClosable
     onClose={onClose}
     appearance="success"
     icon={false}
@@ -478,7 +478,7 @@ A `Toast` element is composed of the [`Box`](./box) component. You can override 
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| isCloseButtonVisible | boolean | | If `true`, a close button will appear on the right side. |
+| isClosable | boolean | | If `true`, a close button will appear on the right side. |
 | onClose | function | | A callback called when the close button is clicked. |
 | appearance | string | 'none' | One of: `'none'`, `'success'`, `'info'`, `'warning'`, `'error'` |
 | icon | string \| ReactNode \| false | | Override the icon displayed before the children. Unless provided, the icon is mapped to the value of the `appearance` prop. |


### PR DESCRIPTION
#322 Shorthand for `isCloseButtonVisible`