### PR TITLE
feat: change `TextLabel` from inline to a block-level element

### DIFF
--- a/packages/react-docs/pages/components/textlabel.mdx
+++ b/packages/react-docs/pages/components/textlabel.mdx
@@ -1,6 +1,6 @@
 # TextLabel
 
-The `TextLabel` component is a label that composes the `Text` component.
+`TextLabel` is a block-level element that composes `Text` and represents as a label.
 
 ## Import
 
@@ -14,7 +14,7 @@ import { TextLabel } from '@tonic-ui/react';
 <TextLabel>Label text:</TextLabel>
 ```
 
-The text colors in the dark mode and light mode are `white:secondary` and `black:secondary`, respectively, defined in `theme.colors`.
+> The text colors in the dark mode and light mode are `white:secondary` and `black:secondary`, respectively, defined in `theme.colors`.
 
 ## Props
 

--- a/packages/react/src/text/TextLabel.js
+++ b/packages/react/src/text/TextLabel.js
@@ -2,15 +2,21 @@ import React, { forwardRef } from 'react';
 import Text from './Text';
 import { useTextLabelStyle } from './styles';
 
-const TextLabel = forwardRef((props, ref) => {
-  const styleProps = useTextLabelStyle();
+const TextLabel = forwardRef((
+  {
+    size,
+    ...rest
+  },
+  ref
+) => {
+  const styleProps = useTextLabelStyle({ size });
 
   return (
     <Text
       as="label"
       ref={ref}
       {...styleProps}
-      {...props}
+      {...rest}
     />
   );
 });

--- a/packages/react/src/text/styles.js
+++ b/packages/react/src/text/styles.js
@@ -5,13 +5,15 @@ const useTextStyle = ({ size }) => {
   const { fontSizes, lineHeights } = useTheme();
 
   return {
+    display: 'block',
     fontFamily: 'base',
     fontSize: fontSizes?.[size],
     lineHeight: lineHeights?.[size],
   };
 };
 
-const useTextLabelStyle = () => {
+const useTextLabelStyle = ({ size }) => {
+  const textStyle = useTextStyle({ size });
   const [colorMode] = useColorMode();
   const color = {
     dark: 'white:secondary',
@@ -19,6 +21,7 @@ const useTextLabelStyle = () => {
   }[colorMode];
 
   return {
+    ...textStyle,
     color,
   };
 };


### PR DESCRIPTION
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-501/components/textlabel