### PR TITLE
fix: fixes an issue that cannot locate tooltip trigger if explicitly set the `isOpen` prop

### DIFF
--- a/packages/docs/pages/tooltip.mdx
+++ b/packages/docs/pages/tooltip.mdx
@@ -12,7 +12,7 @@ import { Tooltip } from '@trendmicro/react-styled-ui';
 
 ## Usage
 
-If the `children` of Tooltip is a string, wrap within a `span` with `tabIndex` set to `0` to ensure accessibility requirements are met.
+If the tooltip anchor is not a focusable content, just like the text string, you can wrap it with a `Text` component and set `tabIndex="0" to make it focusable.
 
 ```jsx
 <Tooltip label="Hey, I'm here!">

--- a/packages/docs/pages/tooltip.mdx
+++ b/packages/docs/pages/tooltip.mdx
@@ -15,7 +15,9 @@ import { Tooltip } from '@trendmicro/react-styled-ui';
 If the `children` of Tooltip is a string, wrap within a `span` with `tabIndex` set to `0` to ensure accessibility requirements are met.
 
 ```jsx
-<Tooltip label="Hey, I'm here!">Hover me</Tooltip>
+<Tooltip label="Hey, I'm here!">
+  <Text tabIndex="0">Hover me</Text>
+</Tooltip>
 ```
 
 ### With an icon

--- a/packages/docs/pages/tooltip.mdx
+++ b/packages/docs/pages/tooltip.mdx
@@ -193,9 +193,7 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
 | isOpen | boolean | | If `true`, the tooltip is shown. |
-| defaultIsOpen | boolean | | If `true`, the tooltip is shown initially. |
 | label | string \| ReactNode | | The label of the tooltip.|
-| aria-label | string | | An alternate label for screen readers. |
 | placement | PopperJS.Placement | 'bottom' | Position the tooltip relative to the trigger element as well as surrounding elements. Possible values: `'top'`, `'bottom'`, `'right'`, `'left'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`, `'right-start'`, `'right-end'`, `'left-start'`, `'left-end'` |
 | children | ReactNode | | The `ReactNode` element to be used as the trigger of the tooltip. |
 | hideArrow | boolean | | If `true`, hide the arrow tip on the tooltip. |
@@ -203,6 +201,5 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 | showDelay | number | | The delay in milliseconds for the tooltip to show. |
 | hideDelay | number | | The delay in milliseconds for the tooltip to hide. |
 | closeOnClick | boolean | | If `true`, hide the tooltip when the trigger is clicked. |
-| shouldWrapChildren | boolean | | If `true`, the tooltip will wrap its children with a `Box`. |
 | onOpen | function | | A callback called when the tooltip shows. |
 | onClose| function | | A callback called when the tooltip hides. |

