### PR TITLE
fix: Make the overflow part of modal top accessible(scroll to top)

### DIFF
--- a/packages/react/src/Modal/styles.js
+++ b/packages/react/src/Modal/styles.js
@@ -65,7 +65,7 @@ const useModalContentStyle = ({
   const [colorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
   const baseStyle = {
-    mx: 'auto',
+    m: 'auto',
     display: 'flex',
     flexDirection: 'column',
     overflow: 'clip', // Set overflow to clip to forbid all scrolling for modal content


### PR DESCRIPTION
### Descriptions
When modal with 1. `scrollBehavior='outside'`,  2. content exceeding viewport height
The modal top would become inaccessible with scrolling

For macos with setting not showing scroll bar when overflow, the ResizeObserver on modalbackdrop would not be triggered and update modal position vertically.

### Changes
Change to set m='auto' (instead of only mx='auto') to the modal baseStyle

### Reference
- https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container