### PR TITLE
fix: `Button`, `Input`, `InputGroupAddon`, `Checkbox`, and `Radio` components should be able to override props inherited from their parent groups

### DIFF
--- a/packages/react/src/box/ControlBox.js
+++ b/packages/react/src/box/ControlBox.js
@@ -65,7 +65,7 @@ const ControlBox = forwardRef((
         '& > *': _indeterminateAndChild,
       },
     }),
-    { ...css },
+    css,
   ];
 
   return (

--- a/packages/react/src/button/Button.js
+++ b/packages/react/src/button/Button.js
@@ -19,34 +19,30 @@ const Button = forwardRef((
   ref,
 ) => {
   const buttonGroupContext = useButtonGroup();
-  let isInGroup = false;
-  let useVertical = false;
   if (buttonGroupContext) {
-    isInGroup = true;
     const {
       size: buttonGroupSize,
       variant: buttonGroupVariant,
       orientation,
     } = { ...buttonGroupContext };
-    useVertical = (orientation === 'vertical');
-    // - Use the inherited value from the button group
-    // - Fallback to the default value if the value is null or undefined
-    size = (buttonGroupSize ?? size) ?? defaultSize;
-    variant = (buttonGroupVariant ?? variant) ?? defaultVariant;
+    // Use fallback values if values are null or undefined
+    size = (size ?? buttonGroupSize) ?? defaultSize;
+    variant = (variant ?? buttonGroupVariant) ?? defaultVariant;
+    css = [
+      getButtonGroupCSS({ orientation }),
+      css,
+    ];
   } else {
     // Use the default value if the value is null or undefined
     size = size ?? defaultSize;
     variant = variant ?? defaultVariant;
   }
-  const buttonStyleProps = useButtonStyle({
+
+  const styleProps = useButtonStyle({
     size,
     variant,
     borderRadius,
   });
-  css = [
-    isInGroup && getButtonGroupCSS({ useVertical }),
-    { ...css }
-  ];
 
   return (
     <ButtonBase
@@ -55,7 +51,7 @@ const Button = forwardRef((
       type={type}
       borderRadius={borderRadius}
       css={css}
-      {...buttonStyleProps}
+      {...styleProps}
       {...rest}
     >
       { children }

--- a/packages/react/src/button/styles.js
+++ b/packages/react/src/button/styles.js
@@ -346,7 +346,7 @@ const useButtonBaseStyle = ({ disabled }) => {
   };
 };
 
-const getButtonGroupCSS = ({ useVertical }) => {
+const getButtonGroupCSS = ({ orientation }) => {
   const horizontalCSS = sx({
     '&:not(:first-of-type)': {
       borderTopLeftRadius: 0,
@@ -367,7 +367,7 @@ const getButtonGroupCSS = ({ useVertical }) => {
       borderBottomRightRadius: 0,
     },
   });
-  return useVertical ? verticalCSS : horizontalCSS;
+  return (orientation === 'vertical') ? verticalCSS : horizontalCSS;
 };
 
 export {

--- a/packages/react/src/checkbox/Checkbox.js
+++ b/packages/react/src/checkbox/Checkbox.js
@@ -17,29 +17,26 @@ const sizes = {
 };
 
 const defaultSize = 'md';
+const defaultVariantColor = 'blue';
 
 const Checkbox = forwardRef((
   {
-    id,
-    name,
-    value,
-
-    defaultChecked,
     checked,
+    children,
+    defaultChecked,
     disabled,
-    readOnly,
-    indeterminate,
-
-    variantColor = 'blue',
-    size,
     iconColor,
-
+    id,
+    indeterminate,
+    name,
+    readOnly,
+    size,
+    value,
+    variantColor,
+    onBlur,
     onChange,
     onClick,
-    onBlur,
     onFocus,
-
-    children,
     ...rest
   },
   ref,
@@ -66,13 +63,13 @@ const Checkbox = forwardRef((
       onChange,
       checkboxGroupOnChange,
     );
-    // - Use the inherited value from the checkbox group
-    // - Fallback to the default value if the value is null or undefined
-    size = (checkboxGroupSize ?? size) ?? defaultSize;
-    variantColor = checkboxGroupVariantColor ?? variantColor;
+    // Use the default value if the value is null or undefined
+    size = (size ?? checkboxGroupSize) ?? defaultSize;
+    variantColor = (variantColor ?? checkboxGroupVariantColor) ?? defaultVariantColor;
   } else {
     // Use the default value if the value is null or undefined
     size = size ?? defaultSize;
+    variantColor = variantColor ?? defaultVariantColor;
   }
 
   const { sizes: themeSizes } = useTheme();

--- a/packages/react/src/input/Input.js
+++ b/packages/react/src/input/Input.js
@@ -21,7 +21,6 @@ const Input = forwardRef((
       size: inputGroupSize,
       variant: inputGroupVariant,
     } = { ...inputGroupContext };
-
     // Use fallback values if values are null or undefined
     size = (size ?? inputGroupSize) ?? defaultSize;
     variant = (variant ?? inputGroupVariant) ?? defaultVariant;

--- a/packages/react/src/input/InputGroupAddon.js
+++ b/packages/react/src/input/InputGroupAddon.js
@@ -3,6 +3,9 @@ import { Box } from '../box';
 import { useInputGroupAddonStyle } from './styles';
 import useInputGroup from './useInputGroup';
 
+const defaultSize = 'md';
+const defaultVariant = 'outline';
+
 const InputGroupAddon = forwardRef((
   {
     size,
@@ -12,18 +15,19 @@ const InputGroupAddon = forwardRef((
   ref,
 ) => {
   const inputGroupContext = useInputGroup();
-  if (!inputGroupContext) {
-    throw new Error('`InputGroupAddon` must be a descendant of a `InputGroup`.');
+  if (inputGroupContext) {
+    const {
+      size: inputGroupSize,
+      variant: inputGroupVariant,
+    } = { ...inputGroupContext };
+    // Use fallback values if values are null or undefined
+    size = (size ?? inputGroupSize) ?? defaultSize;
+    variant = (variant ?? inputGroupVariant) ?? defaultVariant;
+  } else {
+    // Use fallback values if values are null or undefined
+    size = size ?? defaultSize;
+    variant = variant ?? defaultVariant;
   }
-
-  const {
-    size: inputGroupSize,
-    variant: inputGroupVariant,
-  } = inputGroupContext;
-
-  // Use fallback values if values are null or undefined
-  size = size ?? inputGroupSize;
-  variant = variant ?? inputGroupVariant;
 
   const styleProps = useInputGroupAddonStyle({ size, variant });
 

--- a/packages/react/src/radio/Radio.js
+++ b/packages/react/src/radio/Radio.js
@@ -14,6 +14,7 @@ const sizes = {
 };
 
 const defaultSize = 'md';
+const defaultVariantColor = 'blue';
 
 const Radio = forwardRef((
   {
@@ -25,7 +26,7 @@ const Radio = forwardRef((
     name,
     size,
     value,
-    variantColor = 'blue',
+    variantColor,
     onChange,
     onClick,
     onBlur,
@@ -55,13 +56,13 @@ const Radio = forwardRef((
       onChange,
       radioGroupOnChange,
     );
-    // - Use the inherited value from the radio group
-    // - Fallback to the default value if the value is null or undefined
-    size = (radioGroupSize ?? size) ?? defaultSize;
-    variantColor = radioGroupVariantColor ?? variantColor;
+    // Use the default value if the value is null or undefined
+    size = (size ?? radioGroupSize) ?? defaultSize;
+    variantColor = (variantColor ?? radioGroupVariantColor) ?? defaultVariantColor;
   } else {
     // Use the default value if the value is null or undefined
     size = size ?? defaultSize;
+    variantColor = variantColor ?? defaultVariantColor;
   }
 
   const { sizes: themeSizes } = useTheme();


### PR DESCRIPTION
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-454/components/button
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-454/components/checkbox
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-454/components/input
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-454/components/radio

### `ButtonGroup`
![image](https://user-images.githubusercontent.com/447801/148527853-6a68566c-5cca-4e97-bc9b-2bf85aaccba0.png)

### `CheckboxGroup`
![image](https://user-images.githubusercontent.com/447801/148528330-bec8c68c-3f2e-4a87-bc19-917696f3e69e.png)

### `RadioGroup`
![image](https://user-images.githubusercontent.com/447801/148528433-71bca60c-b2f4-49dd-b440-7381faa99dd9.png)