### PR TITLE
fix: fixes an issue that cannot locate popover trigger if explicitly set the `isOpen` prop

### DIFF
--- a/packages/docs/pages/popover.mdx
+++ b/packages/docs/pages/popover.mdx
@@ -406,7 +406,6 @@ The word _"trigger"_ refers to the children of PopoverTrigger.
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
 | isOpen | boolean | | If `true`, the popover is shown. |
-| defaultIsOpen | boolean | | If `true`, the popover is shown initially. |
 | initialFocusRef | React.Ref | | The `ref` of the element that should receive the focus status when the popover opens. |
 | trigger | string | 'click' | The interaction that triggers the popover. One of: `'click'`, `'hover'` |
 | placement | PopperJS.placement | 'bottom' | Position the popover relative to the trigger element as well as surrounding elements. Possible values: `'top'`, `'bottom'`, `'right'`, `'left'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`, `'right-start'`, `'right-end'`, `'left-start'`, `'left-end'` |
@@ -427,6 +426,10 @@ The word _"trigger"_ refers to the children of PopoverTrigger.
 
 ### PopoverTrigger
 
-| Name | Type | Default | Description |
-| :--- | :--- | :------ | :---------- |
-| shouldWrapChildren | boolean | | If `true`, the popover trigger will wrap its children with a `Box`. |
+### PopoverContent
+
+### PopoverHeader
+
+### PopoverBody
+
+### PopoverFooter

--- a/packages/react/src/Popover/Popover.js
+++ b/packages/react/src/Popover/Popover.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
+import useEffectOnce from '../hooks/useEffectOnce';
 import { useId } from '../utils/autoId';
