### PR TITLE
feat: expose 'backdropProps' to ModalContent passing into ModalContentBackdrop

### DIFF
--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonic-ui/react-docs",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-beta",
   "description": "A documentation site for React Tonic UI component library.",
   "private": true,
   "scripts": {
@@ -34,8 +34,8 @@
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
     "@next/mdx": "^12.0.1",
-    "@tonic-ui/react": "^1.0.0-alpha.0",
-    "@tonic-ui/react-hooks": "^1.0.0-alpha.0",
+    "@tonic-ui/react": "^1.0.0-beta",
+    "@tonic-ui/react-hooks": "^1.0.0-beta",
     "@tonic-ui/theme": "^1.0.0-alpha.0",
     "@trendmicro/babel-config": "^1.0.2",
     "@zeit/next-css": "^1.0.1",

--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -453,6 +453,8 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| ContainerComponent | ElementType | ModalContentContainer | The container component used to wrap the content. |
+| ContainerProps | object | | Props applied to the container component. |
 | TransitionComponent | ElementType | Fade | The component used for the transition. |
 | TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
 | TransitionProps.appear | boolean | true | |

--- a/packages/react-docs/pages/getting-started/versions.mdx.template
+++ b/packages/react-docs/pages/getting-started/versions.mdx.template
@@ -12,7 +12,7 @@ The most recent stable version (✓) is recommended for use in production.
   <TableBody>
     <TableRow>
       <TableCell>
-        __TONIC_UI_V1_RELEASE_VERSION__
+        __TONIC_UI_V1_RELEASE_VERSION__ ✓
       </TableCell>
       <TableCell>
         <Link href="__TONIC_UI_V1_RELEASE_DOCUMENTATION__">Documentation</Link>
@@ -23,7 +23,7 @@ The most recent stable version (✓) is recommended for use in production.
     </TableRow>
     <TableRow>
       <TableCell>
-        __TONIC_UI_V0_RELEASE_VERSION__ ✓
+        __TONIC_UI_V0_RELEASE_VERSION__
       </TableCell>
       <TableCell>
         <Link href="__TONIC_UI_V0_RELEASE_DOCUMENTATION__">Documentation</Link>

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonic-ui/react-hooks",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-beta",
   "description": "A collection of React Hooks for Tonic UI components.",
   "main": "dist/index.js",
   "module": "dist/es/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonic-ui/react",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-beta",
   "description": "React Tonic UI component library.",
   "main": "dist/index.js",
   "module": "dist/es/index.js",
@@ -22,7 +22,7 @@
     "@emotion/react": "11.x",
     "@emotion/styled": "11.x",
     "@popperjs/core": "2.x",
-    "@tonic-ui/react-hooks": "^1.0.0-alpha.0",
+    "@tonic-ui/react-hooks": "^1.0.0-beta",
     "@tonic-ui/styled-system": "^1.0.0-alpha.0",
     "@tonic-ui/theme": "^1.0.0-alpha.0",
     "@trendmicro/tmicon": "^1.21.0",

--- a/packages/react/src/modal/ModalContent.js
+++ b/packages/react/src/modal/ModalContent.js
@@ -113,6 +113,7 @@ const ModalContentFront = forwardRef(({ children, ...rest }, ref) => {
 });
 
 const ModalContent = React.forwardRef(({
+  backdropProps,
   children,
   zIndex = 'modal',
   TransitionComponent = Fade,
@@ -134,6 +135,7 @@ const ModalContent = React.forwardRef(({
       TransitionComponent={TransitionComponent}
       TransitionProps={TransitionProps}
       zIndex={zIndex}
+      {...backdropProps}
     >
       <ModalContentFront ref={ref} {...rest}>
         {children}

--- a/packages/react/src/modal/ModalContent.js
+++ b/packages/react/src/modal/ModalContent.js
@@ -22,7 +22,7 @@ const ModalCloseButton = (props) => {
   );
 };
 
-const ModalContentBackdrop = forwardRef(({
+const ModalContentContainer = forwardRef(({
   TransitionComponent,
   TransitionProps,
   ...rest
@@ -34,7 +34,7 @@ const ModalContentBackdrop = forwardRef(({
     onClose,
   } = { ...modalContext };
   const [, safeToRemove] = usePresence();
-  const backdropStyleProps = {
+  const styleProps = {
     position: 'fixed',
     left: 0,
     right: 0,
@@ -43,6 +43,7 @@ const ModalContentBackdrop = forwardRef(({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
+    zIndex: 'modal',
   };
 
   return (
@@ -61,7 +62,7 @@ const ModalContentBackdrop = forwardRef(({
               (typeof onClose === 'function') && onClose(event);
             }
           }}
-          {...backdropStyleProps}
+          {...styleProps}
           {...transitionStyle}
           {...rest}
         />
@@ -113,11 +114,11 @@ const ModalContentFront = forwardRef(({ children, ...rest }, ref) => {
 });
 
 const ModalContent = React.forwardRef(({
-  backdropProps,
-  children,
-  zIndex = 'modal',
+  ContainerComponent = ModalContentContainer,
+  ContainerProps,
   TransitionComponent = Fade,
   TransitionProps,
+  children,
   ...rest
 }, ref) => {
   const modalContext = useModal(); // context might be an undefined value
@@ -131,16 +132,15 @@ const ModalContent = React.forwardRef(({
   }
 
   return (
-    <ModalContentBackdrop
+    <ContainerComponent
       TransitionComponent={TransitionComponent}
       TransitionProps={TransitionProps}
-      zIndex={zIndex}
-      {...backdropProps}
+      {...ContainerProps}
     >
       <ModalContentFront ref={ref} {...rest}>
         {children}
       </ModalContentFront>
-    </ModalContentBackdrop>
+    </ContainerComponent>
   );
 });
 


### PR DESCRIPTION
## Descriptions
Requirement to have a modal without scrolling inside modal body, when dynamic content that exceeds window's height, the exceeding parts would need scroll to view.
<kbd><img src=https://user-images.githubusercontent.com/1054905/157572573-2d2e7ce8-ab64-4c6c-b7e2-f7b3e34c867e.png></kbd>

## Changes
Expose a prop 'backdropProps' to ModalContent passing needed props into ModalContentBackdrop.

**Usage sample:**
```
...
  <ModalContent maxHeight='none' backdropProps={{overflowY: 'auto'}}>
    ...
    <ModalBody overflowY='visible'>
      ...dynamic content that might exceed viewport height
    </ModalBody>    
    ...
  </ModalContent>
...
```