### PR TITLE
fix: downgrade color version from 4.x to 3.x for "Module parse failed:  Identifier directly after number" error

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
     "@trendmicro/styled-ui-theme": "^0.13.1",
     "@trendmicro/tmicon": "^1.21.0",
     "chained-function": "^0.5.0",
-    "color": "4.x",
+    "color": "3.x",
     "ensure-type": "1.x",
     "lodash.get": "4.x",
     "micro-memoize": "4.x",


### PR DESCRIPTION
## Issue
https://github.com/Qix-/color/issues/222

<img width="1112" alt="F8083488-6234-4582-9F53-898FF9DEFF31" src="https://user-images.githubusercontent.com/24446505/140904773-50cb8352-cb94-4b15-adf4-c05f2e3a92d1.png">
