### PR TITLE
feat: refine `Badge` component and deprecate unwanted props

### DIFF
--- a/packages/docs/pages/badge.mdx
+++ b/packages/docs/pages/badge.mdx
@@ -11,108 +11,171 @@ import { Badge } from '@trendmicro/react-styled-ui';
 ## Usage
 
 ```jsx
-<Stack direction="column" spacing="4x" shouldWrapChildren>
-  <Stack direction="row" spacing="6x" shouldWrapChildren>
-    <Badge badgeContent="5+">
-      <Icon icon="alert" />
-    </Badge>
-    <Badge badgeContent="99+">
-      <Icon icon="alert" />
-    </Badge>
-    <Badge badgeContent="87">
-      <Icon icon="alert" />
-    </Badge>
-    <Badge variant="dot" offset={[4, 2]} borderColor="gray:100">
-      <Icon icon="alert" />
-    </Badge>
-    <Badge variant="dot" dotSize={6} offset={[4, 2]} borderColor="gray:100">
-      <Icon icon="alert" />
-    </Badge>
-    <Badge isHidden>
-      <Icon icon="alert" />
-    </Badge>
-    <Badge badgeContent={0}>
-      <Icon icon="alert" />
-    </Badge>
-    <Badge badgeContent="!">
-      <Icon icon="alert" />
-    </Badge>
-    <Badge badgeContent={<Text color="yellow:50">Text</Text>}>
-      <Icon icon="alert" />
-    </Badge>
-  </Stack>
-  <Stack direction="row" spacing="6x" shouldWrapChildren>
-    <Badge badgeContent="5+">
-      <Skeleton variant="rect" width={42} height={42} />
-    </Badge>
-    <Badge badgeContent="99+">
-      <Skeleton variant="rect" width={42} height={42} />
-    </Badge>
-    <Badge badgeContent="87">
-      <Skeleton variant="rect" width={42} height={42} />
-    </Badge>
-    <Badge variant="dot" borderColor="gray:100">
-      <Skeleton variant="rect" width={42} height={42} />
-    </Badge>
-    <Badge variant="dot" dotSize={6} borderColor="gray:100">
-      <Skeleton variant="rect" width={42} height={42} />
-    </Badge>
-    <Badge isHidden>
-      <Skeleton variant="rect" width={42} height={42} />
-    </Badge>
-    <Badge badgeContent={0}>
-      <Skeleton variant="rect" width={42} height={42} />
-    </Badge>
-    <Badge badgeContent="!">
-      <Skeleton variant="rect" width={42} height={42} />
-    </Badge>
-    <Badge badgeContent={<Text color="yellow:50">Text</Text>}>
-      <Skeleton variant="rect" width={42} height={42} />
-    </Badge>
-  </Stack>
-</Stack>
-```
-
-### Badge color
-
-Use the `backgroundColor` prop to set the background color of the badge.
-
-```jsx
-<Stack direction="row" spacing="4x">
-  <Badge backgroundColor="red:60" badgeContent={1} />
-  <Badge backgroundColor="orange:50" badgeContent={2} />
-  <Badge backgroundColor="yellow:50" badgeContent={3} />
-  <Badge backgroundColor="green:60" badgeContent={4} />
-  <Badge backgroundColor="blue:60" badgeContent={5} />
-  <Badge backgroundColor="gray:60" badgeContent={6} />
-  <Badge backgroundColor="magenta:60" badgeContent={7} />
-  <Badge backgroundColor="purple:60" badgeContent={8} />
-  <Badge backgroundColor="teal:60" badgeContent={9} />
-  <Badge backgroundColor="cyan:60" badgeContent={10} />
-</Stack>
-```
-
-### Badge border
-
-Use `borderColor` and `borderWidth` to change the border color and width of the badge.
-
-```jsx
-<Stack direction="row" spacing="6x" shouldWrapChildren>
-  <Badge badgeContent="2" borderColor="orange:50" borderWidth={1}>
+<Grid
+  columnGap="8x"
+  justifyItems="center"
+  rowGap="8x"
+  templateColumns="repeat(5,1fr)"
+  width="min-content"
+>
+  <Badge />
+  <Badge badgeContent="2" />
+  <Badge badgeContent="24" />
+  <Badge badgeContent="99+" />
+  <Badge badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>} />
+  <Badge>
     <Icon icon="alert" />
   </Badge>
-  <Badge badgeContent="2" borderColor="orange:50" borderWidth={3}>
+  <Badge badgeContent="2">
     <Icon icon="alert" />
   </Badge>
-</Stack>
+  <Badge badgeContent="24">
+    <Icon icon="alert" />
+  </Badge>
+  <Badge badgeContent="99+">
+    <Icon icon="alert" />
+  </Badge>
+  <Badge
+    badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>}
+  >
+    <Icon icon="alert" mt="1x" mr="2x" />
+  </Badge>
+  <Badge>
+    <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+  </Badge>
+  <Badge badgeContent="2">
+    <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+  </Badge>
+  <Badge badgeContent="24">
+    <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+  </Badge>
+  <Badge badgeContent="99+">
+    <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+  </Badge>
+  <Badge
+    badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>}
+  >
+    <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+  </Badge>
+</Grid>
 ```
