### PR TITLE
feat: allow `MenuToggle` and `MenuList` not necessarily be rendered in the same DOM context

### DIFF
--- a/packages/react-docs/pages/components/accordion.mdx
+++ b/packages/react-docs/pages/components/accordion.mdx
@@ -224,13 +224,13 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| children | `ReactNode` \| `(context) => ReactNode` | | |
+| children | ReactNode \| (context) => ReactNode | | |
 
 ### AccordionItem
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| children | `ReactNode` \| `(context) => ReactNode` | | |
+| children | ReactNode \| (context) => ReactNode | | |
 | disabled | boolean | | Whether the accordion item is disabled. |
 | isExpanded | boolean | | Whether the accordion item is expanded. |
 | defaultIsExpanded | boolean | | Whether the accordion item is expanded by default. |
@@ -240,20 +240,20 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| children | `ReactNode` | | |
+| children | ReactNode | | |
 | disabled | boolean | | Whether the accordion header is disabled. |
 
 ### AccordionBody
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| children | `ReactNode` | | |
+| children | ReactNode | | |
 
 ### AccordionToggle
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| children | `ReactNode` | | |
+| children | ReactNode | | |
 | disabled | boolean | | Whether the accordion toggle is disabled. |
 | onClick | function | | A callback that is called when the accordion toggle is clicked. |
 
@@ -274,7 +274,7 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| children | `ReactNode` | | |
+| children | ReactNode | | |
 | TransitionComponent | ElementType | Collapse | The component used for the transition. |
 | TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
 | TransitionProps.appear | boolean | false | |

--- a/packages/react-docs/pages/components/menu.mdx
+++ b/packages/react-docs/pages/components/menu.mdx
@@ -584,7 +584,6 @@ The second number, `distance`, controls the distance between the `MenuList` and 
       16, // skidding
       8, // distance
     ]}
-    width="max-content"
   >
     <MenuItem>
       Item #1
@@ -611,7 +610,6 @@ To make the menu scrollable, pass `overflow="auto"` and `maxHeight` to `MenuList
   <MenuList
     maxHeight={200}
     overflow="auto"
-    width="max-content"
   >
     {Array.from({ length: 100 }).map((_, key) => (
       <MenuItem key={key}>
@@ -669,7 +667,7 @@ function menuWithCheckbox() {
       <MenuButton variant="secondary">
         <Text>Selected ({checkedItems.length})</Text>
       </MenuButton>
-      <MenuList width="max-content">
+      <MenuList>
         <CheckboxGroup
           size="sm"
           value={checkedItems}

--- a/packages/react-docs/pages/components/menu.mdx
+++ b/packages/react-docs/pages/components/menu.mdx
@@ -99,6 +99,7 @@ function Example() {
       >
         <MenuList
           onClick={handleClickMenuItem}
+          width="max-content"
         >
           <MenuItem value={1}>
             Item #1
@@ -128,7 +129,7 @@ function Example() {
     <MenuToggle>
       <Text>Options</Text>
     </MenuToggle>
-    <MenuList>
+    <MenuList width="max-content">
       <MenuItem>
         Item #1
       </MenuItem>
@@ -154,7 +155,7 @@ function Example() {
         <MenuToggleIcon />
       </Flex>
     </MenuToggle>
-    <MenuList>
+    <MenuList width="max-content">
       <MenuItem>
         Item #1
       </MenuItem>
@@ -187,7 +188,7 @@ function Example() {
         );
       }}
     </MenuToggle>
-    <MenuList>
+    <MenuList width="max-content">
       <MenuItem>
         Item #1
       </MenuItem>
@@ -235,40 +236,22 @@ const MenuButton = (props) => {
 ```
 
 ```jsx
-<Stack direction="column" spacing="4x">
-  <Menu>
-    <MenuButton variant="secondary" size="md" width={200}>
-      <Text>Options</Text>
-    </MenuButton>
-    <MenuList>
-      <MenuItem>
-        Item #1
-      </MenuItem>
-      <MenuItem>
-        Item #2
-      </MenuItem>
-      <MenuItem>
-        Item #3
-      </MenuItem>
-    </MenuList>
-  </Menu>
-  <Menu>
-    <MenuButton variant="secondary" size="md" width="100%">
-      <Text>Options</Text>
-    </MenuButton>
-    <MenuList>
-      <MenuItem>
-        Item #1
-      </MenuItem>
-      <MenuItem>
-        Item #2
-      </MenuItem>
-      <MenuItem>
-        Item #3
-      </MenuItem>
-    </MenuList>
-  </Menu>
-</Stack>
+<Menu>
+  <MenuButton variant="secondary">
+    <Text>Options</Text>
+  </MenuButton>
+  <MenuList width="max-content">
+    <MenuItem>
+      Item #1
+    </MenuItem>
+    <MenuItem>
+      Item #2
+    </MenuItem>
+    <MenuItem>
+      Item #3
+    </MenuItem>
+  </MenuList>
+</Menu>
 ```
 
 ### MenuToggleIcon
