### PR TITLE
feat: add support for the `colorScheme` property (#379)

### DIFF
--- a/packages/docs/components/MDXComponents.jsx
+++ b/packages/docs/components/MDXComponents.jsx
@@ -280,8 +280,7 @@ const code = props => (
 
 const inlineCode = props => (
   <Code
-    fontSize="md"
-    lineHeight="md"
+    fontSize="85%"
     {...props}
   />
 );

--- a/packages/docs/pages/_app.js
+++ b/packages/docs/pages/_app.js
@@ -1,4 +1,4 @@
-import { css, Global } from '@emotion/react';
+import { Global, css } from '@emotion/react';
 import { MDXProvider } from '@mdx-js/react';
 import {
   Box,
@@ -48,7 +48,7 @@ const Layout = ({ children }) => {
     <>
       <Global
         styles={css`
-          html {
+          :root {
             color-scheme: ${colorMode};
           }
           body {

--- a/packages/docs/pages/_app.js
+++ b/packages/docs/pages/_app.js
@@ -48,6 +48,9 @@ const Layout = ({ children }) => {
     <>
       <Global
         styles={css`
+          html {
+            color-scheme: ${colorMode};
+          }
           body {
             font-size: ${fontSizes.sm};
             line-height: ${lineHeights.sm};

--- a/packages/docs/pages/color-mode.mdx
+++ b/packages/docs/pages/color-mode.mdx
@@ -1,5 +1,7 @@
 # Color Modes
 
+### ColorModeProvider
+
 Use the `ColorModeProvider` to use color mode in your application. The color mode value can be one of `dark` or `light`. By default, the color mode is `light` if the value is not explicitly specified.
 
 ```jsx disabled
@@ -26,6 +28,8 @@ function Example({ children }) {
 }
 ```
 
+### useColorMode Hook
+
 To handle color mode manually in your application, use the `useColorMode` Hook to get current color mode or change the color mode.
 
 ```jsx disabled
@@ -48,7 +52,7 @@ const App = () => {
     <>
       <Global
         styles={css`
-          html {
+          :root {
             color-scheme: ${colorMode};
           }
         `}
@@ -61,19 +65,36 @@ const App = () => {
 };
 ```
 
-To force a specific color mode, wrap your component in `LightMode` or `DarkMode`, it will override the global color mode.
+### Color schemes
+
+To opt the entire page into the user's color scheme preferences declare `color-scheme` on the `:root` element.
+
+```jsx disabled
+<Global
+  styles={css`
+    :root {
+      color-scheme: dark;
+    }
+  `}
+/>
+```
+
+### DarkMode / LightMode
+
+To force a specific color mode, wrap your component in `LightMode` or `DarkMode`, it will override the global color mode and set the color scheme to `dark` or `light` respectively.
 
 ```jsx
 <Flex>
-  <LightMode bg="white" color="black:primary" px="4x" py="2x">
-    <Button variant="outline">
-      Light Mode
-    </Button>
-  </LightMode>
-  <DarkMode bg="gray:100" color="white:primary" px="4x" py="2x">
-    <Button variant="outline">
-      Dark Mode
-    </Button>
+  <DarkMode bg="gray:90" color="white:primary">
+    <Text px="4x" py="3x">
+      This is dark mode
+    </Text>
   </DarkMode>
+  <Space width="4x" />
+  <LightMode bg="gray:10" color="black:primary">
+    <Text px="4x" py="3x">
+      This is light mode
+    </Text>
+  </LightMode>
 </Flex>
 ```

--- a/packages/docs/pages/color-mode.mdx
+++ b/packages/docs/pages/color-mode.mdx
@@ -11,10 +11,12 @@ import {
 } from '@trendmicro/react-styled-ui';
 import App from './App';
 
+const initialColorMode = 'dark';
+
 function Example({ children }) {
   return (
     <ThemeProvider>
-      <ColorModeProvider value="dark">
+      <ColorModeProvider value={initialColorMode}>
         <ColorStyleProvider>
           <App />
         </ColorStyleProvider>
@@ -28,11 +30,12 @@ To handle color mode manually in your application, use the `useColorMode` Hook t
 
 ```jsx disabled
 // App.jsx
+import { css, Global } from '@emotion/react';
 import { Button, useColorMode } from '@trendmicro/react-styled-ui';
 import React from 'react';
 
 const App = () => {
-  const [colorMode, setColorMode] = useColorMode();
+  const [colorMode, setColorMode] = useColorMode(); // One of: 'dark', 'light'
   const toggleColorMode = () => {
     const nextColorMode = {
       'dark': 'light',
@@ -42,9 +45,18 @@ const App = () => {
   };
 
   return (
-    <Button onClick={toggleColorMode}>
-      Toggle Color Mode
-    </Button>
+    <>
+      <Global
+        styles={css`
+          html {
+            color-scheme: ${colorMode};
+          }
+        `}
+      />
+      <Button onClick={toggleColorMode}>
+        Toggle Color Mode
+      </Button>
+    </>
   );
 };
 ```

--- a/packages/docs/pages/getting-started.mdx
+++ b/packages/docs/pages/getting-started.mdx
@@ -54,10 +54,15 @@ object as a prop.
 
 ```js
 import React from 'react';
+import { render } from 'react-dom';
 import { ThemeProvider } from '@trendmicro/react-styled-ui';
 
-// Use at the root of your app
-<ThemeProvider theme={customTheme}>{props.children}</ThemeProvider>;
+render(
+  <ThemeProvider theme={customTheme}>
+    {children}
+  </ThemeProvider>,
+  document.getElementById('root'),
+);
 ```
 
 ## Using components
@@ -75,7 +80,7 @@ Sometimes you may need to apply base CSS styles to your application. Tonic UI ex
 `CSSBaseline` is recommended to add at the root to ensure all components work correctly.
 
 ```js
-import { css, Global } from '@emotion/react';
+import { Global, css } from '@emotion/react';
 import {
   Box,
   ColorModeProvider,
@@ -100,7 +105,7 @@ const Layout = (props) => {
     <>
       <Global
         styles={css`
-          html {
+          :root {
             color-scheme: ${colorMode};
           }
           body {

--- a/packages/docs/pages/getting-started.mdx
+++ b/packages/docs/pages/getting-started.mdx
@@ -90,7 +90,7 @@ import {
 import App from './App';
 
 const Layout = (props) => {
-  const [colorMode] = useColorMode();
+  const [colorMode] = useColorMode(); // One of: 'dark', 'light'
   const [colorStyle] = useColorStyle({ colorMode });
   const { fontSizes, lineHeights } = useTheme();
   const backgroundColor = colorStyle.background.primary;
@@ -100,6 +100,9 @@ const Layout = (props) => {
     <>
       <Global
         styles={css`
+          html {
+            color-scheme: ${colorMode};
+          }
           body {
             font-size: ${fontSizes.sm};
             line-height: ${lineHeights.sm};

--- a/packages/react/src/DarkMode/index.js
+++ b/packages/react/src/DarkMode/index.js
@@ -4,7 +4,10 @@ import ColorModeProvider from '../ColorModeProvider';
 
 const DarkMode = (props) => (
   <ColorModeProvider value="dark">
-    <Box {...props} />
+    <Box
+      colorScheme="dark"
+      {...props}
+    />
   </ColorModeProvider>
 );
 

--- a/packages/react/src/LightMode/index.js
+++ b/packages/react/src/LightMode/index.js
@@ -4,7 +4,10 @@ import ColorModeProvider from '../ColorModeProvider';
 
 const LightMode = (props) => (
   <ColorModeProvider value="light">
-    <Box {...props} />
+    <Box
+      colorScheme="light"
+      {...props}
+    />
   </ColorModeProvider>
 );
 

--- a/packages/react/src/shared/styled-system/config.js
+++ b/packages/react/src/shared/styled-system/config.js
@@ -14,6 +14,9 @@ const config = {
   backgroundAttachment: true,
   backgroundClip: true,
 
+  // Color
+  colorScheme: true,
+
   // Containment
   contain: true,
   containIntrinsicSize: true,


### PR DESCRIPTION
## Examples

### Adapting to color schemes

To opt the entire page into the user's color scheme preferences declare `color-scheme` on the `:root` element.

```jsx
import { Global, css } from '@emotion/react';
import React from 'react';
import { render } from 'react-dom';
import App from './App';

render(
  <>
    <Global
      styles={css`
        :root {
          color-scheme: dark;
        }
      `}
    />
    <App />
  </>
);
```

You can also manually set the `colorScheme` property to change the color scheme:

```jsx
<Box colorScheme="dark" />
```

or using the `DarkMode` or `LightMode` component to change color mode as well:

```jsx
<DarkMode />
```