+
+### Customize badge style
+
+You can customize the badge style by passing style props. See the following example to learn how to create a outline badge.
+
+```jsx noInline
+const OutlineBadge = React.forwardRef((props, ref) => {
+  const [colorMode] = useColorMode();
+  const backgroundColor = {
+    dark: 'gray:100',
+    light: 'white',
+  }[colorMode];
+  const borderColor = {
+    dark: 'red:60',
+    light: 'red:60',
+  }[colorMode];
+  const borderWidth = '2q'; // '2q' is equal to '2px'
+  const boxShadow = { // 'boxShadow' is used to create the outline effect
+    dark: '0 0 0 1px #151515',
+    light: '0 0 0 1px white',
+  }[colorMode];
+  const color = {
+    dark: 'white:primary',
+    light: 'black:primary',
+  }[colorMode];
+
+  return (
+    <Badge
+      ref={ref}
+      backgroundColor={backgroundColor}
+      borderColor={borderColor}
+      borderWidth={borderWidth}
+      boxShadow={boxShadow}
+      color={color}
+      {...props}
+    />
+  );
+});
+
+function Example() {
+  return (
+    <Grid
+      columnGap="8x"
+      justifyItems="center"
+      rowGap="8x"
+      templateColumns="repeat(5,1fr)"
+      width="min-content"
+    >
+      <OutlineBadge>
+        <Icon icon="alert" />
+      </OutlineBadge>
+      <OutlineBadge badgeContent="2">
+        <Icon icon="alert" />
+      </OutlineBadge>
+      <OutlineBadge badgeContent="24">
+        <Icon icon="alert" />
+      </OutlineBadge>
+      <OutlineBadge badgeContent="99+">
+        <Icon icon="alert" />
+      </OutlineBadge>
+      <OutlineBadge
+        badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>}
+      >
+        <Icon icon="alert" mt="1x" mr="2x" />
+      </OutlineBadge>
+      <OutlineBadge>
+        <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+      </OutlineBadge>
+      <OutlineBadge badgeContent="2">
+        <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+      </OutlineBadge>
+      <OutlineBadge badgeContent="24">
+        <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+      </OutlineBadge>
+      <OutlineBadge badgeContent="99+">
+        <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+      </OutlineBadge>
+      <OutlineBadge
+        badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>}
+      >
+        <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+      </OutlineBadge>
+    </Grid>
+  );
+}
+
+render(<Example />);
+```
+
+### Change badge color
+
+The color of the badge can be changed by passing the `backgroundColor` prop. See the [colors](./colors) section to learn more about colors.
+
+```jsx
+<Grid
+  columnGap="6x"
+  justifyItems="center"
+  rowGap="6x"
+  templateColumns="repeat(5,1fr)"
+  width="fit-content"
+>
+  <Box><Badge backgroundColor="red:60" badgeContent="red:60" px="4x" py="1h" /></Box>
+  <Box><Badge backgroundColor="orange:50" badgeContent="orange:50" px="4x" py="1h" /></Box>
+  <Box><Badge backgroundColor="yellow:50" badgeContent="yellow:50" px="4x" py="1h" /></Box>
+  <Box><Badge backgroundColor="green:60" badgeContent="green:60" px="4x" py="1h" /></Box>
+  <Box><Badge backgroundColor="blue:60" badgeContent="blue:60" px="4x" py="1h" /></Box>
+  <Box><Badge backgroundColor="gray:60" badgeContent="gray:60" px="4x" py="1h"/></Box>
+  <Box><Badge backgroundColor="magenta:60" badgeContent="magenta:60" px="4x" py="1h"/></Box>
+  <Box><Badge backgroundColor="purple:60" badgeContent="purple:60" px="4x" py="1h" /></Box>
+  <Box><Badge backgroundColor="teal:60" badgeContent="teal:60" px="4x" py="1h" /></Box>
+  <Box><Badge backgroundColor="cyan:60" badgeContent="cyan:60" px="4x" py="1h" /></Box>
+</Grid>
+```
+
 ## Props
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| variant | string | 'badge' | 'badge' or 'dot'. |
-| badgeContent | number\|string\|React Element  | | |
-| isHidden | boolean  | false | show badge content or not. |
-| offset | \[number, number\]  | - | Set offset of the badge. |
-| borderColor | string  | value of `variantColor` | Set border color of the badge when overlap a children. |
-| borderWidth | number  | 1 | Set border width of the badge when overlap a children. |
+| variant | string | 'solid' | One of: 'solid', 'dot' |
+| badgeContent | node \| string | | The badge content. |

--- a/packages/docs/pages/badge.mdx
+++ b/packages/docs/pages/badge.mdx
@@ -38,7 +38,7 @@ import { Badge } from '@trendmicro/react-styled-ui';
   <Badge
     badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>}
   >
-    <Icon icon="alert" mt="1x" mr="2x" />
+    <Icon icon="alert" mr="2x" />
   </Badge>
   <Badge>
     <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
