### PR TITLE
feat: enhance modal component structure and refine outside scrolling behavior

### DIFF
--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -33,7 +33,7 @@ You can also compose your modal components when customization is needed.
 function Example() {
   return (
     <Stack direction="column" spacing="4x">
-      <ModalContent ml={0} width={480}>
+      <ModalContent width={480}>
         <ModalHeader>
           Modal Title
         </ModalHeader>
@@ -52,7 +52,7 @@ function Example() {
           <Button minWidth="20x">Cancel</Button>
         </ModalFooter>
       </ModalContent>
-      <ModalContent ml={0} width={480}>
+      <ModalContent width={480}>
         <ModalBody>
           <Text mb="4x">
             Modal body text goes here.
@@ -65,7 +65,7 @@ function Example() {
           <Button minWidth="20x">Cancel</Button>
         </ModalFooter>
       </ModalContent>
-      <ModalContent ml={0} width={480}>
+      <ModalContent width={480}>
         <ModalBody>
           <Text mb="4x">
             Modal body text goes here.
@@ -73,7 +73,7 @@ function Example() {
           <SkeletonBody />
         </ModalBody>
       </ModalContent>
-      <ModalContent ml={0} width={480}>
+      <ModalContent width={480}>
         <Box px="4x" py="4x">
           You can create a custom modal with any sort of content.
         </Box>

--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -378,7 +378,7 @@ function Example() {
           </TextLabel>
         </Box>
         <CodeBlock>
-          {`const modalStyleProps = ${JSON.stringify(modalStyleProps, null, 2)};\nconst modalContentStyleProps = ${JSON.stringify(modalContentStyleProps, null, 2)};\n\n// example\n<Modal scrollBehavior="${scrollBehavior}" {...modalStyleProps}>\n  <ModalOverlay />\n  <ModalContent {...contentStyleProps}>\n    <ModalHeader />\n    <ModalBody />\n    <ModalFooter />\n  </ModalContent>\n</Modal>`}
+          {`const modalStyleProps = ${JSON.stringify(modalStyleProps, null, 2)};\nconst modalContentStyleProps = ${JSON.stringify(modalContentStyleProps, null, 2)};\n\n// example\n<Modal\n  scrollBehavior="${scrollBehavior}"\n  {...modalStyleProps}\n>\n  <ModalOverlay />\n  <ModalContent {...contentStyleProps}>\n    <ModalHeader />\n    <ModalBody />\n    <ModalFooter />\n  </ModalContent>\n</Modal>`}
         </CodeBlock>
       </FormGroup>
       <Divider my="4x" />
@@ -447,6 +447,7 @@ function Example() {
         </Box>
       </FormGroup>
       <Modal
+        TransitionComponent={null}
         autoFocus={autoFocus}
         ensureFocus={ensureFocus}
         closeOnEsc={closeOnEsc}
@@ -516,7 +517,7 @@ function Example() {
                   <TabPanel>
                     <Box
                       backgroundColor={colorStyle.background.tertiary}
-                      minHeight={500}
+                      minHeight={1000}
                       px="3x"
                       py="2x"
                     >

--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -149,7 +149,7 @@ function Example() {
   const [size, changeSizeBy] = useSelection('auto');
   const [scrollBehavior, changeScrollBehaviorBy] = useSelection('inside');
   const [initialContentHeight, changeInitialContentHeightBy] = useSelection('default');
-  const [topBottomMargins, changeTopBottomMarginsBy] = useSelection('default');
+  const [verticalPadding, changeVerticalPaddingBy] = useSelection('default');
   const [autoFocus, toggleAutoFocus] = useToggle(true);
   const [closeOnEsc, toggleCloseOnEsc] = useToggle(true);
   const [closeOnOutsideClick, toggleCloseOnOutsideClick] = useToggle(true);
@@ -161,26 +161,17 @@ function Example() {
   const [isFooterVisible, toggleIsFooterVisible] = useToggle(true);
   const [isAlertVisible, toggleIsAlertVisible] = useToggle(true);
   const [enableBodyScrollLock, toggleBodyScrollLock] = useToggle(true);
-  const contentStyleProps = {};
+  const modalStyleProps = {};
+  const modalContentStyleProps = {};
 
   if (size !== 'full') {
-    if (scrollBehavior === 'inside') {
-      if (initialContentHeight !== 'default') {
-        contentStyleProps.height = initialContentHeight;
-      }
-      if (topBottomMargins !== 'default') {
-        contentStyleProps.maxHeight = 'calc(100% - 2 * ' + topBottomMargins + ')';
-      }
+    if (verticalPadding !== 'default') {
+      modalStyleProps.py = verticalPadding;
     }
 
-    if (scrollBehavior === 'outside') {
-      if (initialContentHeight !== 'default') {
-        contentStyleProps.minHeight = initialContentHeight;
-      }
-      if (topBottomMargins !== 'default') {
-        contentStyleProps.marginTop = topBottomMargins;
-        contentStyleProps.marginBottom = topBottomMargins;
-      }
+    if (initialContentHeight !== 'default') {
+      const propKey = (scrollBehavior === 'inside') ? 'height' : 'minHeight';
+      modalContentStyleProps[propKey] = initialContentHeight;
     }
   }
 
@@ -323,7 +314,7 @@ function Example() {
       <Divider my="4x" />
       <Box mb="4x">
         <Text fontSize="lg" lineHeight="lg">
-          ModalContent props
+          Modal style props
         </Text>
       </Box>
       <FormGroup>
@@ -356,7 +347,7 @@ function Example() {
       <FormGroup>
         <Box mb="2x">
           <TextLabel>
-            Top and bottom margins
+            Vertical padding
           </TextLabel>
         </Box>
         <ButtonGroup
@@ -371,8 +362,8 @@ function Example() {
             <SelectButton
               disabled={size === 'full'}
               key={value}
-              isSelected={value === topBottomMargins}
-              onClick={changeTopBottomMarginsBy(value)}
+              isSelected={value === verticalPadding}
+              onClick={changeVerticalPaddingBy(value)}
               minWidth="15x"
             >
               {value}
@@ -387,7 +378,7 @@ function Example() {
           </TextLabel>
         </Box>
         <CodeBlock>
-          {`const contentStyleProps = ${JSON.stringify(contentStyleProps, null, 2)};\n\n// example\n<Modal scrollBehavior="${scrollBehavior}">\n  <ModalOverlay />\n  <ModalContent {...contentStyleProps}>\n    <ModalHeader />\n    <ModalBody />\n    <ModalFooter />\n  </ModalContent>\n</Modal>`}
+          {`const modalStyleProps = ${JSON.stringify(modalStyleProps, null, 2)};\nconst modalContentStyleProps = ${JSON.stringify(modalContentStyleProps, null, 2)};\n\n// example\n<Modal scrollBehavior="${scrollBehavior}" {...modalStyleProps}>\n  <ModalOverlay />\n  <ModalContent {...contentStyleProps}>\n    <ModalHeader />\n    <ModalBody />\n    <ModalFooter />\n  </ModalContent>\n</Modal>`}
         </CodeBlock>
       </FormGroup>
       <Divider my="4x" />
@@ -466,6 +457,7 @@ function Example() {
         onClose={() => toggleModal(false)}
         scrollBehavior={scrollBehavior}
         size={size}
+        {...modalStyleProps}
       >
         {enableBodyScrollLock && (
           <Global
@@ -479,7 +471,9 @@ function Example() {
         {isOverlayVisible && (
           <ModalOverlay />
         )}
-        <ModalContent {...contentStyleProps}>
+        <ModalContent
+          {...modalContentStyleProps}
+        >
           {isHeaderVisible && (
             <ModalHeader>
               {size === 'auto' && <Text>Auto-sized Modal</Text>}
@@ -522,7 +516,7 @@ function Example() {
                   <TabPanel>
                     <Box
                       backgroundColor={colorStyle.background.tertiary}
-                      minHeight={1000}
+                      minHeight={500}
                       px="3x"
                       py="2x"
                     >
@@ -642,6 +636,9 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| TransitionComponent | ElementType | Fade | The component used for the transition. |
+| TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | true | |
 | autoFocus | boolean | false | If `true` and `ensureFocus` is `true` and `initialFocusRef` is not set, it will automatically set focus on the first focusable element. |
 | children | ReactNode | | |
 | closeOnEsc | boolean | false | If `true`, close the modal when the `esc` key is pressed. |
@@ -659,18 +656,12 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| TransitionComponent | ElementType | Fade | The component used for the transition. |
-| TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
-| TransitionProps.appear | boolean | true | |
 | children | ReactNode | | |
 
 ### ModalContent
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| TransitionComponent | ElementType | Fade | The component used for the transition. |
-| TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
-| TransitionProps.appear | boolean | true | |
 | children | ReactNode | | |
 
 ### ModalHeader

--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -637,9 +637,6 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| TransitionComponent | ElementType | Fade | The component used for the transition. |
-| TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
-| TransitionProps.appear | boolean | true | |
 | autoFocus | boolean | false | If `true` and `ensureFocus` is `true` and `initialFocusRef` is not set, it will automatically set focus on the first focusable element. |
 | children | ReactNode | | |
 | closeOnEsc | boolean | false | If `true`, close the modal when the `esc` key is pressed. |
@@ -657,12 +654,18 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| TransitionComponent | ElementType | Fade | The component used for the transition. |
+| TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | true | |
 | children | ReactNode | | |
 
 ### ModalContent
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| TransitionComponent | ElementType | Fade | The component used for the transition. |
+| TransitionProps | object | | Props applied to the [Transition](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
+| TransitionProps.appear | boolean | true | |
 | children | ReactNode | | |
 
 ### ModalHeader

--- a/packages/react/src/modal/Modal.js
+++ b/packages/react/src/modal/Modal.js
@@ -3,7 +3,6 @@ import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import FocusLock from 'react-focus-lock/dist/cjs';
 import { Portal } from '../portal';
-import { Fade } from '../transitions';
 import { AnimatePresence } from '../utils/animate-presence';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
@@ -20,10 +19,9 @@ const defaultSize = 'auto';
 
 const Modal = forwardRef((
   {
-    TransitionComponent = Fade,
-    TransitionProps,
     isCloseButtonVisible, // deprecated
     autoFocus = false,
+    children,
     closeOnEsc = false,
     closeOnOutsideClick = false,
     ensureFocus = false,
@@ -135,11 +133,11 @@ const Modal = forwardRef((
               onDeactivation={onFocusLockDeactivation}
             >
               <ModalContainer
-                TransitionComponent={TransitionComponent}
-                TransitionProps={TransitionProps}
                 ref={ref}
                 {...rest}
-              />
+              >
+                {children}
+              </ModalContainer>
             </FocusLock>
           </Portal>
         )}

--- a/packages/react/src/modal/Modal.js
+++ b/packages/react/src/modal/Modal.js
@@ -135,9 +135,9 @@ const Modal = forwardRef((
               onDeactivation={onFocusLockDeactivation}
             >
               <ModalContainer
-                ref={ref}
                 TransitionComponent={TransitionComponent}
                 TransitionProps={TransitionProps}
+                ref={ref}
                 {...rest}
               />
             </FocusLock>

--- a/packages/react/src/modal/Modal.js
+++ b/packages/react/src/modal/Modal.js
@@ -68,6 +68,7 @@ const Modal = forwardRef((
     size,
     containerRef, // internal use only
     contentRef, // internal use only
+    placement: 'center', // internal use only (only 'center' is supported by Modal)
   });
 
   const portalId = `${config.name}:Modal-${defaultId}`;

--- a/packages/react/src/modal/ModalContainer.js
+++ b/packages/react/src/modal/ModalContainer.js
@@ -1,32 +1,19 @@
-import chainedFunction from 'chained-function';
-import React, { forwardRef, useEffect } from 'react';
-import { isValidElementType } from 'react-is';
+import React, { forwardRef } from 'react';
 import { Box } from '../box';
-import { Fade } from '../transitions';
-import { useAnimatePresence } from '../utils/animate-presence';
 import useForkRef from '../utils/useForkRef';
 import {
   useModalContainerStyle,
 } from './styles';
 import useModal from './useModal';
 
-const ModalContainer = forwardRef((
-  {
-    TransitionComponent = Fade,
-    TransitionProps,
-    ...rest
-  },
-  ref,
-) => {
+const ModalContainer = forwardRef((props, ref) => {
   const modalContext = useModal(); // context might be an undefined value
   const {
     closeOnOutsideClick,
-    isOpen,
     onClose,
     containerRef, // internal use only
   } = { ...modalContext };
   const combinedRef = useForkRef(containerRef, ref);
-  const [, safeToRemove] = useAnimatePresence();
   const styleProps = useModalContainerStyle();
   const containerProps = {
     ref: combinedRef,
@@ -37,35 +24,11 @@ const ModalContainer = forwardRef((
       }
     },
     ...styleProps,
-    ...rest,
+    ...props,
   };
 
-  /**
-   * Check whether modal transition is disabled
-   */
-  const isTransitionDisabled = !isValidElementType(TransitionComponent);
-
-  useEffect(() => {
-    const shouldManuallyRemove = isTransitionDisabled && (isOpen === false) && (typeof safeToRemove === 'function');
-    if (shouldManuallyRemove) {
-      safeToRemove();
-    }
-  }, [isTransitionDisabled, isOpen, safeToRemove]);
-
-  if (isTransitionDisabled) {
-    return (
-      <Box {...containerProps} />
-    );
-  }
-
   return (
-    <TransitionComponent
-      appear={true}
-      {...TransitionProps}
-      in={isOpen}
-      onExited={chainedFunction(safeToRemove, TransitionProps?.onExited)}
-      {...containerProps}
-    />
+    <Box {...containerProps} />
   );
 });
 

--- a/packages/react/src/modal/ModalContainer.js
+++ b/packages/react/src/modal/ModalContainer.js
@@ -37,13 +37,14 @@ const ModalContainer = forwardRef((
         return;
       }
 
-      // When the scroll behavior is set to `inside`, we have to detect whether the content overflows the container.
+      // For inside scrolling, detect whether the content overflows the container.
       // * If it does overflow, set `alignItems` to `flex-start` to make the container scrollable from the top.
       // * If it doesn't overflow, remove the `alignItems` CSS property to vertically align the container to its original position (e.g. `center`).
       if (scrollBehavior === 'inside') {
-        const containerHeight = el.offsetHeight;
-        const contentHeight = contentRef?.current?.clientHeight;
-        if (contentHeight > containerHeight) {
+        const contentOffsetHeight = contentRef?.current?.offsetHeight;
+        const containerOffsetHeight = el.offsetHeight;
+        const isOverflowing = (contentOffsetHeight > containerOffsetHeight);
+        if (isOverflowing) {
           el.style.alignItems = 'flex-start';
         } else {
           el.style.alignItems = '';
@@ -51,13 +52,16 @@ const ModalContainer = forwardRef((
         return;
       }
 
-      // When the scroll behavior is set to `outside`, we have to detect whether the container overflows the viewport.
+      // For outside scrolling, detect whether the content overflows the container or the container overflows the viewport.
       // * If it does overflow, set `alignItems` to `flex-start` to make the container scrollable from the top.
       // * If it doesn't overflow, remove the `alignItems` CSS property to vertically align the container to its original position (e.g. `center`).
       if (scrollBehavior === 'outside') {
-        const viewportHeight = window?.visualViewport?.height;
+        const contentOffsetHeight = contentRef?.current?.offsetHeight;
+        const containerOffsetHeight = el.offsetHeight;
         const containerScrollHeight = el.scrollHeight;
-        if (containerScrollHeight > viewportHeight) {
+        const viewportHeight = window?.visualViewport?.height;
+        const isOverflowing = (contentOffsetHeight > containerOffsetHeight) || (containerScrollHeight > viewportHeight);
+        if (isOverflowing) {
           el.style.alignItems = 'flex-start';
         } else {
           el.style.alignItems = '';

--- a/packages/react/src/modal/ModalContent.js
+++ b/packages/react/src/modal/ModalContent.js
@@ -1,20 +1,18 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
-import { Fade } from '../transitions';
 import useForkRef from '../utils/useForkRef';
 import ModalCloseButton from './ModalCloseButton';
-import ModalContainer from './ModalContainer';
 import {
   useModalContentStyle,
 } from './styles';
 import useModal from './useModal';
 
-const ModalContentBase = forwardRef((
+const ModalContent = forwardRef((
   {
     children,
     ...rest
   },
-  ref
+  ref,
 ) => {
   const modalContext = useModal(); // context might be an undefined value
   const {
@@ -50,32 +48,6 @@ const ModalContentBase = forwardRef((
         <ModalCloseButton onClick={onClose} />
       )}
     </Box>
-  );
-});
-
-const ModalContent = React.forwardRef((
-  {
-    TransitionComponent = Fade,
-    TransitionProps,
-    ...rest
-  },
-  ref,
-) => {
-  const modalContext = useModal(); // context might be an undefined value
-
-  if (!modalContext) {
-    return (
-      <ModalContentBase ref={ref} {...rest} />
-    );
-  }
-
-  return (
-    <ModalContainer
-      TransitionComponent={TransitionComponent}
-      TransitionProps={TransitionProps}
-    >
-      <ModalContentBase ref={ref} {...rest} />
-    </ModalContainer>
   );
 });
 

--- a/packages/react/src/modal/ModalContent.js
+++ b/packages/react/src/modal/ModalContent.js
@@ -28,9 +28,10 @@ const ModalContent = forwardRef((
     scrollBehavior,
     size,
     contentRef, // internal use only
+    placement, // internal use only
   } = { ...modalContext };
   const combinedRef = useForkRef(contentRef, ref);
-  const styleProps = useModalContentStyle({ scrollBehavior, size });
+  const styleProps = useModalContentStyle({ placement, scrollBehavior, size });
   const contentProps = {
     ref: combinedRef,
     role: 'dialog',

--- a/packages/react/src/modal/ModalOverlay.js
+++ b/packages/react/src/modal/ModalOverlay.js
@@ -27,9 +27,16 @@ const ModalOverlay = forwardRef((props, ref) => {
       }
 
       const computedContainerStyle = (containerRef?.current) && getComputedStyle(containerRef?.current);
+      const paddingX = ensurePositiveNumber(parseFloat(computedContainerStyle?.paddingLeft) + parseFloat(computedContainerStyle?.paddingRight));
       const paddingY = ensurePositiveNumber(parseFloat(computedContainerStyle?.paddingTop) + parseFloat(computedContainerStyle?.paddingBottom));
+      const computedScrollWidth = contentRef?.current?.offsetWidth + paddingX;
       const computedScrollHeight = contentRef?.current?.offsetHeight + paddingY;
 
+      if (computedScrollWidth > containerRef?.current?.offsetWidth) {
+        el.style.width = `${computedScrollWidth}px`;
+      } else {
+        el.style.width = '';
+      }
       if (computedScrollHeight > containerRef?.current?.offsetHeight) {
         el.style.height = `${computedScrollHeight}px`;
       } else {

--- a/packages/react/src/modal/styles.js
+++ b/packages/react/src/modal/styles.js
@@ -66,8 +66,6 @@ const useModalContainerStyle = () => {
     top: 0,
     bottom: 0,
     display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
     overflow: 'auto',
     zIndex: 'modal',
   };

--- a/packages/react/src/modal/styles.js
+++ b/packages/react/src/modal/styles.js
@@ -78,8 +78,6 @@ const useModalContentStyle = ({
   const [colorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
   const baseStyle = {
-    // https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container
-    margin: 'auto', // Use the `margin: auto` technique to center the content
     display: 'flex',
     flexDirection: 'column',
     overflow: 'clip', // Set overflow to clip to forbid all scrolling for modal content
@@ -103,6 +101,10 @@ const useModalContentStyle = ({
       boxShadow: colorStyle?.shadow?.thick,
     },
   }[colorMode];
+  const placementStyle = {
+    // https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container
+    margin: 'auto', // Use the `margin: auto` technique to center the content
+  };
   const sizeStyle = {
     xs: {
       width: 352,
@@ -157,6 +159,7 @@ const useModalContentStyle = ({
   return {
     ...baseStyle,
     ...colorModeStyle,
+    ...placementStyle,
     ...sizeStyle,
   };
 };

--- a/packages/react/src/modal/styles.js
+++ b/packages/react/src/modal/styles.js
@@ -80,7 +80,8 @@ const useModalContentStyle = ({
   const [colorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
   const baseStyle = {
-    mx: 'auto',
+    // https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container
+    margin: 'auto', // Use the `margin: auto` technique to center the content
     display: 'flex',
     flexDirection: 'column',
     overflow: 'clip', // Set overflow to clip to forbid all scrolling for modal content
@@ -162,18 +163,6 @@ const useModalContentStyle = ({
   };
 };
 
-const useModalHeaderStyle = () => {
-  return {
-    pt: '4x',
-    pb: '6x',
-    pl: '6x',
-    pr: '12x',
-    position: 'relative',
-    fontSize: 'xl',
-    lineHeight: 'xl',
-  };
-};
-
 const useModalBodyStyle = ({
   scrollBehavior, // No default value if not specified
 }) => {
@@ -216,11 +205,41 @@ const useModalFooterStyle = () => {
   };
 };
 
+const useModalHeaderStyle = () => {
+  return {
+    pt: '4x',
+    pb: '6x',
+    pl: '6x',
+    pr: '12x',
+    position: 'relative',
+    fontSize: 'xl',
+    lineHeight: 'xl',
+  };
+};
+
+const useModalOverlayStyle = () => {
+  const [colorMode] = useColorMode();
+  const backgroundColor = {
+    dark: 'rgba(0, 0, 0, .7)',
+    light: 'rgba(0, 0, 0, .7)',
+  }[colorMode];
+
+  return {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: '100%',
+    height: '100%',
+    backgroundColor,
+  };
+};
+
 export {
   useModalCloseButtonStyle,
   useModalContainerStyle,
   useModalContentStyle,
-  useModalHeaderStyle,
   useModalBodyStyle,
   useModalFooterStyle,
+  useModalHeaderStyle,
+  useModalOverlayStyle,
 };

--- a/packages/react/src/modal/styles.js
+++ b/packages/react/src/modal/styles.js
@@ -72,6 +72,7 @@ const useModalContainerStyle = () => {
 };
 
 const useModalContentStyle = ({
+  placement, // No default value if not specified
   scrollBehavior, // No default value if not specified
   size = defaultSize,
 }) => {
@@ -102,9 +103,11 @@ const useModalContentStyle = ({
     },
   }[colorMode];
   const placementStyle = {
-    // https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container
-    margin: 'auto', // Use the `margin: auto` technique to center the content
-  };
+    'center': {
+      // https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container
+      margin: 'auto', // Use the `margin: auto` technique to center the content
+    },
+  }[placement];
   const sizeStyle = {
     xs: {
       width: 352,

--- a/packages/react/src/utils/animate-presence/useAnimatePresence.js
+++ b/packages/react/src/utils/animate-presence/useAnimatePresence.js
@@ -11,16 +11,16 @@ const useAnimatePresence = () => {
   }
 
   const context = useContext(AnimatePresenceContext);
-  if (context === undefined) {
-    throw new Error('The `useAnimatePresence` hook must be called from a descendent of the `AnimatePresence`.');
-  }
-
-  const { in: inProp, onExitComplete, register } = context;
+  const { in: inProp, onExitComplete, register } = { ...context };
   const safeToRemove = () => ensureFunction(onExitComplete)(id);
 
   useEffect(() => {
     return ensureFunction(register)(id);
   }, [id, register]);
+
+  if (context === undefined) {
+    return [null, null];
+  }
 
   return (!inProp && onExitComplete)
     ? [false, safeToRemove]


### PR DESCRIPTION
On macOS, the vertical scroll bar might keep disappearing if the `Show scroll bars` setting is not set to `Always`. For modal's outside scrolling behavior, we have to detect whether the content overflows the container when the scroll bar is not visible.

https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-527/components/modal