@@ -280,7 +263,7 @@ const MenuButton = (props) => {
   <MenuToggle>
     <MenuToggleIcon />
   </MenuToggle>
-  <MenuList>
+  <MenuList width="max-content">
     <MenuItem>
       Item #1
     </MenuItem>
@@ -319,7 +302,7 @@ You can also customize the indicator by passing a component as children or a fun
             }}
           </MenuToggleIcon>
         </MenuToggle>
-        <MenuList>
+        <MenuList width="max-content">
           <MenuItem>
             Item #1
           </MenuItem>
@@ -366,7 +349,7 @@ render(
         <Icon icon="user-team" size="5x" />
       </Avatar>
     </MenuToggle>
-    <MenuList>
+    <MenuList width="max-content">
       <MenuItem>
         <Text>Profile</Text>
       </MenuItem>
@@ -404,14 +387,14 @@ render(
 
 To change the width of the menu, pass `width` prop to the `MenuList` component.
 
-#### `width={240}`
+#### fixed width
 
 ```jsx
 <Menu>
   <MenuButton variant="secondary">
     <Text>This is a very long menu button</Text>
   </MenuButton>
-  <MenuList width={240}>
+  <MenuList width={200}>
     <MenuItem>
       Item #1
     </MenuItem>
@@ -425,28 +408,30 @@ To change the width of the menu, pass `width` prop to the `MenuList` component.
 </Menu>
 ```
 
-#### `width="max-content"`
+#### full width
+
+Set `display="block"` on the `Menu` and set `width="100%"` on `MenuButton` and `MenuList` to make the menu as wide as the content.
 
 ```jsx
-<Menu>
-  <MenuButton variant="secondary">
+<Menu display="block">
+  <MenuButton variant="secondary" width="100%">
     <Text>Options</Text>
   </MenuButton>
-  <MenuList width="max-content">
+  <MenuList width="100%">
     <MenuItem>
-      This is a very long menu item #1
+      Item #1
     </MenuItem>
     <MenuItem>
-      This is a very long menu item #2
+      Item #2
     </MenuItem>
     <MenuItem>
-      This is a very long menu item #3
+      Item #3
     </MenuItem>
   </MenuList>
 </Menu>
 ```
 
-#### `width="min-content"`
+#### `min-content`
 
 ```jsx
 <Menu>
@@ -462,6 +447,27 @@ To change the width of the menu, pass `width` prop to the `MenuList` component.
     </MenuItem>
     <MenuItem>
       Menu item #3
+    </MenuItem>
+  </MenuList>
+</Menu>
+```
+
+#### `max-content`
+
+```jsx
+<Menu>
+  <MenuButton variant="secondary">
+    <Text>Options</Text>
+  </MenuButton>
+  <MenuList width="max-content">
+    <MenuItem>
+      This is a very long menu item #1
+    </MenuItem>
+    <MenuItem>
+      This is a very long menu item #2
+    </MenuItem>
+    <MenuItem>
+      This is a very long menu item #3
     </MenuItem>
   </MenuList>
 </Menu>
@@ -518,10 +524,10 @@ function Example() {
             return (
               <Box key={key}>
                 <Menu placement={placement}>
-                  <MenuButton variant="secondary">
+                  <MenuButton variant="secondary" width={150}>
                     <Text>Options</Text>
                   </MenuButton>
-                  <MenuList width="max-content">
+                  <MenuList>
                     <MenuItem>
                       Item #1
                     </MenuItem>
@@ -603,13 +609,14 @@ The second number, `distance`, controls the distance between the `MenuList` and 
 To make the menu scrollable, pass `overflow="auto"` and `maxHeight` to `MenuList`. The menu will become scrollable when the menu items exceed the height of the menu.
 
 ```jsx
-<Menu>
-  <MenuButton variant="secondary">
+<Menu display="block">
+  <MenuButton variant="secondary" width={200}>
     <Text>Options</Text>
   </MenuButton>
   <MenuList
     maxHeight={200}
     overflow="auto"
+    width={200}
   >
     {Array.from({ length: 100 }).map((_, key) => (
       <MenuItem key={key}>
@@ -623,11 +630,11 @@ To make the menu scrollable, pass `overflow="auto"` and `maxHeight` to `MenuList
 You can also use the `Scrollbar` component to override the default scrollbar.
 
 ```jsx
-<Menu>
-  <MenuButton variant="secondary">
+<Menu display="block">
+  <MenuButton variant="secondary" width={200}>
     <Text>Options</Text>
   </MenuButton>
-  <MenuList width={100}>
+  <MenuList width={200}>
     <Scrollbar height={200} overflowY="visible">
       {Array.from({ length: 100 }).map((_, key) => (
         <MenuItem key={key}>
@@ -667,7 +674,7 @@ function menuWithCheckbox() {
       <MenuButton variant="secondary">
         <Text>Selected ({checkedItems.length})</Text>
       </MenuButton>
-      <MenuList>
+      <MenuList width="max-content">
         <CheckboxGroup
           size="sm"
           value={checkedItems}
@@ -760,11 +767,13 @@ function menuWithCheckbox() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| children | ReactNode | | |
-| offset | [skidding, distance] | [0, 0] | To control the distance and skidding of the menu list |
+| PopperComponent | ElementType | Popper | The component used for the popover. |
+| PopperProps | object | | Props applied to the Popper component. |
 | TransitionComponent | ElementType | Collapse | The component used for the transition. |
 | TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
 | TransitionProps.appear | boolean | true | |
+| children | ReactNode | | |
+| offset | [skidding, distance] | [0, 0] | To control the distance and skidding of the menu list |
 
 ### MenuGroup
 

--- a/packages/react-docs/pages/components/menu.mdx
+++ b/packages/react-docs/pages/components/menu.mdx
@@ -98,7 +98,6 @@ function Example() {
         mr="2x"
       >
         <MenuList
-          width="max-content"
           onClick={handleClickMenuItem}
         >
           <MenuItem value={1}>
@@ -129,7 +128,7 @@ function Example() {
     <MenuToggle>
       <Text>Options</Text>
     </MenuToggle>
-    <MenuList width="max-content">
+    <MenuList>
       <MenuItem>
         Item #1
       </MenuItem>
@@ -155,7 +154,7 @@ function Example() {
         <MenuToggleIcon />
       </Flex>
     </MenuToggle>
-    <MenuList width="max-content">
+    <MenuList>
       <MenuItem>
         Item #1
       </MenuItem>
@@ -188,7 +187,7 @@ function Example() {
         );
       }}
     </MenuToggle>
-    <MenuList width="max-content">
+    <MenuList>
       <MenuItem>
         Item #1
       </MenuItem>
@@ -241,7 +240,7 @@ const MenuButton = (props) => {
     <MenuButton variant="secondary" size="md" width={200}>
       <Text>Options</Text>
     </MenuButton>
-    <MenuList width="max-content">
+    <MenuList>
       <MenuItem>
         Item #1
       </MenuItem>
@@ -257,7 +256,7 @@ const MenuButton = (props) => {
     <MenuButton variant="secondary" size="md" width="100%">
       <Text>Options</Text>
     </MenuButton>
-    <MenuList width="100%">
+    <MenuList>
       <MenuItem>
         Item #1
       </MenuItem>
@@ -281,7 +280,7 @@ const MenuButton = (props) => {
   <MenuToggle>
     <MenuToggleIcon />
   </MenuToggle>
-  <MenuList width="max-content">
+  <MenuList>
     <MenuItem>
       Item #1
     </MenuItem>
@@ -320,7 +319,7 @@ You can also customize the indicator by passing a component as children or a fun
             }}
           </MenuToggleIcon>
         </MenuToggle>
-        <MenuList width="max-content">
+        <MenuList>
           <MenuItem>
             Item #1
           </MenuItem>
@@ -367,7 +366,7 @@ render(
         <Icon icon="user-team" size="5x" />
       </Avatar>
     </MenuToggle>
-    <MenuList width="max-content">
+    <MenuList>
       <MenuItem>
         <Text>Profile</Text>
       </MenuItem>
@@ -405,14 +404,14 @@ render(
 
 To change the width of the menu, pass `width` prop to the `MenuList` component.
 
-#### `width="100%"`
+#### `width={240}`
 
 ```jsx
 <Menu>
   <MenuButton variant="secondary">
     <Text>This is a very long menu button</Text>
   </MenuButton>
-  <MenuList width="100%">
+  <MenuList width={240}>
     <MenuItem>
       Item #1
     </MenuItem>
@@ -428,8 +427,6 @@ To change the width of the menu, pass `width` prop to the `MenuList` component.
 
 #### `width="max-content"`
 
-By default, the menu items will wrap to the next line if the width of the toggle is smaller than the width of the menu. You can pass `width="max-content"` to `MenuList` to prevent wrapping.
-
 ```jsx
 <Menu>
   <MenuButton variant="secondary">
@@ -444,6 +441,27 @@ By default, the menu items will wrap to the next line if the width of the toggle
     </MenuItem>
     <MenuItem>
       This is a very long menu item #3
+    </MenuItem>
+  </MenuList>
+</Menu>
+```
+
+#### `width="min-content"`
+
+```jsx
+<Menu>
+  <MenuButton variant="secondary">
+    <Text>Options</Text>
+  </MenuButton>
+  <MenuList width="min-content">
+    <MenuItem >
+      Menu item #1
+    </MenuItem>
+    <MenuItem>
+      Menu item #2
+    </MenuItem>
+    <MenuItem>
+      Menu item #3
     </MenuItem>
   </MenuList>
 </Menu>
@@ -611,8 +629,8 @@ You can also use the `Scrollbar` component to override the default scrollbar.
   <MenuButton variant="secondary">
     <Text>Options</Text>
   </MenuButton>
-  <MenuList width="100%">
-    <Scrollbar height={200}>
+  <MenuList width={100}>
+    <Scrollbar height={200} overflowY="visible">
       {Array.from({ length: 100 }).map((_, key) => (
         <MenuItem key={key}>
           Item #{key + 1}
@@ -627,14 +645,24 @@ You can also use the `Scrollbar` component to override the default scrollbar.
 
 Set `closeOnSelect` to `false` to keep the menu open after selecting a menu item.
 
+You can use arrow keys to navigate the menu, and press `Enter` or `Space` to select an item.
+
 ```jsx
 function menuWithCheckbox() {
   const [checkedItems, setCheckedItems] = React.useState(['host', 'ip']);
-  const handleChange = (e) => {
-    const value = e.target.value;
-    const items = [...checkedItems];
-    items.indexOf(value) === -1 ? items.push(value) : items.splice(items.indexOf(value), 1);
-    setCheckedItems(items);
+  const onCheckboxGroupChange = (value) => {
+    setCheckedItems(value);
+  };
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      const el = event.currentTarget.querySelector('input');
+      if (el) {
+        const value = el.value;
+        const items = [...checkedItems];
+        items.indexOf(value) === -1 ? items.push(value) : items.splice(items.indexOf(value), 1);
+        setCheckedItems(items);
+      }
+    }
   };
   return (
     <Menu closeOnSelect={false}>
@@ -642,10 +670,25 @@ function menuWithCheckbox() {
         <Text>Selected ({checkedItems.length})</Text>
       </MenuButton>
       <MenuList width="max-content">
-        <CheckboxGroup size="sm" defaultValue={checkedItems}>
-          <MenuItem><Checkbox value="host" onChange={e => handleChange(e)}>Endpoint name</Checkbox></MenuItem>
-          <MenuItem><Checkbox value="ip" onChange={e => handleChange(e)}>IP address</Checkbox></MenuItem>
-          <MenuItem><Checkbox value="os" onChange={e => handleChange(e)}>Operating system</Checkbox></MenuItem>
+        <CheckboxGroup
+          size="sm"
+          value={checkedItems}
+          onChange={onCheckboxGroupChange}
+        >
+          <MenuItem onKeyDown={handleKeyDown}>
+            <Checkbox value="host">
+              Endpoint name</Checkbox>
+          </MenuItem>
+          <MenuItem onKeyDown={handleKeyDown}>
+            <Checkbox value="ip">
+              IP address
+            </Checkbox>
+          </MenuItem>
+          <MenuItem onKeyDown={handleKeyDown}>
+            <Checkbox value="os">
+              Operating system
+            </Checkbox>
+          </MenuItem>
         </CheckboxGroup>
       </MenuList>
     </Menu>
@@ -669,9 +712,9 @@ function menuWithCheckbox() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| anchorEl | `Element` | | The element to which the menu is attached. |
+| anchorEl | ElementType | | The element to which the menu is attached. |
 | autoSelect | boolean | `true` | Whether to automatically select the first menu item when the menu is opened. |
-| children | ReactNode | | The children must be composed by a `MenuList` and either one of `MenuToggle` or `MenuButton`. |
+| children | ReactNode \| (context) => ReactNode | | |
 | closeOnBlur | boolean | `true` | Whether to close the menu when the user clicks outside of the menu. |
 | closeOnSelect | boolean | `true` | Whether to close the menu when the user selects a menu item. |
 | defaultActiveIndex | number | -1 | The index of the menu item to be selected by default. |
@@ -688,7 +731,7 @@ function menuWithCheckbox() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| children | ReactNode \| function | | |
+| children | ReactNode | | |
 | disabled | boolean | | Whether the menu button is disabled. |
 | onClick | function | | Callback when the menu button is clicked. |
 | onKeyDown | function | | Callback when the user presses a key. |
@@ -697,7 +740,7 @@ function menuWithCheckbox() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| children | ReactNode \| function | | |
+| children | ReactNode \| ({ getMenuToggleProps, isOpen, openMenu, closeMenu }) => ReactNode | | |
 | disabled | boolean | | Whether the menu toggle is disabled. |
 | onClick | function | | Callback when the menu toggle is clicked. |
 | onKeyDown | function | | Callback when the user presses a key. |

--- a/packages/react-docs/pages/components/tooltip.mdx
+++ b/packages/react-docs/pages/components/tooltip.mdx
@@ -213,6 +213,13 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| PopperComponent | ElementType | Popper | The component used for the popover. |
+| PopperProps | object | | Props applied to the Popper component. |
+| PopperArrowComponent | ElementType | PopperArrow | The component used for the popover arrow. |
+| PopperArrowProps | object | | Props applied to the PopoverArrow component. |
+| TransitionComponent | ElementType | Grow | The component used for the transition. |
+| TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | true | |
 | children | | | If the children is a function, it will be called with `{ getTooltipTriggerProps }` and the return value will be used as the trigger. |
 | defaultIsOpen | boolean | false | Whether the tooltip is open by default. |
 | isOpen | boolean | | If `true`, the tooltip is shown. |
@@ -226,6 +233,3 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 | closeOnClick | boolean | | If `true`, hide the tooltip when the trigger is clicked. |
 | onOpen | function | | A callback called when the tooltip shows. |
 | onClose| function | | A callback called when the tooltip hides. |
-| TransitionComponent | ElementType | Grow | The component used for the transition. |
-| TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
-| TransitionProps.appear | boolean | true | |

--- a/packages/react/src/menu/Menu.js
+++ b/packages/react/src/menu/Menu.js
@@ -1,10 +1,12 @@
 import { usePrevious } from '@tonic-ui/react-hooks';
 import { ensureString } from 'ensure-type';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useRef, useState } from 'react';
+import { Box } from '../box';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
 import getFocusableElements from '../utils/getFocusableElements';
 import { MenuProvider } from './context';
+import { useMenuStyle } from './styles';
 
 const mapPlacementToDirection = (placement) => {
   const p0 = ensureString(placement).split('-')[0];
@@ -16,23 +18,26 @@ const mapPlacementToDirection = (placement) => {
   return direction;
 };
 
-const Menu = ({
-  anchorEl,
-  autoSelect = false,
-  children,
-  closeOnBlur = true,
-  closeOnSelect = true,
-  defaultActiveIndex = -1,
-  defaultIsOpen = false,
-  isOpen: isOpenProp,
-  onBlur,
-  onClose,
-  onKeyDown,
-  onOpen,
-  placement = 'bottom-start', // One of: 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end'
-  usePortal = true,
-  ...rest
-}) => {
+const Menu = forwardRef((
+  {
+    anchorEl,
+    autoSelect = false,
+    children,
+    closeOnBlur = true,
+    closeOnSelect = true,
+    defaultActiveIndex = -1,
+    defaultIsOpen = false,
+    isOpen: isOpenProp,
+    onBlur,
+    onClose,
+    onKeyDown,
+    onOpen,
+    placement = 'bottom-start', // One of: 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end'
+    usePortal = false, // Pass `true` if you want to render the menu in a portal
+    ...rest
+  },
+  ref,
+) => {
   const [activeIndex, setActiveIndex] = useState(defaultActiveIndex);
   const [isOpen, setIsOpen] = useState(defaultIsOpen);
   const [focusableElements, setFocusableElements] = useState([]);
@@ -169,12 +174,20 @@ const Menu = ({
     usePortal,
   };
 
+  const styleProps = useMenuStyle({});
+
   return (
     <MenuProvider value={context}>
-      {(typeof children === 'function') ? children(context) : children}
+      <Box
+        ref={ref}
+        {...styleProps}
+        {...rest}
+      >
+        {(typeof children === 'function') ? children(context) : children}
+      </Box>
     </MenuProvider>
   );
-};
+});
 
 Menu.displayName = 'Menu';
 

--- a/packages/react/src/menu/Menu.js
+++ b/packages/react/src/menu/Menu.js
@@ -1,7 +1,6 @@
 import { usePrevious } from '@tonic-ui/react-hooks';
 import { ensureString } from 'ensure-type';
 import React, { useEffect, useRef, useState } from 'react';
-import { Box } from '../box';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
 import getFocusableElements from '../utils/getFocusableElements';

--- a/packages/react/src/menu/Menu.js
+++ b/packages/react/src/menu/Menu.js
@@ -31,6 +31,7 @@ const Menu = ({
   onKeyDown,
   onOpen,
   placement = 'bottom-start', // One of: 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end'
+  usePortal = true,
   ...rest
 }) => {
   const [activeIndex, setActiveIndex] = useState(defaultActiveIndex);
@@ -152,6 +153,7 @@ const Menu = ({
     menuRef,
     menuToggleId,
     menuToggleRef,
+    usePortal,
   };
 
   return (

--- a/packages/react/src/menu/MenuList.js
+++ b/packages/react/src/menu/MenuList.js
@@ -42,6 +42,7 @@ const MenuList = forwardRef((
     placement,
     onKeyDown,
     onBlur,
+    usePortal,
   } = { ...menuContext };
 
   const handleKeyDown = event => {
@@ -99,7 +100,7 @@ const MenuList = forwardRef((
       ref={menuRef}
       role="menu"
       tabIndex={-1}
-      usePortal={false}
+      usePortal={usePortal}
       willUseTransition={true}
       zIndex="dropdown"
       _focus={{

--- a/packages/react/src/menu/MenuList.js
+++ b/packages/react/src/menu/MenuList.js
@@ -12,6 +12,8 @@ import useMenu from './useMenu';
 
 const MenuList = forwardRef((
   {
+    PopperComponent = Popper,
+    PopperProps,
     TransitionComponent = Collapse,
     TransitionProps,
     children,
@@ -43,6 +45,22 @@ const MenuList = forwardRef((
     usePortal,
   } = { ...menuContext };
 
+  // Close the menu on blur
+  const handleBlur = event => {
+    const target = event.relatedTarget || document.activeElement;
+    const isClickingOutside =
+      target &&
+      !(menuRef?.current?.contains(target)) &&
+      !(menuToggleRef?.current?.contains(target));
+    const shouldCloseMenu = isOpen && closeOnBlur && isClickingOutside;
+
+    if (shouldCloseMenu) {
+      ensureFunction(closeMenu)();
+    }
+
+    ensureFunction(onBlur)(event);
+  };
+
   const handleKeyDown = event => {
     if (event.key === 'ArrowDown' || event.key === 'Tab') {
       event.preventDefault();
@@ -63,33 +81,20 @@ const MenuList = forwardRef((
     ensureFunction(onKeyDown)(event);
   };
 
-  // Close the menu on blur
-  const handleBlur = event => {
-    const target = event.relatedTarget || document.activeElement;
-    const isClickingOutside =
-      target &&
-      !(menuRef?.current?.contains(target)) &&
-      !(menuToggleRef?.current?.contains(target));
-    const shouldCloseMenu = isOpen && closeOnBlur && isClickingOutside;
-
-    if (shouldCloseMenu) {
-      ensureFunction(closeMenu)();
-    }
-
-    ensureFunction(onBlur)(event);
-  };
-
   const styleProps = useMenuListStyle();
 
+  const eventHandlers = {
+    onBlur: wrapEvent(onBlurProp, handleBlur),
+    onKeyDown: wrapEvent(onKeyDownProp, handleKeyDown),
+  };
+
   return (
-    <Popper
+    <PopperComponent
       anchorEl={menuToggleRef?.current}
       aria-labelledby={menuToggleId}
       id={menuId}
       isOpen={isOpen}
       modifiers={{ offset }}
-      onBlur={wrapEvent(onBlurProp, handleBlur)}
-      onKeyDown={wrapEvent(onKeyDownProp, handleKeyDown)}
       placement={placement}
       ref={menuRef}
       role="menu"
@@ -97,6 +102,8 @@ const MenuList = forwardRef((
       usePortal={usePortal}
       willUseTransition={true}
       {...styleProps}
+      {...eventHandlers}
+      {...PopperProps}
       {...rest}
     >
       {({ placement, transition }) => {
@@ -125,7 +132,7 @@ const MenuList = forwardRef((
           </TransitionComponent>
         );
       }}
-    </Popper>
+    </PopperComponent>
   );
 });
 

--- a/packages/react/src/menu/MenuList.js
+++ b/packages/react/src/menu/MenuList.js
@@ -1,6 +1,5 @@
 import chainedFunction from 'chained-function';
 import {
-  ensureArray,
   ensureFunction,
 } from 'ensure-type';
 import React, { forwardRef, useRef } from 'react';
@@ -27,45 +26,36 @@ const MenuList = forwardRef((
   const combinedRef = useForkRef(nodeRef, ref);
   const menuContext = useMenu(); // context might be an undefined value
   const {
-    activeIndex: index,
+    closeMenu,
+    closeOnBlur,
     isOpen,
-    focusAtIndex,
     focusOnFirstItem,
     focusOnLastItem,
-    closeMenu,
-    focusableItems,
-    menuToggleRef,
+    focusOnNextItem,
+    focusOnPreviousItem,
     menuId,
     menuToggleId,
+    menuToggleRef,
     menuRef,
-    closeOnBlur,
-    placement,
-    onKeyDown,
     onBlur,
+    onKeyDown,
+    placement,
     usePortal,
   } = { ...menuContext };
 
   const handleKeyDown = event => {
-    const count = ensureArray(focusableItems?.current).length;
-    let nextIndex;
-    if (event.key === 'ArrowDown') {
+    if (event.key === 'ArrowDown' || event.key === 'Tab') {
       event.preventDefault();
-      if (count > 0) {
-        nextIndex = (index + 1) % count;
-        ensureFunction(focusAtIndex)(nextIndex);
-      }
+      ensureFunction(focusOnNextItem)();
     } else if (event.key === 'ArrowUp') {
       event.preventDefault();
-      if (count > 0) {
-        nextIndex = (index - 1 + count) % count;
-        ensureFunction(focusAtIndex)(nextIndex);
-      }
+      ensureFunction(focusOnPreviousItem)();
     } else if (event.key === 'Home') {
+      event.preventDefault();
       ensureFunction(focusOnFirstItem)();
     } else if (event.key === 'End') {
-      ensureFunction(focusOnLastItem)();
-    } else if (event.key === 'Tab') {
       event.preventDefault();
+      ensureFunction(focusOnLastItem)();
     } else if (event.key === 'Escape') {
       ensureFunction(closeMenu)();
     }
@@ -106,10 +96,6 @@ const MenuList = forwardRef((
       tabIndex={-1}
       usePortal={usePortal}
       willUseTransition={true}
-      zIndex="dropdown"
-      _focus={{
-        outline: 0,
-      }}
       {...styleProps}
       {...rest}
     >

--- a/packages/react/src/menu/MenuList.js
+++ b/packages/react/src/menu/MenuList.js
@@ -50,12 +50,16 @@ const MenuList = forwardRef((
     let nextIndex;
     if (event.key === 'ArrowDown') {
       event.preventDefault();
-      nextIndex = (index + 1) % count;
-      ensureFunction(focusAtIndex)(nextIndex);
+      if (count > 0) {
+        nextIndex = (index + 1) % count;
+        ensureFunction(focusAtIndex)(nextIndex);
+      }
     } else if (event.key === 'ArrowUp') {
       event.preventDefault();
-      nextIndex = (index - 1 + count) % count;
-      ensureFunction(focusAtIndex)(nextIndex);
+      if (count > 0) {
+        nextIndex = (index - 1 + count) % count;
+        ensureFunction(focusAtIndex)(nextIndex);
+      }
     } else if (event.key === 'Home') {
       ensureFunction(focusOnFirstItem)();
     } else if (event.key === 'End') {

--- a/packages/react/src/menu/styles.js
+++ b/packages/react/src/menu/styles.js
@@ -2,6 +2,13 @@ import { useColorMode } from '../color-mode';
 import { useColorStyle } from '../color-style';
 import { setColorWithOpacity } from '../utils/colors';
 
+const useMenuStyle = () => {
+  return {
+    position: 'relative',
+    display: 'inline-flex',
+  };
+};
+
 const useMenuButtonStyle = () => {
   return {
     display: 'inline-flex',
@@ -124,6 +131,7 @@ const useMenuToggleIconStyle = () => {
 };
 
 export {
+  useMenuStyle,
   useMenuButtonStyle,
   useMenuListStyle,
   useMenuGroupStyle,

--- a/packages/react/src/menu/styles.js
+++ b/packages/react/src/menu/styles.js
@@ -16,11 +16,11 @@ const useMenuListStyle = () => {
   const [colorStyle] = useColorStyle({ colorMode });
   const colorModeStyle = {
     light: {
-      bg: 'white',
+      backgroundColor: 'white',
       boxShadow: colorStyle?.shadow?.medium,
     },
     dark: {
-      bg: 'gray:80',
+      backgroundColor: 'gray:80',
       boxShadow: colorStyle?.shadow?.medium,
     },
   }[colorMode];
@@ -30,6 +30,10 @@ const useMenuListStyle = () => {
     m: '0',
     p: '0',
     py: '2x',
+    zIndex: 'dropdown',
+    _focus: {
+      outline: 'none',
+    },
     ...colorModeStyle,
   };
 };
@@ -50,11 +54,11 @@ const useMenuGroupStyle = () => {
 
 const useMenuItemStyle = () => {
   const [colorMode] = useColorMode();
-  const hoverBackground = {
+  const hoverBackgroundColor = {
     light: 'black:disabled',
     dark: setColorWithOpacity('white', 0.12),
   }[colorMode];
-  const activeBackground = {
+  const activeBackgroundColor = {
     light: 'gray:20',
     dark: setColorWithOpacity('white', 0.08),
   }[colorMode];
@@ -62,11 +66,11 @@ const useMenuItemStyle = () => {
     light: 'black:disabled',
     dark: 'white:disabled',
   }[colorMode];
-  const disabledBackground = {
+  const disabledBackgroundColor = {
     light: 'white',
     dark: 'gray:80',
   }[colorMode];
-  const focusBackground = activeBackground;
+  const focusBackgroundColor = activeBackgroundColor;
 
   return {
     flex: ' 0 0 auto',
@@ -81,17 +85,16 @@ const useMenuItemStyle = () => {
     textAlign: 'left',
     outline: 'none',
     _hover: {
-      bg: hoverBackground,
+      backgroundColor: hoverBackgroundColor,
     },
     _active: {
-      bg: activeBackground,
+      backgroundColor: activeBackgroundColor,
     },
     _focus: {
-      bg: focusBackground,
-      outline: 0,
+      backgroundColor: focusBackgroundColor,
     },
     _disabled: {
-      bg: disabledBackground,
+      backgroundColor: disabledBackgroundColor,
       color: disabledColor,
       cursor: 'not-allowed',
     },
@@ -107,6 +110,7 @@ const useMenuItemDividerStyle = () => {
 const useMenuToggleStyle = () => {
   return {
     cursor: 'pointer',
+    display: 'inline-flex',
   };
 };
 

--- a/packages/react/src/popover/PopoverContent.js
+++ b/packages/react/src/popover/PopoverContent.js
@@ -24,20 +24,18 @@ const mapPlacementToTransformOrigin = placement => ({
 }[placement]);
 
 const PopoverContent = ({
-  onKeyDown,
-  onBlur: onBlurProp,
-  onMouseLeave,
-  onMouseEnter,
-  onFocus,
-  children,
-
-  'aria-label': ariaLabel,
   PopperComponent = Popper,
   PopperProps,
   PopperArrowComponent = PopperArrow,
   PopperArrowProps,
   TransitionComponent = Grow,
   TransitionProps,
+  onKeyDown,
+  onBlur: onBlurProp,
+  onMouseLeave,
+  onMouseEnter,
+  onFocus,
+  children,
   ...rest
 }) => {
   const isHydrated = useHydrated();

--- a/packages/react/src/popper/Popper.js
+++ b/packages/react/src/popper/Popper.js
@@ -88,6 +88,7 @@ const Popper = forwardRef((
           },
         }
       ],
+      strategy: 'absolute',
       ...popperOptions,
     });
 

--- a/packages/react/src/tooltip/Tooltip.js
+++ b/packages/react/src/tooltip/Tooltip.js
@@ -28,6 +28,13 @@ const mapPlacementToTransformOrigin = placement => ({
 
 const Tooltip = forwardRef((
   {
+    PopperComponent = Popper,
+    PopperProps,
+    PopperArrowComponent = PopperArrow,
+    PopperArrowProps,
+    TransitionComponent = Grow,
+    TransitionProps,
+
     showDelay, // deprecated
     hideDelay, // deprecated
     shouldWrapChildren, // removed
@@ -44,12 +51,7 @@ const Tooltip = forwardRef((
     onOpen: onOpenProp,
     onClose: onCloseProp,
     arrowAt,
-    PopperComponent = Popper,
-    PopperProps,
-    PopperArrowComponent = PopperArrow,
-    PopperArrowProps,
-    TransitionComponent = Grow,
-    TransitionProps,
+    usePortal = true,
     ...rest
   },
   ref,
@@ -168,7 +170,7 @@ const Tooltip = forwardRef((
       {isHydrated && (
         <PopperComponent
           aria-hidden={!isOpen}
-          usePortal
+          usePortal={usePortal}
           isOpen={_isOpen}
           data-popper-placement={placement}
           placement={placement}


### PR DESCRIPTION
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-458/components/menu

For most use cases, the `usePortal` prop should default to `false`. Pass `usePortal={true}` if you want to render the menu in a portal.