+import warnRemovedProps from '../utils/warnRemovedProps';
 import { PopoverContextProvider } from './context';
 
 const usePrevious = (value) => {
@@ -13,10 +15,11 @@ const usePrevious = (value) => {
 };
 
 const Popover = ({
+  defaultIsOpen, // removed
+
   id,
   isOpen: isOpenProp,
   initialFocusRef,
-  defaultIsOpen,
   usePortal = true,
   returnFocusOnClose = true,
   trigger = 'click',
@@ -34,7 +37,17 @@ const Popover = ({
   followCursor,
   arrowAt,
 }) => {
-  const [isOpen, setIsOpen] = useState(defaultIsOpen || false);
+  useEffectOnce(() => {
+    const prefix = `${Popover.displayName}:`;
+
+    if (defaultIsOpen !== undefined) {
+      warnRemovedProps('defaultIsOpen', {
+        prefix,
+      });
+    }
+  });
+
+  const [isOpen, setIsOpen] = useState(false);
   const [mousePageX, setMousePageX] = useState(0);
   const [mousePageY, setMousePageY] = useState(0);
   const { current: isControlled } = useRef(isOpenProp != null);

--- a/packages/react/src/Popover/PopoverContent.js
+++ b/packages/react/src/Popover/PopoverContent.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import wrapEvent from '../utils/wrapEvent';
 import { usePopover } from './context';
 import Popper from '../Popper/Popper';
@@ -12,9 +12,13 @@ const PopoverContent = ({
   onMouseEnter,
   onFocus,
   children,
-  'aria-label': ariaLabel,
   ...props
 }) => {
+  const [isHydrated, setIsHydrated] = useState(false); // false for initial render
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
   const {
     popoverRef,
     anchorRef,
@@ -40,6 +44,7 @@ const PopoverContent = ({
     arrowAt,
   } = usePopover();
   const contentStyleProps = usePopoverContentStyle();
+
   const arrowSize = 12;
   let _skidding = skidding;
   let _distance = distance + 8; // Arrow height is 8px
@@ -97,21 +102,23 @@ const PopoverContent = ({
     }),
   };
 
+  if (!isHydrated) {
+    return null;
+  }
+
   return (
     <Popper
-      as="section"
+      aria-hidden={!isOpen}
+      aria-labelledby={headerId}
+      aria-describedby={bodyId}
       usePortal={usePortal}
       isOpen={isOpen}
       placement={placement}
-      aria-label={ariaLabel}
       anchorEl={anchorRef.current}
       ref={popoverRef}
       id={popoverId}
-      aria-hidden={!isOpen}
       arrowSize={`${arrowSize}px`}
       modifiers={{ offset: [_skidding, _distance] }}
-      aria-labelledby={headerId}
-      aria-describedby={bodyId}
       {...contentStyleProps}
       {...roleProps}
       {...eventHandlers}

--- a/packages/react/src/Popover/PopoverTrigger.js
+++ b/packages/react/src/Popover/PopoverTrigger.js
@@ -1,15 +1,29 @@
 import React, { forwardRef, useRef, useState } from 'react';
 import Box from '../Box';
+import useEffectOnce from '../hooks/useEffectOnce';
 import useForkRef from '../utils/useForkRef';
+import warnRemovedProps from '../utils/warnRemovedProps';
 import { usePopover } from './context';
 
 const PopoverTrigger = forwardRef((
   {
+    shouldWrapChildren, // removed
+
     children,
     ...rest
   },
   ref,
 ) => {
+  useEffectOnce(() => {
+    const prefix = `${PopoverTrigger.displayName}:`;
+
+    if (shouldWrapChildren !== undefined) {
+      warnRemovedProps('shouldWrapChildren', {
+        prefix,
+      });
+    }
+  });
+
   const {
     anchorRef,
     popoverId,

--- a/packages/react/src/Popover/PopoverTrigger.js
+++ b/packages/react/src/Popover/PopoverTrigger.js
@@ -42,6 +42,7 @@ const PopoverTrigger = forwardRef((
   const combinedRef = useForkRef(ref, anchorRef);
   const openTimeout = useRef(null);
   const [enableMouseMove, setEnableMouseMove] = useState(true);
+
   const eventHandlerProps = {};
 
   if (trigger === 'click') {
@@ -89,7 +90,6 @@ const PopoverTrigger = forwardRef((
   const getPopoverTriggerProps = () => {
     const popoverTriggerStyleProps = {
       display: 'inline-block',
-      outline: '0',
     };
 
     return {
@@ -98,7 +98,6 @@ const PopoverTrigger = forwardRef((
       'aria-controls': popoverId,
       ref: combinedRef,
       role: 'button',
-      tabIndex: '0',
       ...popoverTriggerStyleProps,
       ...eventHandlerProps,
     };

--- a/packages/react/src/Popover/PopoverTrigger.js
+++ b/packages/react/src/Popover/PopoverTrigger.js
@@ -89,7 +89,7 @@ const PopoverTrigger = forwardRef((
 
   const getPopoverTriggerProps = () => {
     const popoverTriggerStyleProps = {
-      display: 'inline-block',
+      display: 'inline-flex',
     };
 
     return {

--- a/packages/react/src/Popover/PopoverTrigger.js
+++ b/packages/react/src/Popover/PopoverTrigger.js
@@ -17,9 +17,10 @@ const PopoverTrigger = forwardRef((
   useEffectOnce(() => {
     const prefix = `${PopoverTrigger.displayName}:`;
 
-    if (shouldWrapChildren !== undefined) {
+    if (shouldWrapChildren !== undefined && !shouldWrapChildren) {
       warnRemovedProps('shouldWrapChildren', {
         prefix,
+        message: 'Use Function as Child Component (FaCC) to render the popover trigger instead.',
       });
     }
   });


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-410/popover

See #408 for a similar issue on tooltip

## Description

The popover cannot locate the trigger if explicitly set the `isOpen` prop.

### Steps to reproduce

1. Go to https://trendmicro-frontend.github.io/tonic-ui/react/0.23.0/popover
2. Add the `isOpen` prop to a `Popover` component.
3. Inline styles are not available on the popover trigger

### Expected result

![image](https://user-images.githubusercontent.com/447801/145984143-0b17c23a-e5c4-4fb5-9594-308e7a7faf4a.png)

## What's Changed

* Use `isHydrated` state to check whether it is the initial render for SSR-friendly.
* Remove `shouldWrapChildren` prop from `PopoverTrigger`.
* You can use function as children to render the popover trigger (anchor) if you don't want it to be wrapped with a `Box` component:
  ```jsx
  <PopoverTrigger>
    {({ getPopoverTriggerProps }) => {
      return (
        <Button {...getPopoverTriggerProps()}>
          Tooltip Trigger
        </Button>
      );
    }}
  </PopoverTrigger>
  ```

  ![image](https://user-images.githubusercontent.com/447801/145984475-52781ff1-260b-4fe9-98e7-37d100d17108.png)