@@ -84,6 +84,7 @@ const OutlineBadge = React.forwardRef((props, ref) => {
     dark: 'white:primary',
     light: 'black:primary',
   }[colorMode];
+  const minWidth = '5x';
 
   return (
     <Badge
@@ -93,6 +94,7 @@ const OutlineBadge = React.forwardRef((props, ref) => {
       borderWidth={borderWidth}
       boxShadow={boxShadow}
       color={color}
+      minWidth={minWidth}
       {...props}
     />
   );
@@ -122,7 +124,7 @@ function Example() {
       <OutlineBadge
         badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>}
       >
-        <Icon icon="alert" mt="1x" mr="2x" />
+        <Icon icon="alert" mr="2x" />
       </OutlineBadge>
       <OutlineBadge>
         <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />

--- a/packages/docs/pages/badge.mdx
+++ b/packages/docs/pages/badge.mdx
@@ -12,6 +12,8 @@ import { Badge } from '@trendmicro/react-styled-ui';
 
 ### Basic badge
 
+To display the badge on the top-right corner of the wrapped component, specify the `badgeContent` prop with the desired content.
+
 ```jsx
 <Grid
   columnGap="8x"
@@ -78,15 +80,15 @@ Use `variant="dot"` to change a badge into a small dot. This can be used as a no
 
 ### Standalone badge
 
-The badge can be standalone when children is not provided. This can be useful for displaying a badge without a surrounding element.
+The badge can be used as a standalone component. This can be useful for displaying a badge without a surrounding element.
 
 ```jsx
 <Stack direction="row" spacing="8x" alignItems="center" shouldWrapChildren>
   <Badge variant="dot" />
-  <Badge badgeContent={0} />
-  <Badge badgeContent={5} />
-  <Badge badgeContent="99+" />
-  <Badge badgeContent={<Icon icon="virus" size="4x" />} px="1x" py="1x" />
+  <Badge variant="solid" badgeContent={0} />
+  <Badge variant="solid" badgeContent={5} />
+  <Badge variant="solid" badgeContent="99+" />
+  <Badge variant="solid" badgeContent={<Icon icon="virus" size="4x" />} px="1x" py="1x" />
 </Stack>
 ```
 
@@ -295,7 +297,7 @@ render(<Example />);
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| badgeContent | node \| string | | The badge content. |
+| badgeContent | node \| number \| string | | The badge content. |
 | isInvisible | boolean | | Whether the badge is invisible. |
 | placement | string | 'top-right' | The placement of the badge. One of: 'top-left', 'top-right', 'bottom-left', 'bottom-right'. |
 | variant | string | 'solid' | One of: 'solid', 'dot' |

--- a/packages/docs/pages/badge.mdx
+++ b/packages/docs/pages/badge.mdx
@@ -215,6 +215,24 @@ function Example() {
 }
 ```
 
+### Size
+
+The size of the badge can be changed by passing the `width` and `height` props.
+
+```jsx
+<Stack direction="row" spacing="8x" shouldWrapChildren>
+  <Badge badgeContent={5} width="4x" height="4x" minWidth="4x" fontSize="xs">
+    <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+  </Badge>
+  <Badge badgeContent={5} width="5x" height="5x" minWidth="5x" fontSize="sm">
+    <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+  </Badge>
+  <Badge badgeContent={5} width="6x" height="6x" minWidth="6x" fontSize="md">
+    <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+  </Badge>
+</Stack>
+```
+
 ### Customization
 
 You can customize the badge style by passing style props. See the following example to learn how to create a outline badge.

--- a/packages/docs/pages/badge.mdx
+++ b/packages/docs/pages/badge.mdx
@@ -83,12 +83,12 @@ Use `variant="dot"` to change a badge into a small dot. This can be used as a no
 The badge can be used as a standalone component. This can be useful for displaying a badge without a surrounding element.
 
 ```jsx
-<Stack direction="row" spacing="8x" alignItems="center" shouldWrapChildren>
+<Stack direction="row" spacing="8x" alignItems="center">
   <Badge variant="dot" />
   <Badge variant="solid" badgeContent={0} />
   <Badge variant="solid" badgeContent={5} />
   <Badge variant="solid" badgeContent="99+" />
-  <Badge variant="solid" badgeContent={<Icon icon="virus" size="4x" />} px="1x" py="1x" />
+  <Badge variant="solid" badgeContent={<Icon icon="virus" size="4x" />} height="6x" />
 </Stack>
 ```
 
@@ -217,17 +217,17 @@ function Example() {
 
 ### Size
 
-The size of the badge can be changed by passing the `width` and `height` props.
+The size of the badge can be changed by passing the `height` and `minWidth` props.
 
 ```jsx
 <Stack direction="row" spacing="8x" shouldWrapChildren>
-  <Badge badgeContent={5} width="4x" height="4x" minWidth="4x" fontSize="xs">
+  <Badge badgeContent={5} height="4x" minWidth="4x" fontSize="xs">
     <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
   </Badge>
-  <Badge badgeContent={5} width="5x" height="5x" minWidth="5x" fontSize="sm">
+  <Badge badgeContent={5} height="5x" minWidth="5x" fontSize="sm">
     <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
   </Badge>
-  <Badge badgeContent={5} width="6x" height="6x" minWidth="6x" fontSize="md">
+  <Badge badgeContent={5} height="6x" minWidth="6x" fontSize="md">
     <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
   </Badge>
 </Stack>
@@ -245,18 +245,16 @@ const OutlineBadge = React.forwardRef((props, ref) => {
     light: 'white',
   }[colorMode];
   const borderColor = {
-    dark: 'red:60',
-    light: 'red:60',
+    dark: 'yellow:50',
+    light: 'yellow:50',
   }[colorMode];
+  const borderStyle = 'solid';
   const borderWidth = '2px';
-  const boxShadow = { // 'boxShadow' is used to create the outline effect
-    dark: '0 0 0 1px #151515',
-    light: '0 0 0 1px white',
-  }[colorMode];
   const color = {
     dark: 'white:primary',
     light: 'black:primary',
   }[colorMode];
+  const height = '5x';
   const minWidth = '5x';
 
   return (
@@ -264,9 +262,10 @@ const OutlineBadge = React.forwardRef((props, ref) => {
       ref={ref}
       backgroundColor={backgroundColor}
       borderColor={borderColor}
+      borderStyle={borderStyle}
       borderWidth={borderWidth}
-      boxShadow={boxShadow}
       color={color}
+      height={height}
       minWidth={minWidth}
       {...props}
     />
@@ -282,17 +281,6 @@ function Example() {
       templateColumns="repeat(3,1fr)"
       width="min-content"
     >
-      <OutlineBadge badgeContent={0}>
-        <Icon icon="alert" />
-      </OutlineBadge>
-      <OutlineBadge badgeContent="99+">
-        <Icon icon="alert" />
-      </OutlineBadge>
-      <OutlineBadge
-        badgeContent={<Text fontFamily="mono" fontSize="xs">!</Text>}
-      >
-        <Icon icon="alert" />
-      </OutlineBadge>
       <OutlineBadge badgeContent={0}>
         <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
       </OutlineBadge>

--- a/packages/docs/pages/badge.mdx
+++ b/packages/docs/pages/badge.mdx
@@ -75,7 +75,7 @@ const OutlineBadge = React.forwardRef((props, ref) => {
     dark: 'red:60',
     light: 'red:60',
   }[colorMode];
-  const borderWidth = '2q'; // '2q' is equal to '2px'
+  const borderWidth = '2px';
   const boxShadow = { // 'boxShadow' is used to create the outline effect
     dark: '0 0 0 1px #151515',
     light: '0 0 0 1px white',

--- a/packages/docs/pages/badge.mdx
+++ b/packages/docs/pages/badge.mdx
@@ -75,43 +75,33 @@ import { Badge } from '@trendmicro/react-styled-ui';
 
 ### Badge color
 
-* Pass the `variantColor` prop to customize the color of the Badge. `variantColor`
-can be any **color key with key 60** that exists in the `theme.colors`.
-  > Thats mean the `green:60` exists in the `theme.colors` then can use variantColor="green".
-
-* [Learn more about theming](./theme).
+Use the `backgroundColor` prop to set the background color of the badge.
 
 ```jsx
 <Stack direction="row" spacing="4x">
-  <Badge badgeContent={1} />
-  <Badge variantColor="orange" badgeContent={2} />
-  <Badge variantColor="yellow" badgeContent={3} />
-  <Badge variantColor="green" badgeContent={4} />
-  <Badge variantColor="blue" badgeContent={5} />
-  <Badge variantColor="gray" badgeContent={6} />
-  <Badge variantColor="magenta" badgeContent={7} />
-  <Badge variantColor="purple" badgeContent={8} />
-  <Badge variantColor="teal" badgeContent={9} />
-  <Badge variantColor="cyan" badgeContent={10} />
+  <Badge backgroundColor="red:60" badgeContent={1} />
+  <Badge backgroundColor="orange:50" badgeContent={2} />
+  <Badge backgroundColor="yellow:50" badgeContent={3} />
+  <Badge backgroundColor="green:60" badgeContent={4} />
+  <Badge backgroundColor="blue:60" badgeContent={5} />
+  <Badge backgroundColor="gray:60" badgeContent={6} />
+  <Badge backgroundColor="magenta:60" badgeContent={7} />
+  <Badge backgroundColor="purple:60" badgeContent={8} />
+  <Badge backgroundColor="teal:60" badgeContent={9} />
+  <Badge backgroundColor="cyan:60" badgeContent={10} />
 </Stack>
 ```
 
-### Badge border color
+### Badge border
 
-* Pass the `borderColor` or `borderWidth` props to customize the border of the Badge. It only effect on wrapped children.
+Use `borderColor` and `borderWidth` to change the border color and width of the badge.
 
 ```jsx
 <Stack direction="row" spacing="6x" shouldWrapChildren>
-  <Badge badgeContent="5" borderColor="orange:50">
+  <Badge badgeContent="2" borderColor="orange:50" borderWidth={1}>
     <Icon icon="alert" />
   </Badge>
-  <Badge badgeContent="5">
-    <Icon icon="alert" borderColor="orange:50" borderWidth={3} />
-  </Badge>
-  <Badge badgeContent="5" borderColor="orange:50">
-    <Icon icon="alert" />
-  </Badge>
-  <Badge variant="dot" offset={[4, 2]} borderColor="orange:50" borderWidth={3}>
+  <Badge badgeContent="2" borderColor="orange:50" borderWidth={3}>
     <Icon icon="alert" />
   </Badge>
 </Stack>
@@ -121,7 +111,6 @@ can be any **color key with key 60** that exists in the `theme.colors`.
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
 | variant | string | 'badge' | 'badge' or 'dot'. |
-| variantColor | string | 'red' | The color scheme to use for the badge. It must be a color key defined in `theme.colors`. |
 | badgeContent | number\|string\|React Element  | | |
 | isHidden | boolean  | false | show badge content or not. |
 | offset | \[number, number\]  | - | Set offset of the badge. |

--- a/packages/docs/pages/badge.mdx
+++ b/packages/docs/pages/badge.mdx
@@ -10,6 +10,8 @@ import { Badge } from '@trendmicro/react-styled-ui';
 
 ## Usage
 
+### Basic badge
+
 ```jsx
 <Grid
   columnGap="8x"
@@ -18,49 +20,200 @@ import { Badge } from '@trendmicro/react-styled-ui';
   templateColumns="repeat(5,1fr)"
   width="min-content"
 >
-  <Badge />
-  <Badge badgeContent="2" />
-  <Badge badgeContent="24" />
-  <Badge badgeContent="99+" />
-  <Badge badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>} />
   <Badge>
     <Icon icon="alert" />
   </Badge>
-  <Badge badgeContent="2">
+  <Badge badgeContent={0}>
     <Icon icon="alert" />
   </Badge>
-  <Badge badgeContent="24">
+  <Badge badgeContent={5}>
     <Icon icon="alert" />
   </Badge>
   <Badge badgeContent="99+">
     <Icon icon="alert" />
   </Badge>
   <Badge
-    badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>}
+    badgeContent={<Text fontFamily="mono" fontSize="xs">!</Text>}
   >
-    <Icon icon="alert" mr="2x" />
+    <Icon icon="alert" />
   </Badge>
   <Badge>
     <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
   </Badge>
-  <Badge badgeContent="2">
+  <Badge badgeContent={0}>
     <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
   </Badge>
-  <Badge badgeContent="24">
+  <Badge badgeContent={5}>
     <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
   </Badge>
   <Badge badgeContent="99+">
     <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
   </Badge>
   <Badge
-    badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>}
+    badgeContent={<Text fontFamily="mono" fontSize="xs">!</Text>}
   >
     <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
   </Badge>
 </Grid>
 ```
 
-### Customize badge style
+### Dot badge
+
+Use `variant="dot"` to change a badge into a small dot. This can be used as a notification that something has changed without giving a count.
+
+```jsx
+<Stack direction="row" spacing="8x" shouldWrapChildren>
+  // Pass `isInvisible` to make it invisible
+  <Badge variant="dot" isInvisible>
+    <Icon icon="alert" />
+  </Badge>
+  <Badge variant="dot">
+    <Icon icon="alert" />
+  </Badge>
+  <Badge variant="dot" width="3x" height="3x">
+    <Icon icon="alert" />
+  </Badge>
+</Stack>
+```
+
+### Standalone badge
+
+The badge can be standalone when children is not provided. This can be useful for displaying a badge without a surrounding element.
+
+```jsx
+<Stack direction="row" spacing="8x" alignItems="center" shouldWrapChildren>
+  <Badge variant="dot" />
+  <Badge badgeContent={0} />
+  <Badge badgeContent={5} />
+  <Badge badgeContent="99+" />
+  <Badge badgeContent={<Icon icon="virus" size="4x" />} px="1x" py="1x" />
+</Stack>
+```
+
+### Badge alignment
+
+You can use the `placement` prop to move the badge to any corner of the wrapped element. The default placement is `top-right`. The `placement` prop can be one of `top-left`, `top-right`, `bottom-left`, `bottom-right`.
+
+```jsx
+<Grid
+  columnGap="8x"
+  rowGap="8x"
+  templateColumns="1fr 1fr"
+  width="min-content"
+>
+  <Badge placement="top-left" badgeContent={1}>
+    <Icon icon="alert" />
+  </Badge>
+  <Badge placement="top-right" badgeContent={1}>
+    <Icon icon="alert" />
+  </Badge>
+  <Badge placement="bottom-left" badgeContent={1}>
+    <Icon icon="alert" />
+  </Badge>
+  <Badge placement="bottom-right" badgeContent={1}>
+    <Icon icon="alert" />
+  </Badge>
+</Grid>
+```
+
+### Badge visibility
+
+The badge visibility can be controlled using the `isInvisible` prop.
+
+```jsx
+function Example() {
+  const [count, setCount] = React.useState(1);
+  const [isInvisible, setIsInvisible] = React.useState(false);
+
+  return (
+    <Stack direction="column" spacing="8x">
+      <Flex align="center">
+        <Box mr="8x">
+          <Badge badgeContent={count} isInvisible={!(count > 0)}>
+            <Icon icon="alert" />
+          </Badge>
+        </Box>
+        <ButtonGroup
+          variant="secondary"
+        >
+          <Button
+            aria-label="decrease"
+            onClick={() => {
+              setCount(Math.max(count - 1, 0));
+            }}
+          >
+            <Icon icon="minus" />
+          </Button>
+          <Button
+            aria-label="increase"
+            onClick={() => {
+              setCount(Math.max(count + 1, 0));
+            }}
+          >
+            <Icon icon="add" />
+          </Button>
+        </ButtonGroup>
+      </Flex>
+      <Flex alignItems="center">
+        <Box mr="8x">
+          <Badge
+            variant="dot"
+            isInvisible={isInvisible}
+          >
+            <Icon icon="alert" />
+          </Badge>
+        </Box>
+        <TextLabel cursor="pointer">
+          <Flex align="center">
+            <Switch
+              size="md"
+              checked={!isInvisible}
+              onChange={() => {
+                setIsInvisible(!isInvisible);
+              }}
+            />
+            <Space width="2x" />
+            <Text userSelect="none">Show Badge</Text>
+          </Flex>
+        </TextLabel>
+      </Flex>
+    </Stack>
+  );
+}
+```
+
+### Color
+
+The color of the badge can be changed by passing the `backgroundColor` prop. See the [colors](./colors) section to learn more about colors.
+
+```jsx
+function Example() {
+  const colors = [
+    'red:60',
+    'orange:50',
+    'yellow:50',
+    'green:60',
+    'blue:60',
+    'gray:60',
+    'magenta:60',
+    'purple:60',
+    'teal:60',
+    'cyan:60',
+  ];
+
+  return (
+    <Stack direction="row" spacing="8x" shouldWrapChildren>
+      {colors.map(color => (
+        <Badge key={color} backgroundColor={color} badgeContent={5}>
+          <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
+        </Badge>
+      ))}
+    </Stack>
+  );
+}
+```
+
+### Customization
 
 You can customize the badge style by passing style props. See the following example to learn how to create a outline badge.
 
@@ -106,40 +259,28 @@ function Example() {
       columnGap="8x"
       justifyItems="center"
       rowGap="8x"
-      templateColumns="repeat(5,1fr)"
+      templateColumns="repeat(3,1fr)"
       width="min-content"
     >
-      <OutlineBadge>
-        <Icon icon="alert" />
-      </OutlineBadge>
-      <OutlineBadge badgeContent="2">
-        <Icon icon="alert" />
-      </OutlineBadge>
-      <OutlineBadge badgeContent="24">
+      <OutlineBadge badgeContent={0}>
         <Icon icon="alert" />
       </OutlineBadge>
       <OutlineBadge badgeContent="99+">
         <Icon icon="alert" />
       </OutlineBadge>
       <OutlineBadge
-        badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>}
+        badgeContent={<Text fontFamily="mono" fontSize="xs">!</Text>}
       >
-        <Icon icon="alert" mr="2x" />
+        <Icon icon="alert" />
       </OutlineBadge>
-      <OutlineBadge>
-        <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
-      </OutlineBadge>
-      <OutlineBadge badgeContent="2">
-        <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
-      </OutlineBadge>
-      <OutlineBadge badgeContent="24">
+      <OutlineBadge badgeContent={0}>
         <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
       </OutlineBadge>
       <OutlineBadge badgeContent="99+">
         <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
       </OutlineBadge>
       <OutlineBadge
-        badgeContent={<Text fontFamily="mono" fontSize="xs">999+</Text>}
+        badgeContent={<Text fontFamily="mono" fontSize="xs">!</Text>}
       >
         <Skeleton variant="rect" borderRadius="sm" width="8x" height="8x" />
       </OutlineBadge>
@@ -150,34 +291,11 @@ function Example() {
 render(<Example />);
 ```
 
-### Change badge color
-
-The color of the badge can be changed by passing the `backgroundColor` prop. See the [colors](./colors) section to learn more about colors.
-
-```jsx
-<Grid
-  columnGap="6x"
-  justifyItems="center"
-  rowGap="6x"
-  templateColumns="repeat(5,1fr)"
-  width="fit-content"
->
-  <Box><Badge backgroundColor="red:60" badgeContent="red:60" px="4x" py="1h" /></Box>
-  <Box><Badge backgroundColor="orange:50" badgeContent="orange:50" px="4x" py="1h" /></Box>
-  <Box><Badge backgroundColor="yellow:50" badgeContent="yellow:50" px="4x" py="1h" /></Box>
-  <Box><Badge backgroundColor="green:60" badgeContent="green:60" px="4x" py="1h" /></Box>
-  <Box><Badge backgroundColor="blue:60" badgeContent="blue:60" px="4x" py="1h" /></Box>
-  <Box><Badge backgroundColor="gray:60" badgeContent="gray:60" px="4x" py="1h"/></Box>
-  <Box><Badge backgroundColor="magenta:60" badgeContent="magenta:60" px="4x" py="1h"/></Box>
-  <Box><Badge backgroundColor="purple:60" badgeContent="purple:60" px="4x" py="1h" /></Box>
-  <Box><Badge backgroundColor="teal:60" badgeContent="teal:60" px="4x" py="1h" /></Box>
-  <Box><Badge backgroundColor="cyan:60" badgeContent="cyan:60" px="4x" py="1h" /></Box>
-</Grid>
-```
-
 ## Props
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| variant | string | 'solid' | One of: 'solid', 'dot' |
 | badgeContent | node \| string | | The badge content. |
+| isInvisible | boolean | | Whether the badge is invisible. |
+| placement | string | 'top-right' | The placement of the badge. One of: 'top-left', 'top-right', 'bottom-left', 'bottom-right'. |
+| variant | string | 'solid' | One of: 'solid', 'dot' |

--- a/packages/react/src/Badge/index.js
+++ b/packages/react/src/Badge/index.js
@@ -1,9 +1,12 @@
-import { ensureBoolean } from 'ensure-type';
+import {
+  ensureArray,
+  ensureBoolean,
+} from 'ensure-type';
 import React, { forwardRef } from 'react';
 import Box from '../Box';
 import useEffectOnce from '../hooks/useEffectOnce';
+import useTheme from '../useTheme';
 import warnDeprecatedProps from '../utils/warnDeprecatedProps';
-import warnRemovedProps from '../utils/warnRemovedProps';
 import {
   useBadgeStyle,
   useBadgeContentStyle,
@@ -12,10 +15,11 @@ import {
 
 const Badge = forwardRef((
   {
-    isHidden, // deprecated
-    variantColor, // deprecated
-    dotSize, // removed
-    offset, // removed
+    dotSize: dotSizeProp, // deprecated
+    isHidden: isHiddenProp, // deprecated
+    offset: offsetProp, // deprecated
+    variantColor: variantColorProp, // deprecated
+
     badgeContent: badgeContentProp,
     children,
     isInvisible: isInvisibleProp,
@@ -25,10 +29,26 @@ const Badge = forwardRef((
   },
   ref,
 ) => {
+  const theme = useTheme();
+
   useEffectOnce(() => {
-    if (isHidden !== undefined) {
+    if (dotSizeProp !== undefined) {
+      warnDeprecatedProps('dotSize', {
+        alternative: ['width', 'height'],
+        willRemove: true,
+      });
+    }
+
+    if (isHiddenProp !== undefined) {
       warnDeprecatedProps('isHidden', {
         alternative: 'isInvisible',
+        willRemove: true,
+      });
+    }
+
+    if (offsetProp !== undefined) {
+      warnDeprecatedProps('offset', {
+        alternative: ['right', 'top'],
         willRemove: true,
       });
     }
@@ -40,34 +60,36 @@ const Badge = forwardRef((
       });
     }
 
-    if (variantColor !== undefined) {
+    if (variantColorProp !== undefined) {
       warnDeprecatedProps('variantColor', {
-        alternative: 'background',
+        alternative: 'backgroundColor',
         willRemove: true,
-      });
-    }
-
-    if (dotSize !== undefined) {
-      warnRemovedProps('dotSize', {
-        alternative: ['width', 'height'],
-      });
-    }
-
-    if (offset !== undefined) {
-      warnRemovedProps('offset', {
-        alternative: ['left', 'top'],
       });
     }
   });
 
   { // map deprecated props to new props
-    if (isHidden !== undefined) {
-      isInvisibleProp = ensureBoolean(isHidden);
+    if (variant === 'dot' && dotSizeProp !== undefined) {
+      rest.height = rest.height ?? dotSizeProp;
+      rest.width = rest.width ?? dotSizeProp;
+    }
+    if (isHiddenProp !== undefined) {
+      isInvisibleProp = ensureBoolean(isHiddenProp);
+    }
+    if (offsetProp !== undefined) {
+      const [offsetX, offsetY] = ensureArray(offsetProp);
+      if (offsetX !== undefined) {
+        rest.right = rest.right ?? offsetX;
+      }
+      if (offsetY !== undefined) {
+        rest.top = rest.top ?? offsetY;
+      }
     }
     if (variant === 'badge') {
       variant = 'solid';
     }
-    if (variantColor) {
+    if (variantColorProp !== undefined) {
+      const variantColor = theme?.colors?.[`${variantColorProp}:60`] ?? theme?.colors?.[`${variantColorProp}:50`] ?? variantColorProp;
       rest.backgroundColor = rest.backgroundColor ?? variantColor;
     }
   }

--- a/packages/react/src/Badge/styles.js
+++ b/packages/react/src/Badge/styles.js
@@ -27,6 +27,7 @@ const getSolidBadgeContentStyle = ({
 
 const useBadgeStyle = () => {
   return {
+    display: 'inline-flex',
     position: 'relative',
     width: 'fit-content',
   };

--- a/packages/react/src/Badge/styles.js
+++ b/packages/react/src/Badge/styles.js
@@ -1,83 +1,88 @@
-import { ensureArray } from 'ensure-type';
-import _get from 'lodash.get';
 import useColorMode from '../useColorMode';
 import useTheme from '../useTheme';
 
-const get = (color, hue) => `${color}:${hue}`;
+const getSolidBadgeContentStyle = ({
+  colorMode,
+  theme,
+}) => {
+  const backgroundColor = {
+    dark: 'red:60',
+    light: 'red:60',
+  }[colorMode];
+  const borderColor = {
+    dark: 'gray:100',
+    light: 'white',
+  }[colorMode];
+  const color = {
+    dark: 'white:primary',
+    light: 'white:primary',
+  }[colorMode];
 
-const badgeStyle = ({ color, borderColor, borderWidth, theme: { colors, lineHeights } }) => {
-  const xsLineHeight = _get(lineHeights, 'xs');
   return {
-    light: {
-      bg: colors[get(color, 60)] ? get(color, 60) : get(color, 50),
-      color: '#fff',
-      textAlign: 'center',
-      lineHeight: `calc(${xsLineHeight} - 2px)`, // 18px - 2px
-      px: 4,
-      fontSize: 'xs'
-    },
-    dark: {
-      bg: colors[get(color, 60)] ? get(color, 60) : get(color, 50),
-      color: '#fff',
-      textAlign: 'center',
-      lineHeight: `calc(${xsLineHeight} - 2px)`, // 18px - 2px
-      px: 4,
-      fontSize: 'xs'
-    },
-  };
-};
-
-const variantProps = props => {
-  const {
-    colorMode,
-    hasChildren,
-    showAsDot,
-    dotSize,
-    offset,
+    backgroundColor,
     borderColor,
-    borderWidth,
-    theme: { colors }
-  } = props;
-  const hasChildrenProps = hasChildren ? {
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    transform: 'translate(50%, -50%)',
-    border: `${borderWidth}px solid ${colors[borderColor] || borderColor}`,
-    borderRadius: 18,
-    minWidth: 18,
-  } : {
-    top: 0,
-    display: 'block',
-    transform: 'none',
-    borderRadius: 16,
-    minWidth: 16
+    color,
   };
-  const showAsDotProps = showAsDot ? {
-    p: 0,
-    width: dotSize,
-    height: dotSize,
-    minWidth: 0
-  } : {};
-  const offsetArray = ensureArray(offset);
-  const offsetProps = offsetArray.length === 2 ? {
-    right: offsetArray[0],
-    mt: offsetArray[1]
-  } : {};
+};
+
+const useBadgeStyle = () => {
   return {
-    ...hasChildrenProps,
-    ...badgeStyle(props)[colorMode],
-    ...showAsDotProps,
-    ...offsetProps
+    position: 'relative',
+    width: 'fit-content',
   };
 };
 
-const useBadgeStyle = props => {
-  const theme = useTheme();
+const useBadgeContentStyle = ({
+  variant,
+}) => {
   const [colorMode] = useColorMode();
-  const _props = { ...props, theme, colorMode };
+  const theme = useTheme();
+  const borderWidth = theme?.sizes?.['1q'];
+  const fontSize = 'xs';
+  const minorAxisLength = theme?.lineHeights?.[fontSize]; // ellipsis: width=majorAxisLength, height=minorAxisLength
+  const lineHeight = `calc(${minorAxisLength} - ${borderWidth} - ${borderWidth})`;
+  const baseStyle = {
+    borderColor: 'transparent',
+    borderRadius: minorAxisLength,
+    borderStyle: 'solid',
+    borderWidth,
+    fontSize,
+    lineHeight,
+    minWidth: minorAxisLength,
+    px: '1x',
+  };
+  const layoutStyle = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+  const variantStyle = {
+    'solid': getSolidBadgeContentStyle({
+      colorMode,
+      theme,
+    }),
+  }[variant];
 
-  return variantProps(_props);
+  return {
+    ...baseStyle,
+    ...layoutStyle,
+    ...variantStyle,
+  };
 };
 
-export default useBadgeStyle;
+const useBadgeContentPlacementStyle = ({
+  placement,
+}) => {
+  return {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    transform: 'translate(50%, -50%)',
+  };
+};
+
+export {
+  useBadgeStyle,
+  useBadgeContentStyle,
+  useBadgeContentPlacementStyle,
+};

--- a/packages/react/src/Badge/styles.js
+++ b/packages/react/src/Badge/styles.js
@@ -11,10 +11,10 @@ const getSolidBadgeContentStyle = ({
   }[colorMode];
   const borderRadius = theme?.sizes?.['4x'];
   const boxShadowSpreadRadius = theme?.sizes?.['1q'];
-  const boxShadowColor = theme?.colors?.[{
-    dark: 'gray:100',
+  const boxShadowColor = {
+    dark: theme?.colors?.['gray:100'],
     light: 'white',
-  }[colorMode]];
+  }[colorMode];
   const boxShadow = `0 0 0 ${boxShadowSpreadRadius} ${boxShadowColor}`;
   const color = {
     dark: 'white:primary',
@@ -44,10 +44,10 @@ const getDotBadgeContentStyle = ({
   }[colorMode];
   const borderRadius = theme?.sizes?.['2x'];
   const boxShadowSpreadRadius = theme?.sizes?.['1q'];
-  const boxShadowColor = theme?.colors?.[{
-    dark: 'gray:100',
+  const boxShadowColor = {
+    dark: theme?.colors?.['gray:100'],
     light: 'white',
-  }[colorMode]];
+  }[colorMode];
   const boxShadow = `0 0 0 ${boxShadowSpreadRadius} ${boxShadowColor}`;
   const color = {
     dark: 'white:primary',

--- a/packages/react/src/Badge/styles.js
+++ b/packages/react/src/Badge/styles.js
@@ -13,15 +13,61 @@ const getSolidBadgeContentStyle = ({
     dark: 'gray:100',
     light: 'white',
   }[colorMode];
+  const borderStyle = 'solid';
+  const borderWidth = theme?.sizes?.['1q'];
   const color = {
     dark: 'white:primary',
     light: 'white:primary',
   }[colorMode];
+  const fontSize = 'xs';
+  const offsetHeight = theme?.lineHeights?.[fontSize];
+  const clientHeight = `calc(${offsetHeight} - ${borderWidth} - ${borderWidth})`;
 
   return {
     backgroundColor,
     borderColor,
+    borderRadius: offsetHeight,
+    borderStyle,
+    borderWidth,
     color,
+    fontSize,
+    lineHeight: clientHeight,
+    minWidth: offsetHeight,
+    px: '1x',
+  };
+};
+
+const getDotBadgeContentStyle = ({
+  colorMode,
+  theme,
+}) => {
+  const backgroundColor = {
+    dark: 'red:60',
+    light: 'red:60',
+  }[colorMode];
+  const borderColor = {
+    dark: 'gray:100',
+    light: 'white',
+  }[colorMode];
+  const borderRadius = theme?.sizes?.['2x'];
+  const borderWidth = theme?.sizes?.['1q'];
+  const borderStyle = 'solid';
+  const color = {
+    dark: 'white:primary',
+    light: 'white:primary',
+  }[colorMode];
+  const height = borderRadius;
+  const width = borderRadius;
+
+  return {
+    backgroundColor,
+    borderColor,
+    borderRadius,
+    borderStyle,
+    borderWidth,
+    color,
+    height,
+    width,
   };
 };
 
@@ -38,21 +84,7 @@ const useBadgeContentStyle = ({
 }) => {
   const [colorMode] = useColorMode();
   const theme = useTheme();
-  const borderWidth = theme?.sizes?.['1q'];
-  const fontSize = 'xs';
-  const minorAxisLength = theme?.lineHeights?.[fontSize]; // ellipsis: width=majorAxisLength, height=minorAxisLength
-  const lineHeight = `calc(${minorAxisLength} - ${borderWidth} - ${borderWidth})`;
   const baseStyle = {
-    borderColor: 'transparent',
-    borderRadius: minorAxisLength,
-    borderStyle: 'solid',
-    borderWidth,
-    fontSize,
-    lineHeight,
-    minWidth: minorAxisLength,
-    px: '1x',
-  };
-  const layoutStyle = {
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -62,11 +94,14 @@ const useBadgeContentStyle = ({
       colorMode,
       theme,
     }),
+    'dot': getDotBadgeContentStyle({
+      colorMode,
+      theme,
+    }),
   }[variant];
 
   return {
     ...baseStyle,
-    ...layoutStyle,
     ...variantStyle,
   };
 };
@@ -74,11 +109,32 @@ const useBadgeContentStyle = ({
 const useBadgeContentPlacementStyle = ({
   placement,
 }) => {
+  const placementStyle = {
+    'top-left': {
+      top: 0,
+      left: 0,
+      transform: 'translate(-50%, -50%)',
+    },
+    'top-right': {
+      top: 0,
+      right: 0,
+      transform: 'translate(50%, -50%)',
+    },
+    'bottom-left': {
+      bottom: 0,
+      left: 0,
+      transform: 'translate(-50%, 50%)',
+    },
+    'bottom-right': {
+      bottom: 0,
+      right: 0,
+      transform: 'translate(50%, 50%)',
+    },
+  }[placement];
+
   return {
     position: 'absolute',
-    right: 0,
-    top: 0,
-    transform: 'translate(50%, -50%)',
+    ...placementStyle,
   };
 };
 

--- a/packages/react/src/Badge/styles.js
+++ b/packages/react/src/Badge/styles.js
@@ -9,30 +9,27 @@ const getSolidBadgeContentStyle = ({
     dark: 'red:60',
     light: 'red:60',
   }[colorMode];
-  const borderColor = {
+  const borderRadius = theme?.sizes?.['4x'];
+  const boxShadowSpreadRadius = theme?.sizes?.['1q'];
+  const boxShadowColor = theme?.colors?.[{
     dark: 'gray:100',
     light: 'white',
-  }[colorMode];
-  const borderStyle = 'solid';
-  const borderWidth = theme?.sizes?.['1q'];
+  }[colorMode]];
+  const boxShadow = `0 0 0 ${boxShadowSpreadRadius} ${boxShadowColor}`;
   const color = {
     dark: 'white:primary',
     light: 'white:primary',
   }[colorMode];
-  const fontSize = 'xs';
-  const offsetHeight = theme?.lineHeights?.[fontSize];
-  const clientHeight = `calc(${offsetHeight} - ${borderWidth} - ${borderWidth})`;
 
   return {
     backgroundColor,
-    borderColor,
-    borderRadius: offsetHeight,
-    borderStyle,
-    borderWidth,
+    borderRadius,
+    boxShadow,
     color,
-    fontSize,
-    lineHeight: clientHeight,
-    minWidth: offsetHeight,
+    fontSize: 'xs',
+    height: borderRadius,
+    lineHeight: '1',
+    minWidth: borderRadius,
     px: '1x',
   };
 };
@@ -45,29 +42,25 @@ const getDotBadgeContentStyle = ({
     dark: 'red:60',
     light: 'red:60',
   }[colorMode];
-  const borderColor = {
+  const borderRadius = theme?.sizes?.['2x'];
+  const boxShadowSpreadRadius = theme?.sizes?.['1q'];
+  const boxShadowColor = theme?.colors?.[{
     dark: 'gray:100',
     light: 'white',
-  }[colorMode];
-  const borderRadius = theme?.sizes?.['2x'];
-  const borderWidth = theme?.sizes?.['1q'];
-  const borderStyle = 'solid';
+  }[colorMode]];
+  const boxShadow = `0 0 0 ${boxShadowSpreadRadius} ${boxShadowColor}`;
   const color = {
     dark: 'white:primary',
     light: 'white:primary',
   }[colorMode];
-  const height = borderRadius;
-  const width = borderRadius;
 
   return {
     backgroundColor,
-    borderColor,
     borderRadius,
-    borderStyle,
-    borderWidth,
+    boxShadow,
     color,
-    height,
-    width,
+    height: borderRadius,
+    width: borderRadius,
   };
 };
 

--- a/packages/react/src/hooks/useEffectOnce.js
+++ b/packages/react/src/hooks/useEffectOnce.js
@@ -1,0 +1,8 @@
+import { useEffect } from 'react';
+
+const useEffectOnce = (effect) => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(effect, []);
+};
+
+export default useEffectOnce;

--- a/packages/react/src/utils/warnDeprecatedProps.js
+++ b/packages/react/src/utils/warnDeprecatedProps.js
@@ -1,0 +1,47 @@
+import { ensureArray, ensureBoolean, ensureString } from 'ensure-type';
+
+const joinWords = (words) => {
+  words = ensureArray(words);
+  if (words.length === 0) {
+    return '';
+  }
+  if (words.length === 1) {
+    return `'${words[0]}'`;
+  }
+  if (words.length === 2) {
+    return `'${words[0]}' and '${words[1]}'`;
+  }
+  return `'${words.slice(0, -1).join('\', \'')}', and '${words.slice(-1)}'`;
+};
+
+const warnDeprecatedProps = (props, options) => {
+  const alternative = ensureArray(options?.alternative);
+  const willRemove = ensureBoolean(options?.willRemove);
+  const message = ensureString(options?.message);
+
+  props = ensureArray(props);
+  if (props.length === 0) {
+    return;
+  }
+
+  const messages = [];
+  const verb = (props.length > 1) ? 'are' : 'is';
+
+  if (willRemove) {
+    messages.push(`Warning: ${joinWords(props)} ${verb} deprecated and will be removed in the next major release.`);
+  } else {
+    messages.push(`Warning: ${joinWords(props)} ${verb} deprecated.`);
+  }
+
+  if (alternative.length > 0) {
+    messages.push(`Use ${joinWords(alternative)} instead.`);
+  }
+
+  if (message) {
+    messages.push(message);
+  }
+
+  console.error(messages.join(' '));
+};
+
+export default warnDeprecatedProps;

--- a/packages/react/src/utils/warnRemovedProps.js
+++ b/packages/react/src/utils/warnRemovedProps.js
@@ -1,0 +1,42 @@
+import { ensureArray, ensureString } from 'ensure-type';
+
+const joinWords = (words) => {
+  words = ensureArray(words);
+  if (words.length === 0) {
+    return '';
+  }
+  if (words.length === 1) {
+    return `'${words[0]}'`;
+  }
+  if (words.length === 2) {
+    return `'${words[0]}' and '${words[1]}'`;
+  }
+  return `'${words.slice(0, -1).join('\', \'')}', and '${words.slice(-1)}'`;
+};
+
+const warnRemovedProps = (props, options) => {
+  const alternative = ensureArray(options?.alternative);
+  const message = ensureString(options?.message);
+
+  props = ensureArray(props);
+  if (props.length === 0) {
+    return;
+  }
+
+  const messages = [];
+  const verb = (props.length > 1) ? 'are' : 'is';
+
+  messages.push(`Warning: ${joinWords(props)} ${verb} removed.`);
+
+  if (alternative.length > 0) {
+    messages.push(`Use ${joinWords(alternative)} instead.`);
+  }
+
+  if (message) {
+    messages.push(message);
+  }
+
+  console.error(messages.join(' '));
+};
+
+export default warnRemovedProps;


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-395/badge

### Visual Spec

* Dark Mode
https://www.figma.com/file/bHr2zAshr0D5ROp8vCVPFR/Tonic---Dark-Mode?node-id=110%3A6

* Light Mode
https://www.figma.com/file/62S1DnH4Pqy1MxJQCcLXUA/Tonic---Light-Mode?node-id=7003%3A130

### Tasks
* [x] Add deprecation warning message for the following props: `isHidden`, `variant="badge"`, `variantColor`, `dotSize`, `offset`
* [x] Refine `Badge` examples
* [x] Rename `variant="badge"` to `variant="solid"`
* [ ] The transition effect will be added in PR #297

### Reference
* Material UI
https://mui.com/components/badges/

* Bootstrap
https://getbootstrap.com/docs/4.0/components/badge/

* Ant Design
https://ant.design/components/badge/

* Chakra UI
https://chakra-ui.com/docs/data-display/badge