### PR TITLE
feat(styled-system): add scroll style props

### DIFF
--- a/packages/styled-system/src/config/scroll.js
+++ b/packages/styled-system/src/config/scroll.js
@@ -1,0 +1,77 @@
+import system from '../core/system';
+import { positiveOrNegative as positiveOrNegativeTransform } from '../utils/transforms';
+
+const group = 'scroll';
+const config = {
+  scrollBehavior: true,
+  scrollMargin: {
+    property: 'scrollMargin',
+    scale: 'space',
+    transform: positiveOrNegativeTransform, // multi-value
+  },
+  scrollMarginTop: {
+    property: 'scrollMarginTop',
+    scale: 'space',
+    transform: positiveOrNegativeTransform,
+  },
+  scrollMarginRight: {
+    property: 'scrollMarginRight',
+    scale: 'space',
+    transform: positiveOrNegativeTransform,
+  },
+  scrollMarginBottom: {
+    property: 'scrollMarginBottom',
+    scale: 'space',
+    transform: positiveOrNegativeTransform,
+  },
+  scrollMarginLeft: {
+    property: 'scrollMarginLeft',
+    scale: 'space',
+    transform: positiveOrNegativeTransform,
+  },
+  scrollPadding: {
+    property: 'scrollPadding',
+    scale: 'space',
+  },
+  scrollPaddingTop: {
+    property: 'scrollPaddingTop',
+    scale: 'space',
+  },
+  scrollPaddingRight: {
+    property: 'scrollPaddingRight',
+    scale: 'space',
+  },
+  scrollPaddingBottom: {
+    property: 'scrollPaddingBottom',
+    scale: 'space',
+  },
+  scrollPaddingLeft: {
+    property: 'scrollPaddingLeft',
+    scale: 'space',
+  },
+  scrollSnapAlign: true,
+  scrollSnapType: true,
+};
+
+config.scrollMarginX = {
+  properties: ['scrollMarginLeft', 'scrollMarginRight'],
+  scale: 'space',
+  transform: positiveOrNegativeTransform,
+};
+config.scrollMarginY = {
+  properties: ['scrollMarginTop', 'scrollMarginBottom'],
+  scale: 'space',
+  transform: positiveOrNegativeTransform,
+};
+config.scrollPaddingX = {
+  properties: ['scrollPaddingLeft', 'scrollPaddingRight'],
+  scale: 'space',
+};
+config.scrollPaddingY = {
+  properties: ['scrollPaddingTop', 'scrollPaddingBottom'],
+  scale: 'space',
+};
+
+const scroll = system(config, { group });
+
+export default scroll;

--- a/packages/styled-system/src/config/scroll.test.js
+++ b/packages/styled-system/src/config/scroll.test.js
@@ -1,0 +1,85 @@
+import scroll from './scroll';
+
+test('returns style objects', () => {
+  const styles = scroll({
+    scrollBehavior: 'smooth',
+    scrollMargin: '0 0',
+    scrollMarginTop: 0,
+    scrollMarginRight: 0,
+    scrollMarginBottom: 0,
+    scrollMarginLeft: 0,
+    scrollPadding: '12px 16px',
+    scrollPaddingTop: '12px',
+    scrollPaddingRight: '16px',
+    scrollPaddingBottom: '12px',
+    scrollPaddingLeft: '16px',
+    scrollSnapAlign: 'start',
+    scrollSnapType: 'x mandatory',
+  });
+  expect(styles).toEqual({
+    scrollBehavior: 'smooth',
+    scrollMargin: '0 0',
+    scrollMarginTop: 0,
+    scrollMarginRight: 0,
+    scrollMarginBottom: 0,
+    scrollMarginLeft: 0,
+    scrollPadding: '12px 16px',
+    scrollPaddingTop: '12px',
+    scrollPaddingRight: '16px',
+    scrollPaddingBottom: '12px',
+    scrollPaddingLeft: '16px',
+    scrollSnapAlign: 'start',
+    scrollSnapType: 'x mandatory',
+  });
+});
+
+test('returns aliased values', () => {
+  const styles = scroll({
+    scrollMarginX: 12,
+    scrollMarginY: 8,
+    scrollPaddingX: 12,
+    scrollPaddingY: 8,
+  });
+  expect(styles).toEqual({
+    scrollMarginTop: 8,
+    scrollMarginRight: 12,
+    scrollMarginBottom: 8,
+    scrollMarginLeft: 12,
+    scrollPaddingTop: 8,
+    scrollPaddingRight: 12,
+    scrollPaddingBottom: 8,
+    scrollPaddingLeft: 12,
+  });
+});
+
+test('scrollMarginX prop overrides scrollMarginRight prop', () => {
+  const styles = scroll({
+    scrollMarginRight: 4,
+    scrollMarginX: 8,
+  });
+  expect(styles).toEqual({ scrollMarginLeft: 8, scrollMarginRight: 8 });
+});
+
+test('scrollMarginY prop overrides scrollMarginTop prop', () => {
+  const styles = scroll({
+    scrollMarginTop: 4,
+    scrollMarginY: 8,
+  });
+  expect(styles).toEqual({ scrollMarginTop: 8, scrollMarginBottom: 8 });
+});
+
+test('scrollPaddingX prop overrides scrollPaddingRight prop', () => {
+  const styles = scroll({
+    scrollPaddingRight: 4,
+    scrollPaddingX: 8,
+  });
+  expect(styles).toEqual({ scrollPaddingLeft: 8, scrollPaddingRight: 8 });
+});
+
+test('scrollPaddingY prop overrides scrollPaddingTop prop', () => {
+  const styles = scroll({
+    scrollPaddingTop: 4,
+    scrollPaddingY: 8,
+  });
+  expect(styles).toEqual({ scrollPaddingTop: 8, scrollPaddingBottom: 8 });
+});

--- a/packages/styled-system/src/system.js
+++ b/packages/styled-system/src/system.js
@@ -16,6 +16,7 @@ import margin from './config/margin';
 import outline from './config/outline';
 import padding from './config/padding';
 import position from './config/position';
+import scroll from './config/scroll';
 import shape from './config/shape';
 import text from './config/text';
 import transform from './config/transform';
@@ -40,6 +41,7 @@ const system = compose(
   outline,
   padding,
   position,
+  scroll,
   shape,
   text,
   transform,


### PR DESCRIPTION
### Style props
* [scrollBehavior](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior)
* [scrollMargin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin)
* [scrollMarginTop](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top)
* [scrollMarginRight](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-right)
* [scrollMarginBottom](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-bottom)
* [scrollMarginLeft](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-left)
* [scrollPadding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding)
* [scrollPaddingTop](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-top)
* [scrollPaddingRight](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-right)
* [scrollPaddingBottom](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-bottom)
* [scrollPaddingLeft](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-left)
* [scrollSnapAlign](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-align)
* [scrollSnapType](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type)

### Alias props
* scrollMarginX
* scrollMarginY
* scrollPaddingX
* scrollPaddingY