### PR TITLE
refactor: by default the transition components will not perform the enter transition when it first mounts

### DIFF
--- a/packages/react-docs/config/sidebar-routes.js
+++ b/packages/react-docs/config/sidebar-routes.js
@@ -98,6 +98,12 @@ const routes = [
       { title: 'CSSBaseline', path: 'components/cssbaseline' },
       { title: 'Scrollbar', path: 'components/scrollbar' },
       { title: 'Transitions', path: 'components/transitions' },
+      { title: 'Transitions / Collapse', path: 'components/transitions-collapse' },
+      { title: 'Transitions / Fade', path: 'components/transitions-fade' },
+      { title: 'Transitions / Grow', path: 'components/transitions-grow' },
+      { title: 'Transitions / Scale', path: 'components/transitions-scale' },
+      { title: 'Transitions / Slide', path: 'components/transitions-slide' },
+      { title: 'Transitions / Zoom', path: 'components/transitions-zoom' },
     ],
   },
   {

--- a/packages/react-docs/pages/components/accordion.mdx
+++ b/packages/react-docs/pages/components/accordion.mdx
@@ -278,3 +278,4 @@ function Example() {
 | children | `ReactNode` | | |
 | TransitionComponent | ElementType | Collapse | The component used for the transition. |
 | TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | false | |

--- a/packages/react-docs/pages/components/accordion.mdx
+++ b/packages/react-docs/pages/components/accordion.mdx
@@ -138,7 +138,7 @@ function Example() {
   };
   const renderToggleIcon = item => (
     <AccordionToggleIcon>
-      {({ ref, style: styleProps }) => {
+      {(state, { ref, style: styleProps }) => {
         styleProps.transform = (expandedItem === item) ? 'rotate(0deg)' : 'rotate(-90deg)';
         return (
           <Icon ref={ref} icon="chevron-down" size="4x" {...styleProps} />
@@ -262,7 +262,14 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| children | `ReactNode` \| `({ ref, style, ...props }) => ReactNode` | | |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
+| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
+| disabled | boolean | | Whether the accordion toggle icon is disabled. |
+| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
+| in | boolean | | If `true`, the component will transition in. |
+| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
+| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: duration.enterScreen, exit: duration.levingScreen } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |
 
 ### AccordionCollapse
 

--- a/packages/react-docs/pages/components/accordion.mdx
+++ b/packages/react-docs/pages/components/accordion.mdx
@@ -27,7 +27,7 @@ To compose an accordion with default styles, you can use `Accordion`, `Accordion
 
 ```jsx
 <Accordion rowGap={1}>
-  <AccordionItem>
+  <AccordionItem defaultIsExpanded>
     <AccordionHeader>
       <Text>
         Accordion 1
@@ -66,7 +66,7 @@ Extend the default behavior to create an accordion with controlled state.
 
 ```jsx
 function Example() {
-  const [expandedItem, setExpandedItem] = React.useState(null);
+  const [expandedItem, setExpandedItem] = React.useState('item1');
   const handleToggle = item => ({ isExpanded }) => {
     setExpandedItem(isExpanded ? item : null);
   };

--- a/packages/react-docs/pages/components/drawer.mdx
+++ b/packages/react-docs/pages/components/drawer.mdx
@@ -339,6 +339,7 @@ render(<Example />);
 | :--- | :--- | :------ | :---------- |
 | TransitionComponent | ElementType | Fade | The component used for the transition. |
 | TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | true | |
 
 ### DrawerContent
 
@@ -346,6 +347,7 @@ render(<Example />);
 | :--- | :--- | :------ | :---------- |
 | TransitionComponent | ElementType | Slide | The component used for the transition. |
 | TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | true | |
 
 ### DrawerHeader
 

--- a/packages/react-docs/pages/components/menu.mdx
+++ b/packages/react-docs/pages/components/menu.mdx
@@ -723,6 +723,7 @@ function menuWithCheckbox() {
 | offset | [skidding, distance] | [0, 0] | To control the distance and skidding of the menu list |
 | TransitionComponent | ElementType | Collapse | The component used for the transition. |
 | TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | true | |
 
 ### MenuGroup
 

--- a/packages/react-docs/pages/components/menu.mdx
+++ b/packages/react-docs/pages/components/menu.mdx
@@ -304,7 +304,7 @@ You can also customize the indicator by passing a component as children or a fun
       <>
         <MenuToggle>
           <MenuToggleIcon>
-            {({ ref, style: styleProps }) => {
+            {(state, { ref, style: styleProps }) => {
               // direction is either 'up' or 'down'
               const icon = `arrow-${direction}`;
               styleProps.transform = isOpen ? 'scaleY(-1)' : 'scaleY(1)';
@@ -706,10 +706,14 @@ function menuWithCheckbox() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| children | ReactNode \| function | | |
-| disabled | boolean | | Whether the menu indicator is disabled. |
-| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeOut, exit: easing.easeOut } | The timing function to use for the animation. |
-| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: 133, exit: 93 } | The duration of the animation. |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
+| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
+| disabled | boolean | | Whether the menu toggle icon is disabled. |
+| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
+| in | boolean | | If `true`, the component will transition in. |
+| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
+| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: duration.enterScreen, exit: duration.levingScreen } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |
 
 ### MenuList
 

--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -447,6 +447,7 @@ function Example() {
 | :--- | :--- | :------ | :---------- |
 | TransitionComponent | ElementType | Fade | The component used for the transition. |
 | TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | true | |
 
 ### ModalContent
 
@@ -454,6 +455,7 @@ function Example() {
 | :--- | :--- | :------ | :---------- |
 | TransitionComponent | ElementType | Fade | The component used for the transition. |
 | TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | true | |
 
 ### ModalHeader
 

--- a/packages/react-docs/pages/components/popover.mdx
+++ b/packages/react-docs/pages/components/popover.mdx
@@ -26,7 +26,37 @@ import {
 } from '@tonic-ui/react';
 ```
 
-## Basic Usage
+## Usage
+
+### Controlled and uncontrolled popovers
+
+Pass `isOpen` to the `Popover` component to control the state of the popover.
+
+```jsx
+<Popover isOpen>
+  <PopoverTrigger>
+    <Button>Popover trigger</Button>
+  </PopoverTrigger>
+  <PopoverContent>
+    <Text>Popover (controlled)</Text>
+  </PopoverContent>
+</Popover>
+```
+
+Set `defaultIsOpen` to `true` to have the popover open by default.
+
+```jsx
+<Popover defaultIsOpen>
+  <PopoverTrigger>
+    <Button>Popover trigger</Button>
+  </PopoverTrigger>
+  <PopoverContent>
+    <Text>Popover (uncontrolled)</Text>
+  </PopoverContent>
+</Popover>
+```
+
+### Basic Usage
 
 When using this component, ensure the children passed to `PopoverTrigger` is focusable. `Popover` should be accessible and should allow users to access it using the tab key on a keyboard.
 
@@ -43,7 +73,7 @@ When using this component, ensure the children passed to `PopoverTrigger` is foc
   </PopoverContent>
 </Popover>
 ```
-## Focus an element when `Popover` opens
+### Focus an element when `Popover` opens
 
 By default, the focus status is to sent to `PopoverContent` when `Popover` opens. You can send the focus status to a specific element when it opens by passing the `initialFocusRef` prop.
 
@@ -86,7 +116,7 @@ function WalkthroughPopover() {
 }
 ```
 
-## Accessing Internal state
+### Accessing Internal state
 
 Tonic UI provides access to two internal states:  `isOpen` and `onClose`. Use the render prop pattern to access the internal states.
 
@@ -133,7 +163,7 @@ function InternalStateEx() {
 }
 ```
 
-## Controlled Usage
+### Controlled Usage
 
 You can control the opening and closing of `Popover` by passing the `isOpen` or `onClose` state.
 
@@ -176,9 +206,9 @@ function ControlledUsage() {
 }
 ```
 
-## Customizing Popover
+### Customization
 
-### Hide arrow
+#### Hide arrow
 
 ```jsx
 <Popover hideArrow>
@@ -192,7 +222,7 @@ function ControlledUsage() {
 </Popover>
 ```
 
-### Offset position
+#### Offset position
 
 ```jsx
 <Popover skidding={50} distance={0}>
@@ -206,7 +236,7 @@ function ControlledUsage() {
 </Popover>
 ```
 
-## Hover Trigger
+### Hover Trigger
 
 To show `Popover` when you mouse over or focus on the trigger, pass the prop `trigger` and set it to `hover`. When you focus on or mouse over the popover trigger, `Popover` will open.
 
@@ -247,7 +277,7 @@ If you quickly move your cursor to the popover content when it is open, `Popover
 </Stack>
 ```
 
-## Popover Placement
+### Popover Placement
 
 Since `Popover` is controlled by PopperJS, you can change the placement of `Popover` by passing the `placement` prop.
 
@@ -375,6 +405,7 @@ Although you may have specified the placement, `Popover` will try to reposition 
 ```
 
 ## Accessibility
+
 The word _"trigger"_ refers to the children of PopoverTrigger.
 
 ### Keyboard and focus
@@ -395,7 +426,7 @@ The word _"trigger"_ refers to the children of PopoverTrigger.
 - `PopoverContent` has `aria-labelledby` set to the `id` attribute of `PopoverHeader`.
 - `PopoverContent` has `aria-describedby` set to the `id` attribute of `PopoverBody`.
 - `PopoverContent` has `aria-hidden` set to `true` or `false` depending on the open/closed state of `Popover`.
-- The trigger has` aria-haspopup` set to `true` to denote that it triggers a popover.
+- The trigger has `aria-haspopup` set to `true` to denote that it triggers a popover.
 - The trigger has `aria-controls` set to the 'id' attribute of `PopoverContent` to associate the popover with the trigger.
 - The trigger has `aria-expanded` set to `true` or `false` depending on the open/closed state of the popover.
 
@@ -405,6 +436,7 @@ The word _"trigger"_ refers to the children of PopoverTrigger.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| defaultIsOpen | boolean | false | Whether the popover is open by default. |
 | isOpen | boolean | | If `true`, the popover is shown. |
 | initialFocusRef | React.Ref | | The `ref` of the element that should receive the focus status when the popover opens. |
 | trigger | string | 'click' | The interaction that triggers the popover. One of: 'click', 'hover' |

--- a/packages/react-docs/pages/components/popover.mdx
+++ b/packages/react-docs/pages/components/popover.mdx
@@ -473,6 +473,7 @@ The word _"trigger"_ refers to the children of PopoverTrigger.
 | PopperArrowProps | object | | Props applied to the PopoverArrow component. |
 | TransitionComponent | ElementType | Grow | The component used for the transition. |
 | TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | true | |
 
 ### PopoverHeader
 

--- a/packages/react-docs/pages/components/tooltip.mdx
+++ b/packages/react-docs/pages/components/tooltip.mdx
@@ -12,7 +12,37 @@ import { Tooltip } from '@tonic-ui/react';
 
 ## Usage
 
-If the tooltip anchor is not a focusable content, just like the text string, you can wrap it with a `Text` component and set `tabIndex="0" to make it focusable.
+### Controlled and uncontrolled tooltips
+
+Pass `isOpen` to the `Tooltip` component to control the state of the tooltip.
+
+```jsx
+<Tooltip label="Tooltip (controlled)" isOpen>
+  <Text>Tooltip anchor</Text>
+</Tooltip>
+```
+
+Set `defaultIsOpen` to `true` to have the tooltip open by default.
+
+```jsx
+<Tooltip label="Tooltip (uncontrolled)" defaultIsOpen>
+  <Text>Tooltip anchor</Text>
+</Tooltip>
+```
+
+### Tooltip with focusable content
+
+If the children of Tooltip are focusable elements, Tooltip will show when you focus or hover on the a children element and will hide when you blur or move cursor out of the element.
+
+```jsx
+<Tooltip label="Search places" placement="top">
+  <Button>Button</Button>
+</Tooltip>
+```
+
+### Tooltip with non-focusable content
+
+If the tooltip anchor is not a focusable content, just like the text string, you can wrap it with a `Text` component and set `tabIndex="0"` to make it focusable.
 
 ```jsx
 <Tooltip label="Hey, I'm here!">
@@ -20,7 +50,7 @@ If the tooltip anchor is not a focusable content, just like the text string, you
 </Tooltip>
 ```
 
-### With an icon
+### Icon
 
 ```jsx
 <Tooltip label="Show calendar" placement="left">
@@ -36,17 +66,7 @@ If the tooltip anchor is not a focusable content, just like the text string, you
 </Tooltip>
 ```
 
-### Tooltip with focusable content
-
-If the children of Tooltip are focusable elements, Tooltip will show when you focus or hover on the a children element and will hide when you blur or move cursor out of the element.
-
-```jsx
-<Tooltip label="Search places" placement="top">
-  <Button>Button</Button>
-</Tooltip>
-```
-
-### Customized tooltips
+### Customization
 
 ```jsx
 <Tooltip
@@ -88,22 +108,21 @@ function Example() {
       }
     }, 0);
   };
+  const buttonText = {
+    'hostname': 'Search by: Endpoint name',
+    'filename': 'Search by: File name',
+  }[menuItem];
 
   return (
     <InputGroup>
       <InputGroupPrepend>
         <Menu>
-          <MenuButton>
-            <Box
+          <MenuButton mr="4x">
+            <Text
               color={colorMode === 'dark' ? 'white:secondary' : 'black:secondary'}
-              mr="2x"
             >
-              Search by:
-            </Box>
-            {{
-              'hostname': 'Endpoint name',
-              'filename': 'File name',
-            }[menuItem]}
+              {buttonText}
+            </Text>
           </MenuButton>
           <MenuList
             onClick={handleMenuClick}
@@ -195,6 +214,7 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
 | children | | | If the children is a function, it will be called with `{ getTooltipTriggerProps }` and the return value will be used as the trigger. |
+| defaultIsOpen | boolean | false | Whether the tooltip is open by default. |
 | isOpen | boolean | | If `true`, the tooltip is shown. |
 | label | string \| ReactNode | | The label of the tooltip.|
 | placement | PopperJS.Placement | 'bottom' | Position the tooltip relative to the trigger element as well as surrounding elements. One of: 'top', 'bottom', 'right', 'left', 'top-start', 'top-end', 'bottom-start', 'bottom-end', 'right-start', 'right-end', 'left-start', 'left-end' |

--- a/packages/react-docs/pages/components/tooltip.mdx
+++ b/packages/react-docs/pages/components/tooltip.mdx
@@ -228,3 +228,4 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 | onClose| function | | A callback called when the tooltip hides. |
 | TransitionComponent | ElementType | Grow | The component used for the transition. |
 | TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | true | |

--- a/packages/react-docs/pages/components/transitions-collapse.mdx
+++ b/packages/react-docs/pages/components/transitions-collapse.mdx
@@ -1,0 +1,63 @@
+# Transitions / Collapse
+
+Transition helps make a UI expressive and easy to use.
+
+The transition components use `react-transition-group` internally to perform animation effects and manage component states (including mounting and unmounting) over time. You can check out all the transition props at https://reactcommunity.org/react-transition-group/transition/#Transition-props. For more information, visit http://reactcommunity.org/react-transition-group/transition for detailed usage.
+
+## Import
+
+```js
+import {
+  Collapse, // internally used in `Accordion` and `Menu`
+} from '@tonic-ui/react';
+```
+
+## Usage
+
+### Collapse
+
+The `Collapse` transition is used to animate the height of a component. The `collapsedHeight` prop is used to set the height of the component when it is collapsed.
+
+```jsx
+function Example() {
+  const [isOpen, onToggle] = useToggle();
+
+  return (
+    <Stack
+      direction="column"
+      spacing="4x"
+      overflow="hidden"
+      shouldWrapChildren
+    >
+      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
+        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
+        <Space width="2x" />
+        <Text>Show</Text>
+      </Flex>
+      <Collapse
+        in={isOpen}
+        collapsedHeight={0}
+        unmountOnExit={false}
+      >
+        <SkeletonContent>
+          <SkeletonBody />
+        </SkeletonContent>
+      </Collapse>
+    </Stack>
+  );
+}
+```
+
+## Props
+
+### Collapse
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
+| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
+| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
+| in | boolean | | If `true`, the component will transition in. |
+| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
+| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: duration.standard, exit: duration.standard } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |

--- a/packages/react-docs/pages/components/transitions-fade.mdx
+++ b/packages/react-docs/pages/components/transitions-fade.mdx
@@ -1,0 +1,62 @@
+# Transitions / Fade
+
+Transition helps make a UI expressive and easy to use.
+
+The transition components use `react-transition-group` internally to perform animation effects and manage component states (including mounting and unmounting) over time. You can check out all the transition props at https://reactcommunity.org/react-transition-group/transition/#Transition-props. For more information, visit http://reactcommunity.org/react-transition-group/transition for detailed usage.
+
+## Import
+
+```js
+import {
+  Fade, // internally used in `Modal`
+} from '@tonic-ui/react';
+```
+
+## Usage
+
+### Fade
+
+The `Fade` transition is used to animate the opacity of a component.
+
+```jsx
+function Example() {
+  const [isOpen, onToggle] = useToggle();
+
+  return (
+    <Stack
+      direction="column"
+      spacing="4x"
+      overflow="hidden"
+      shouldWrapChildren
+    >
+      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
+        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
+        <Space width="2x" />
+        <Text>Show</Text>
+      </Flex>
+      <Fade
+        in={isOpen}
+        unmountOnExit={false}
+      >
+        <SkeletonContent>
+          <SkeletonBody />
+        </SkeletonContent>
+      </Fade>
+    </Stack>
+  );
+}
+```
+
+## Props
+
+### Fade
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
+| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
+| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
+| in | boolean | | If `true`, the component will transition in. |
+| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
+| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: duration.enterScreen, exit: duration.levingScreen } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |

--- a/packages/react-docs/pages/components/transitions-grow.mdx
+++ b/packages/react-docs/pages/components/transitions-grow.mdx
@@ -1,0 +1,62 @@
+# Transitions / Grow
+
+Transition helps make a UI expressive and easy to use.
+
+The transition components use `react-transition-group` internally to perform animation effects and manage component states (including mounting and unmounting) over time. You can check out all the transition props at https://reactcommunity.org/react-transition-group/transition/#Transition-props. For more information, visit http://reactcommunity.org/react-transition-group/transition for detailed usage.
+
+## Import
+
+```js
+import {
+  Grow, // internally used in `Popover` and `Tooltip`
+} from '@tonic-ui/react';
+```
+
+## Usage
+
+### Grow
+
+The `Grow` transition is used to animate the width and height of a component.
+
+```jsx
+function Example() {
+  const [isOpen, onToggle] = useToggle();
+
+  return (
+    <Stack
+      direction="column"
+      spacing="4x"
+      overflow="hidden"
+      shouldWrapChildren
+    >
+      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
+        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
+        <Space width="2x" />
+        <Text>Show</Text>
+      </Flex>
+      <Grow
+        in={isOpen}
+        unmountOnExit={false}
+      >
+        <SkeletonContent>
+          <SkeletonBody />
+        </SkeletonContent>
+      </Grow>
+    </Stack>
+  );
+}
+```
+
+## Props
+
+### Grow
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
+| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
+| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
+| in | boolean | | If `true`, the component will transition in. |
+| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
+| timeout | string \| number \| { appear?: number, enter?: number, exit?: number } | 'auto' | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |

--- a/packages/react-docs/pages/components/transitions-scale.mdx
+++ b/packages/react-docs/pages/components/transitions-scale.mdx
@@ -1,0 +1,64 @@
+# Transitions / Scale
+
+Transition helps make a UI expressive and easy to use.
+
+The transition components use `react-transition-group` internally to perform animation effects and manage component states (including mounting and unmounting) over time. You can check out all the transition props at https://reactcommunity.org/react-transition-group/transition/#Transition-props. For more information, visit http://reactcommunity.org/react-transition-group/transition for detailed usage.
+
+## Import
+
+```js
+import {
+  Scale,
+} from '@tonic-ui/react';
+```
+
+## Usage
+
+### Scale
+
+The `Scale` transition is used to animate the scale of a component.
+
+```jsx
+function Example() {
+  const [isOpen, onToggle] = useToggle();
+
+  return (
+    <Stack
+      direction="column"
+      spacing="4x"
+      overflow="hidden"
+      shouldWrapChildren
+    >
+      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
+        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
+        <Space width="2x" />
+        <Text>Show</Text>
+      </Flex>
+      <Scale
+        in={isOpen}
+        unmountOnExit={false}
+        initialScale={[0.9, 0.9**2]}
+      >
+        <SkeletonContent>
+          <SkeletonBody />
+        </SkeletonContent>
+      </Scale>
+    </Stack>
+  );
+}
+```
+
+## Props
+
+### Scale
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
+| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
+| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeOut, exit: easing.easeIn } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
+| in | boolean | | If `true`, the component will transition in. |
+| initialScale | number | 0.95 | The initial scale of the element. |
+| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
+| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: 150, exit: 150 } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |

--- a/packages/react-docs/pages/components/transitions-slide.mdx
+++ b/packages/react-docs/pages/components/transitions-slide.mdx
@@ -1,0 +1,102 @@
+# Transitions / Slide
+
+Transition helps make a UI expressive and easy to use.
+
+The transition components use `react-transition-group` internally to perform animation effects and manage component states (including mounting and unmounting) over time. You can check out all the transition props at https://reactcommunity.org/react-transition-group/transition/#Transition-props. For more information, visit http://reactcommunity.org/react-transition-group/transition for detailed usage.
+
+## Import
+
+```js
+import {
+  Slide, // internally used in `Drawer`
+} from '@tonic-ui/react';
+```
+
+## Usage
+
+### Slide
+
+The `Slide` transition is used to slide a component in and out of view.
+
+```jsx noInline
+const useSelection = (defaultValue) => {
+  const [value, setValue] = React.useState(defaultValue);
+  const changeBy = (value) => () => setValue(value);
+  return [value, changeBy];
+};
+
+function Example() {
+  const [isOpen, onToggle] = useToggle();
+  const [direction, changeDirectionBy] = useSelection('up');
+
+  return (
+    <Stack
+      direction="column"
+      spacing="4x"
+      overflow="hidden"
+      shouldWrapChildren
+    >
+      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
+        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
+        <Space width="2x" />
+        <Text>Show</Text>
+      </Flex>
+      <ButtonGroup
+        variant="secondary"
+        css={{
+          '> *:not(:first-of-type)': {
+            marginLeft: -1
+          }
+        }}
+      >
+        {['up', 'down', 'left', 'right'].map(value => {
+          const changeDirection = changeDirectionBy(value);
+          const onClick = () => {
+            changeDirection();
+            onToggle(false);
+          };
+
+          return (
+            <SelectableButton
+              key={value}
+              selected={value === direction}
+              onClick={onClick}
+              minWidth="15x"
+            >
+              {value}
+            </SelectableButton>
+          );
+        })}
+      </ButtonGroup>
+      <Box overflow="hidden">
+        <Slide
+          in={isOpen}
+          direction={direction}
+          unmountOnExit={false}
+        >
+          <SkeletonContent>
+            <SkeletonBody />
+          </SkeletonContent>
+        </Slide>
+      </Box>
+    </Stack>
+  );
+}
+
+render(<Example />);
+```
+
+## Props
+
+### Slide
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
+| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
+| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeOut, exit: easing.sharp } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
+| direction | string | 'down' | One of: 'up', 'down', 'left', 'right' |
+| in | boolean | | If `true`, the component will transition in. |
+| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
+| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: duration.enterScreen, exit: duration.levingScreen } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |

--- a/packages/react-docs/pages/components/transitions-zoom.mdx
+++ b/packages/react-docs/pages/components/transitions-zoom.mdx
@@ -1,0 +1,62 @@
+# Transitions / Zoom
+
+Transition helps make a UI expressive and easy to use.
+
+The transition components use `react-transition-group` internally to perform animation effects and manage component states (including mounting and unmounting) over time. You can check out all the transition props at https://reactcommunity.org/react-transition-group/transition/#Transition-props. For more information, visit http://reactcommunity.org/react-transition-group/transition for detailed usage.
+
+## Import
+
+```js
+import {
+  Zoom,
+} from '@tonic-ui/react';
+```
+
+## Usage
+
+### Zoom
+
+The `Zoom` transition is used to zoom in and out of a component.
+
+```jsx
+function Example() {
+  const [isOpen, onToggle] = useToggle();
+
+  return (
+    <Stack
+      direction="column"
+      spacing="4x"
+      overflow="hidden"
+      shouldWrapChildren
+    >
+      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
+        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
+        <Space width="2x" />
+        <Text>Show</Text>
+      </Flex>
+      <Zoom
+        in={isOpen}
+        unmountOnExit={false}
+      >
+        <SkeletonContent>
+          <SkeletonBody />
+        </SkeletonContent>
+      </Zoom>
+    </Stack>
+  );
+}
+```
+
+## Props
+
+### Zoom
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
+| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
+| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
+| in | boolean | | If `true`, the component will transition in. |
+| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
+| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: duration.enterScreen, exit: duration.levingScreen } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |

--- a/packages/react-docs/pages/components/transitions.mdx
+++ b/packages/react-docs/pages/components/transitions.mdx
@@ -17,249 +17,6 @@ import {
 } from '@tonic-ui/react';
 ```
 
-## Usage
-
-### Collapse
-
-The `Collapse` transition is used to animate the height of a component. The `collapsedHeight` prop is used to set the height of the component when it is collapsed.
-
-```jsx
-function Example() {
-  const [isOpen, onToggle] = useToggle();
-
-  return (
-    <Stack
-      direction="column"
-      spacing="4x"
-      overflow="hidden"
-      shouldWrapChildren
-    >
-      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
-        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
-        <Space width="2x" />
-        <Text>Show</Text>
-      </Flex>
-      <Collapse
-        in={isOpen}
-        collapsedHeight={0}
-        unmountOnExit={false}
-      >
-        <SkeletonContent>
-          <SkeletonBody />
-        </SkeletonContent>
-      </Collapse>
-    </Stack>
-  );
-}
-```
-
-### Fade
-
-The `Fade` transition is used to animate the opacity of a component.
-
-```jsx
-function Example() {
-  const [isOpen, onToggle] = useToggle();
-
-  return (
-    <Stack
-      direction="column"
-      spacing="4x"
-      overflow="hidden"
-      shouldWrapChildren
-    >
-      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
-        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
-        <Space width="2x" />
-        <Text>Show</Text>
-      </Flex>
-      <Fade
-        in={isOpen}
-        unmountOnExit={false}
-      >
-        <SkeletonContent>
-          <SkeletonBody />
-        </SkeletonContent>
-      </Fade>
-    </Stack>
-  );
-}
-```
-
-### Grow
-
-The `Grow` transition is used to animate the width and height of a component.
-
-```jsx
-function Example() {
-  const [isOpen, onToggle] = useToggle();
-
-  return (
-    <Stack
-      direction="column"
-      spacing="4x"
-      overflow="hidden"
-      shouldWrapChildren
-    >
-      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
-        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
-        <Space width="2x" />
-        <Text>Show</Text>
-      </Flex>
-      <Grow
-        in={isOpen}
-        unmountOnExit={false}
-      >
-        <SkeletonContent>
-          <SkeletonBody />
-        </SkeletonContent>
-      </Grow>
-    </Stack>
-  );
-}
-```
-
-### Scale
-
-The `Scale` transition is used to animate the scale of a component.
-
-```jsx
-function Example() {
-  const [isOpen, onToggle] = useToggle();
-
-  return (
-    <Stack
-      direction="column"
-      spacing="4x"
-      overflow="hidden"
-      shouldWrapChildren
-    >
-      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
-        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
-        <Space width="2x" />
-        <Text>Show</Text>
-      </Flex>
-      <Scale
-        in={isOpen}
-        unmountOnExit={false}
-        initialScale={[0.9, 0.9**2]}
-      >
-        <SkeletonContent>
-          <SkeletonBody />
-        </SkeletonContent>
-      </Scale>
-    </Stack>
-  );
-}
-```
-
-### Slide
-
-The `Slide` transition is used to slide a component in and out of view.
-
-```jsx noInline
-const useSelection = (defaultValue) => {
-  const [value, setValue] = React.useState(defaultValue);
-  const changeBy = (value) => () => setValue(value);
-  return [value, changeBy];
-};
-
-function Example() {
-  const [isOpen, onToggle] = useToggle();
-  const [direction, changeDirectionBy] = useSelection('up');
-
-  return (
-    <Stack
-      direction="column"
-      spacing="4x"
-      overflow="hidden"
-      shouldWrapChildren
-    >
-      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
-        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
-        <Space width="2x" />
-        <Text>Show</Text>
-      </Flex>
-      <ButtonGroup
-        variant="secondary"
-        css={{
-          '> *:not(:first-of-type)': {
-            marginLeft: -1
-          }
-        }}
-      >
-        {['up', 'down', 'left', 'right'].map(value => {
-          const changeDirection = changeDirectionBy(value);
-          const onClick = () => {
-            changeDirection();
-            onToggle(false);
-          };
-
-          return (
-            <SelectableButton
-              key={value}
-              selected={value === direction}
-              onClick={onClick}
-              minWidth="15x"
-            >
-              {value}
-            </SelectableButton>
-          );
-        })}
-      </ButtonGroup>
-      <Box overflow="hidden">
-        <Slide
-          in={isOpen}
-          direction={direction}
-          unmountOnExit={false}
-        >
-          <SkeletonContent>
-            <SkeletonBody />
-          </SkeletonContent>
-        </Slide>
-      </Box>
-    </Stack>
-  );
-}
-
-render(<Example />);
-```
-
-### Zoom
-
-The `Zoom` transition is used to zoom in and out of a component.
-
-```jsx
-function Example() {
-  const [isOpen, onToggle] = useToggle();
-
-  return (
-    <Stack
-      direction="column"
-      spacing="4x"
-      overflow="hidden"
-      shouldWrapChildren
-    >
-      <Flex as="label" display="inline-flex" alignItems="center" cursor="pointer" userSelect="none">
-        <ToggleSwitch checked={isOpen} onChange={() => onToggle()} size="sm" />
-        <Space width="2x" />
-        <Text>Show</Text>
-      </Flex>
-      <Zoom
-        in={isOpen}
-        unmountOnExit={false}
-      >
-        <SkeletonContent>
-          <SkeletonBody />
-        </SkeletonContent>
-      </Zoom>
-    </Stack>
-  );
-}
-```
-
-## Transition Components
-
 ### Transition easing & timeout
 
 ```js
@@ -284,6 +41,8 @@ or
 />
 ```
 
+### Transition components
+
 | Transition | Enter Easing | Exit Easing | Enter Timeout | Exit Timeout |
 | :-- | :-- | :-- | :-- | :-- |
 | Collapse | easeInOut | easeInOut | standard (300ms) | standard (300ms) |
@@ -293,7 +52,7 @@ or
 | Slide | easeOut | sharp | enteringScreen (225ms) | leavingScreen (195ms) |
 | Zoom | easeInOut | easeInOut | enteringScreen (225ms) | leavingScreen (195ms) |
 
-#### Easing
+### Transition easing
 
 The timing functions are commonly called <i>easing functions</i>, and can be defined using a predefined keyword value, a stepping function, or a cubic Bezier curve.
 
@@ -306,7 +65,7 @@ The following specifies the easing functions that are used internally transition
 | easeIn | 'cubic-bezier(0.4, 0, 1, 1)' | Objects leave the screen at full velocity. They do not decelerate when off-screen. |
 | sharp | 'cubic-bezier(0.4, 0, 0.6, 1)' | The sharp curve is used by objects that may return to the screen at any time. |
 
-#### Timeout
+### Transition timeout
 
 The duration for the transition, in milliseconds.
 
@@ -332,79 +91,15 @@ The following specifies the duration for the transition that is used internally 
 | Slide | <pre>transform: none;</pre> | <pre>transform: none;</pre> | <pre>transform: translateX(+100%); // LEFT<br/>transform: translateX(-100%); // RIGHT<br/>transform: translateY(+100%); // UP<br/>transform: translateY(-100%); // DOWN</pre> | <pre>transform: translateX(+100%); // LEFT<br/>transform: translateX(-100%); // RIGHT<br/>transform: translateY(+100%); // UP<br/>transform: translateY(-100%); // DOWN</pre> |
 | Zoom | <pre>transform: none;</pre> | <pre>transform: none;</pre> | <pre>transform: scale(0);</pre> | <pre>transform: scale(0);</pre> |
 
-## Props
-
-### Collapse
+### Transition props
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
 | appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
 | children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
-| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
+| easing | string \| { enter?: string, exit?: string } | | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
 | in | boolean | | If `true`, the component will transition in. |
 | mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
-| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: duration.standard, exit: duration.standard } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| timeout | number \| { appear?: number, enter?: number, exit?: number } | | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |
 
-### Fade
-
-| Name | Type | Default | Description |
-| :--- | :--- | :------ | :---------- |
-| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
-| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
-| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
-| in | boolean | | If `true`, the component will transition in. |
-| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
-| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: duration.enterScreen, exit: duration.levingScreen } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
-| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |
-
-### Grow
-
-| Name | Type | Default | Description |
-| :--- | :--- | :------ | :---------- |
-| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
-| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
-| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
-| in | boolean | | If `true`, the component will transition in. |
-| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
-| timeout | string \| number \| { appear?: number, enter?: number, exit?: number } | 'auto' | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
-| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |
-
-
-### Scale
-
-| Name | Type | Default | Description |
-| :--- | :--- | :------ | :---------- |
-| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
-| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
-| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeOut, exit: easing.easeIn } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
-| in | boolean | | If `true`, the component will transition in. |
-| initialScale | number | 0.95 | The initial scale of the element. |
-| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
-| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: 150, exit: 150 } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
-| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |
-
-### Slide
-
-| Name | Type | Default | Description |
-| :--- | :--- | :------ | :---------- |
-| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
-| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
-| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeOut, exit: easing.sharp } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
-| direction | string | 'down' | One of: 'up', 'down', 'left', 'right' |
-| in | boolean | | If `true`, the component will transition in. |
-| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
-| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: duration.enterScreen, exit: duration.levingScreen } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
-| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |
-
-### Zoom
-
-| Name | Type | Default | Description |
-| :--- | :--- | :------ | :---------- |
-| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
-| children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
-| easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
-| in | boolean | | If `true`, the component will transition in. |
-| mountOnEnter | boolean | | If `true`, it will "lazy mount" the component on the first `in={true}`. After the first enter transition the component will stay mounted, even on the 'exited' state, unless you also specify `unmountOnExit`. By default the child component is mounted immediately along with the parent transition component. |
-| timeout | number \| { appear?: number, enter?: number, exit?: number } | { enter: duration.enterScreen, exit: duration.levingScreen } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
-| unmountOnExit | boolean | | If `true`, it will unmount the child component when `in={false}` and the animation has finished. By default the child component stays mounted after it reaches the 'exited' state. |

--- a/packages/react-docs/pages/components/transitions.mdx
+++ b/packages/react-docs/pages/components/transitions.mdx
@@ -338,6 +338,7 @@ The following specifies the duration for the transition that is used internally 
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
 | children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
 | easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
 | in | boolean | | If `true`, the component will transition in. |
@@ -349,6 +350,7 @@ The following specifies the duration for the transition that is used internally 
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
 | children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
 | easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
 | in | boolean | | If `true`, the component will transition in. |
@@ -360,6 +362,7 @@ The following specifies the duration for the transition that is used internally 
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
 | children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
 | easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
 | in | boolean | | If `true`, the component will transition in. |
@@ -372,6 +375,7 @@ The following specifies the duration for the transition that is used internally 
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
 | children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
 | easing | string \| { enter?: string, exit?: string } | { enter: easing.easeOut, exit: easing.easeIn } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
 | in | boolean | | If `true`, the component will transition in. |
@@ -384,6 +388,7 @@ The following specifies the duration for the transition that is used internally 
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
 | children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
 | easing | string \| { enter?: string, exit?: string } | { enter: easing.easeOut, exit: easing.sharp } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
 | direction | string | 'down' | One of: 'up', 'down', 'left', 'right' |
@@ -396,6 +401,7 @@ The following specifies the duration for the transition that is used internally 
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| appear | boolean | false | By default the child component does not perform the enter transition when it first mounts, regardless of the value of `in`. If you want this behavior, set both `appear` and `in` to true. |
 | children | ReactNode \| (state, props) => ReactNode | | A function child can be used instead of a React element. This function is called with the current transition state ('entering', 'entered', 'exiting', 'exited'), ref, style, and context specific props for a component. |
 | easing | string \| { enter?: string, exit?: string } | { enter: easing.easeInOut, exit: easing.easeInOut } | The timing function that describes how intermediate values are calculated during a transition. You may specify a single timing function for all transitions, or individually with an object. |
 | in | boolean | | If `true`, the component will transition in. |

--- a/packages/react/src/accordion/AccordionCollapse.js
+++ b/packages/react/src/accordion/AccordionCollapse.js
@@ -21,6 +21,7 @@ const AccordionCollapse = forwardRef((
 
   return (
     <TransitionComponent
+      appear={false} // do not perform the enter transition when it first mounts
       {...TransitionProps}
       ref={ref}
       in={context?.isExpanded}

--- a/packages/react/src/accordion/AccordionToggleIcon.js
+++ b/packages/react/src/accordion/AccordionToggleIcon.js
@@ -93,7 +93,7 @@ const AccordionToggleIcon = forwardRef((
         };
 
         if (typeof children === 'function') {
-          return children({
+          return children(state, {
             ...childProps,
             ref: combinedRef,
             style: {

--- a/packages/react/src/accordion/AccordionToggleIcon.js
+++ b/packages/react/src/accordion/AccordionToggleIcon.js
@@ -47,7 +47,7 @@ const defaultTimeout = {
 
 const AccordionToggleIcon = forwardRef((
   {
-    appear = true,
+    appear = false, // do not perform the enter transition when it first mounts
     children,
     disabled: disabledProp,
     easing = defaultEasing,

--- a/packages/react/src/drawer/DrawerContent.js
+++ b/packages/react/src/drawer/DrawerContent.js
@@ -56,6 +56,7 @@ const DrawerContentBackdrop = forwardRef(({
 
   return (
     <TransitionComponent
+      appear={true}
       {...TransitionProps}
       in={isOpen}
       direction={direction}

--- a/packages/react/src/drawer/DrawerOverlay.js
+++ b/packages/react/src/drawer/DrawerOverlay.js
@@ -32,6 +32,7 @@ const DrawerOverlay = forwardRef(({
   if (drawerContext) {
     return (
       <TransitionComponent
+        appear={true}
         {...TransitionProps}
         in={isOpen}
         onExited={chainedFunction(safeToRemove, TransitionProps?.onExited)}

--- a/packages/react/src/menu/MenuList.js
+++ b/packages/react/src/menu/MenuList.js
@@ -112,6 +112,7 @@ const MenuList = forwardRef((
         const { in: inProp, onEnter, onExited } = { ...transition };
         return (
           <TransitionComponent
+            appear={true}
             easing="linear"
             timeout={{
               enter: 133,

--- a/packages/react/src/menu/MenuToggleIcon.js
+++ b/packages/react/src/menu/MenuToggleIcon.js
@@ -121,7 +121,7 @@ const MenuToggleIcon = forwardRef((
         };
 
         if (typeof children === 'function') {
-          return children({
+          return children(state, {
             ...childProps,
             ref: combinedRef,
             style: {

--- a/packages/react/src/menu/MenuToggleIcon.js
+++ b/packages/react/src/menu/MenuToggleIcon.js
@@ -73,7 +73,7 @@ const defaultTimeout = {
 
 const MenuToggleIcon = forwardRef((
   {
-    appear = true,
+    appear = false, // do not perform the enter transition when it first mounts
     children,
     disabled,
     easing = defaultEasing,

--- a/packages/react/src/modal/ModalContent.js
+++ b/packages/react/src/modal/ModalContent.js
@@ -48,6 +48,7 @@ const ModalContentBackdrop = forwardRef(({
 
   return (
     <TransitionComponent
+      appear={true}
       {...TransitionProps}
       in={isOpen}
       onExited={chainedFunction(safeToRemove, TransitionProps?.onExited)}

--- a/packages/react/src/modal/ModalOverlay.js
+++ b/packages/react/src/modal/ModalOverlay.js
@@ -32,6 +32,7 @@ const ModalOverlay = forwardRef(({
   if (modalContext) {
     return (
       <TransitionComponent
+        appear={true}
         {...TransitionProps}
         in={isOpen}
         onExited={chainedFunction(safeToRemove, TransitionProps?.onExited)}

--- a/packages/react/src/popover/Popover.js
+++ b/packages/react/src/popover/Popover.js
@@ -1,14 +1,12 @@
-import { useEffectOnce, usePrevious } from '@tonic-ui/react-hooks';
+import { usePrevious } from '@tonic-ui/react-hooks';
 import React, { useEffect, useRef, useState } from 'react';
 import config from '../shared/config';
 import { useId } from '../utils/autoId';
-import warnRemovedProps from '../utils/warnRemovedProps';
 import { PopoverContextProvider } from './context';
 
 const Popover = ({
-  defaultIsOpen, // removed
-
   id,
+  defaultIsOpen = false,
   isOpen: isOpenProp,
   initialFocusRef,
   usePortal = true,
@@ -29,17 +27,7 @@ const Popover = ({
   followCursor,
   arrowAt,
 }) => {
-  useEffectOnce(() => {
-    const prefix = `${Popover.displayName}:`;
-
-    if (defaultIsOpen !== undefined) {
-      warnRemovedProps('defaultIsOpen', {
-        prefix,
-      });
-    }
-  }, true); // TODO: check if `when` is true for each prop
-
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(defaultIsOpen);
   const [mousePageX, setMousePageX] = useState(0);
   const [mousePageY, setMousePageY] = useState(0);
   const { current: isControlled } = useRef(isOpenProp != null);

--- a/packages/react/src/popover/PopoverContent.js
+++ b/packages/react/src/popover/PopoverContent.js
@@ -153,6 +153,7 @@ const PopoverContent = ({
         const { in: inProp, onEnter, onExited } = { ...transition };
         return (
           <TransitionComponent
+            appear={true}
             {...TransitionProps}
             ref={nodeRef}
             in={inProp}

--- a/packages/react/src/toast/ToastTransition.js
+++ b/packages/react/src/toast/ToastTransition.js
@@ -61,7 +61,7 @@ const Wrapper = forwardRef((props, ref) => <Box ref={ref} {...props} />);
 
 const ToastTransition = forwardRef((
   {
-    appear = true,
+    appear = false, // do not perform the enter transition when it first mounts
     children,
     collapsedHeight = 0,
     easing = defaultEasing,

--- a/packages/react/src/tooltip/Tooltip.js
+++ b/packages/react/src/tooltip/Tooltip.js
@@ -193,6 +193,7 @@ const Tooltip = forwardRef((
             const { in: inProp, onEnter, onExited } = { ...transition };
             return (
               <TransitionComponent
+                appear={true}
                 {...TransitionProps}
                 ref={nodeRef}
                 in={inProp}

--- a/packages/react/src/tooltip/Tooltip.js
+++ b/packages/react/src/tooltip/Tooltip.js
@@ -30,7 +30,6 @@ const Tooltip = forwardRef((
   {
     showDelay, // deprecated
     hideDelay, // deprecated
-    defaultIsOpen, // removed
     shouldWrapChildren, // removed
 
     label,
@@ -40,7 +39,8 @@ const Tooltip = forwardRef((
     children,
     hideArrow,
     closeOnClick,
-    isOpen: isControlledOpen,
+    defaultIsOpen = false,
+    isOpen: isOpenProp,
     onOpen: onOpenProp,
     onClose: onCloseProp,
     arrowAt,
@@ -73,12 +73,6 @@ const Tooltip = forwardRef((
       });
     }
 
-    if (defaultIsOpen !== undefined) {
-      warnRemovedProps('defaultIsOpen', {
-        prefix,
-      });
-    }
-
     if (shouldWrapChildren !== undefined && !shouldWrapChildren) {
       warnRemovedProps('shouldWrapChildren', {
         prefix,
@@ -92,9 +86,9 @@ const Tooltip = forwardRef((
   const combinedRef = useForkRef(anchorRef, ref);
   const isHydrated = useHydrated();
 
-  const [isOpen, setIsOpen] = useState(false);
-  const { current: isControlled } = useRef((isControlledOpen !== undefined) && (isControlledOpen !== null));
-  const _isOpen = isControlled ? isControlledOpen : isOpen;
+  const [isOpen, setIsOpen] = useState(defaultIsOpen);
+  const { current: isControlled } = useRef((isOpenProp !== undefined) && (isOpenProp !== null));
+  const _isOpen = isControlled ? isOpenProp : isOpen;
 
   const enterTimeoutRef = useRef();
   const exitTimeoutRef = useRef();

--- a/packages/react/src/transitions/Collapse.js
+++ b/packages/react/src/transitions/Collapse.js
@@ -54,7 +54,7 @@ const Wrapper = forwardRef((props, ref) => <Box ref={ref} {...props} />);
 
 const Collapse = forwardRef((
   {
-    appear = true,
+    appear = false, // do not perform the enter transition when it first mounts
     children,
     collapsedHeight = 0,
     easing = defaultEasing,

--- a/packages/react/src/transitions/Fade.js
+++ b/packages/react/src/transitions/Fade.js
@@ -46,7 +46,7 @@ const defaultTimeout = {
 
 const Fade = forwardRef((
   {
-    appear = true,
+    appear = false, // do not perform the enter transition when it first mounts
     children,
     easing = defaultEasing,
     in: inProp,

--- a/packages/react/src/transitions/Grow.js
+++ b/packages/react/src/transitions/Grow.js
@@ -59,7 +59,7 @@ const getAutoHeightDuration = height => {
 
 const Grow = forwardRef((
   {
-    appear = true,
+    appear = false, // do not perform the enter transition when it first mounts
     children,
     easing = defaultEasing,
     in: inProp,

--- a/packages/react/src/transitions/Scale.js
+++ b/packages/react/src/transitions/Scale.js
@@ -61,7 +61,7 @@ const defaultTimeout = {
 
 const Scale = forwardRef((
   {
-    appear = true,
+    appear = false, // do not perform the enter transition when it first mounts
     children,
     easing = defaultEasing,
     in: inProp,

--- a/packages/react/src/transitions/Slide.js
+++ b/packages/react/src/transitions/Slide.js
@@ -73,7 +73,7 @@ const defaultTimeout = {
 
 const Slide = forwardRef((
   {
-    appear = true,
+    appear = false, // do not perform the enter transition when it first mounts
     children,
     direction = DIRECTION_DOWN,
     easing = defaultEasing,

--- a/packages/react/src/transitions/Zoom.js
+++ b/packages/react/src/transitions/Zoom.js
@@ -46,7 +46,7 @@ const defaultTimeout = {
 
 const Zoom = forwardRef((
   {
-    appear = true,
+    appear = false, // do not perform the enter transition when it first mounts
     children,
     easing = defaultEasing,
     in: inProp,


### PR DESCRIPTION
By default the transition component does not perform the enter transition when it first mounts, regardless of the value of `in`. For If you want this behavior, set both `appear` and `in` to true.

#### TODOs
- [x] Add the following table to the docs
- [x] Update accordion example

| Transition | `appear` |
| :-- | :-- |
| Collapse | false |
| Fade | false |
| Grow | false |
| Scale | false |
| Slide | false |
| Zoom | false |

| Component | Composed Transition | `appear` |
| :-- | :-- | :-- |
| ✔️ AccordionCollapse | Collapse | false |
| ✔️ AccordionToggleIcon | built-in | false |
| ✔️ DrawerContent | Slide | true |
| ✔️ DrawerOverlay | Fade | true |
| ✔️ MenuList | Collapse | true |
| ✔️ MenuToggleIcon | built-in | false |
| ✔️ ModalContent | Fade | true |
| ✔️ ModalOverlay | Fade | true |
| ✔️ PopoverContent | Grow | true |
| ToastTransition | built-in | false |
| ✔️ Tooltip | Grow | false |

Note: Some components set `appear` to true because `Portal` is used internally or it renders after the first mount.