--- a/packages/react/src/Popper/Popper.js
+++ b/packages/react/src/Popper/Popper.js
@@ -38,8 +38,8 @@ const Popper = forwardRef((
   },
   ref,
 ) => {
-  const tooltipRef = useRef(null);
-  const ownRef = useForkRef(tooltipRef, ref);
+  const nodeRef = useRef();
+  const combinedRef = useForkRef(nodeRef, ref);
 
   const popperRef = useRef(null);
   const handlePopperRef = useForkRef(popperRef, popperRefProp);
@@ -56,7 +56,7 @@ const Popper = forwardRef((
   const [placement, setPlacement] = useState(initialPlacement);
 
   const handleOpen = useCallback(() => {
-    const popperNode = tooltipRef.current;
+    const popperNode = nodeRef.current;
 
     if (!popperNode || !anchorEl || !isOpen) {
       return;
@@ -99,10 +99,10 @@ const Popper = forwardRef((
 
   const handleRef = useCallback(
     node => {
-      setRef(ownRef, node);
+      setRef(combinedRef, node);
       handleOpen();
     },
-    [ownRef, handleOpen],
+    [combinedRef, handleOpen],
   );
 
   const handleEnter = () => {

--- a/packages/react/src/Tooltip/index.js
+++ b/packages/react/src/Tooltip/index.js
@@ -47,6 +47,10 @@ const Tooltip = forwardRef((
   });
 
   const [isHydrated, setIsHydrated] = useState(false); // false for initial render
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
   const { isOpen, onClose, onOpen } = useDisclosure(false);
   const { current: isControlled } = useRef((isControlledOpen !== undefined) && (isControlledOpen !== null));
   const _isOpen = isControlled ? isControlledOpen : isOpen;
@@ -97,27 +101,24 @@ const Tooltip = forwardRef((
   const anchorEl = nodeRef.current;
   const arrowSize = '6px';
   const tooltipStyleProps = useTooltipStyle();
-
-  useEffect(() => {
-    setIsHydrated(true);
-  }, []);
-
   const getTooltipTriggerProps = () => {
     const tooltipTriggerStyleProps = {
-      'aria-describedby': _isOpen ? tooltipId : undefined,
       display: 'inline-block',
-      role: 'presentation',
-      tabIndex: '0',
     };
-
-    return {
-      ...tooltipTriggerStyleProps,
+    const eventHandlerProps = {
       onMouseEnter: handleOpen,
       onMouseLeave: handleClose,
       onClick: handleClick,
       onFocus: handleOpen,
       onBlur: handleClose,
+    };
+
+    return {
+      'aria-describedby': _isOpen ? tooltipId : undefined,
       ref: combinedRef,
+      role: 'presentation',
+      ...tooltipTriggerStyleProps,
+      ...eventHandlerProps,
     };
   };
 

--- a/packages/react/src/Tooltip/index.js
+++ b/packages/react/src/Tooltip/index.js
@@ -38,10 +38,10 @@ const Tooltip = forwardRef((
       });
     }
 
-    if (shouldWrapChildren !== undefined) {
+    if (shouldWrapChildren !== undefined && !shouldWrapChildren) {
       warnRemovedProps('shouldWrapChildren', {
         prefix,
-        message: 'Use children as a function to render the tooltip trigger instead.',
+        message: 'Use Function as Child Component (FaCC) to render the tooltip trigger instead.',
       });
     }
   });

--- a/packages/react/src/Tooltip/index.js
+++ b/packages/react/src/Tooltip/index.js
@@ -103,7 +103,7 @@ const Tooltip = forwardRef((
   const tooltipStyleProps = useTooltipStyle();
   const getTooltipTriggerProps = () => {
     const tooltipTriggerStyleProps = {
-      display: 'inline-block',
+      display: 'inline-flex',
     };
     const eventHandlerProps = {
       onMouseEnter: handleOpen,

--- a/packages/react/src/Tooltip/index.js
+++ b/packages/react/src/Tooltip/index.js
@@ -39,7 +39,7 @@ const Tooltip = forwardRef((
     }
 
     if (shouldWrapChildren !== undefined) {
-      warnRemovedProps('isHidden', {
+      warnRemovedProps('shouldWrapChildren', {
         prefix,
         message: 'Use children as a function to render the tooltip trigger instead.',
       });

--- a/packages/react/src/Tooltip/index.js
+++ b/packages/react/src/Tooltip/index.js
@@ -47,7 +47,7 @@ const Tooltip = forwardRef((
   });
 
   const [isHydrated, setIsHydrated] = useState(false); // false for initial render
-  const { isOpen, onClose, onOpen } = useDisclosure(defaultIsOpen || false);
+  const { isOpen, onClose, onOpen } = useDisclosure(false);
   const { current: isControlled } = useRef((isControlledOpen !== undefined) && (isControlledOpen !== null));
   const _isOpen = isControlled ? isControlledOpen : isOpen;
 

--- a/packages/react/src/Tooltip/styles.js
+++ b/packages/react/src/Tooltip/styles.js
@@ -33,4 +33,6 @@ const useTooltipStyle = props => {
   };
 };
 
-export default useTooltipStyle;
+export {
+  useTooltipStyle,
+};


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-408/tooltip

See #410 for a similar issue on popover

## Description

The tooltip cannot locate the trigger if explicitly set the `isOpen` prop.

### Steps to reproduce

1. Go to https://trendmicro-frontend.github.io/tonic-ui/react/0.23.0/tooltip
2. Add the `isOpen` prop to a `Tooltip` component.
3. Inline styles are not available on the tooltip trigger
 ![image](https://user-images.githubusercontent.com/447801/145974583-fc058b89-9838-4cb7-866c-54233b51286b.png)

### Expected result

![image](https://user-images.githubusercontent.com/447801/145974090-31cc75cf-fb2f-4a3a-82a9-63f9d2287a7a.png)

![image](https://user-images.githubusercontent.com/447801/145974726-86248e22-d177-430f-99cb-ae8f14af838f.png)

## What's Changed

* Use `isHydrated` state to check whether it is the initial render for SSR-friendly.
* Remove `aria-label`, `defaultIsOpen`, `shouldWrapChildren` props.
* You can use function as children to render the tooltip trigger (anchor) if you don't want it to be wrapped with a `Box` component:
  ```jsx
  <Tooltip label="tooltip label">
    {({ getTooltipTriggerProps }) => {
      return (
        <Button {...getTooltipTriggerProps()}>
          Tooltip Trigger
        </Button>
      );
    }}
  </Tooltip>
  ```
  ![image](https://user-images.githubusercontent.com/447801/145976361-5cfd2f36-cff2-4abb-a388-5b154038ad37.png)
