### PR TITLE
fix: fix a performance issue in `Popper` that would cause infinite loop with `setState`

### DIFF
--- a/packages/docs/.eslintrc.js
+++ b/packages/docs/.eslintrc.js
@@ -11,11 +11,8 @@ module.exports = {
   },
   plugins: [
     '@babel',
-    'react-hooks',
   ],
   rules: {
     'react/prop-types': 0,
-    'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
-    'react-hooks/exhaustive-deps': 'error', // Checks effect dependencies
   },
 };

--- a/packages/react/src/Popper/Popper.js
+++ b/packages/react/src/Popper/Popper.js
@@ -83,17 +83,21 @@ const Popper = forwardRef((
     const popper = createPopper(getAnchorEl(anchorEl), popperNode, {
       placement: placement,
       modifiers: [
-        {
+        { // https://popper.js.org/docs/v2/modifiers/offset/
           name: 'offset',
           options: {
             offset: modifiers.offset
           },
         },
-        {
+        { // https://popper.js.org/docs/v2/modifiers/arrow/
           name: 'arrow',
           options: {
             padding: 12, // 12px from the edges of the popper
           },
+        },
+        { // https://popper.js.org/docs/v2/modifiers/flip/
+          name: 'flip',
+          enabled: false, // No flip
         },
         {
           name: 'handlePopperUpdate',


### PR DESCRIPTION
This is a hot fix for v0