### PR TITLE
feat: add `useMergeRefs` Hook

### DIFF
--- a/packages/react-docs/config/sidebar-routes.js
+++ b/packages/react-docs/config/sidebar-routes.js
@@ -309,6 +309,7 @@ const routes = [
       { title: 'useIsomorphicEffect', path: 'hooks/useIsomorphicEffect' },
       { title: 'useLatestRef', path: 'hooks/useLatestRef' },
       { title: 'useMediaQuery', path: 'hooks/useMediaQuery' },
+      { title: 'useMergeRefs', path: 'hooks/useMergeRefs' },
       { title: 'useOnce', path: 'hooks/useOnce' },
       { title: 'useOnceWhen', path: 'hooks/useOnceWhen' },
       { title: 'useOutsideClick', path: 'hooks/useOutsideClick' },

--- a/packages/react-docs/pages/components/drawer.mdx
+++ b/packages/react-docs/pages/components/drawer.mdx
@@ -422,8 +422,8 @@ render(<Example />);
 | closeOnEsc | boolean | false | If `true`, close the drawer when the `esc` key is pressed. |
 | closeOnOutsideClick | boolean | false | If `true`, close the drawer when click outside of the drawer. Note that this value will not have any effect when `backdrop` is set to `true`. |
 | ensureFocus | boolean | false | If `true`, it will always bring the focus back to the `Drawer` descendants, which does not allow the focus to escape while open. |
-| finalFocusRef | React.ref | | The `ref` of element to receive focus when the drawer closes. |
-| initialFocusRef | React.ref | | The `ref` of the element to receive focus when the drawer opens. |
+| finalFocusRef | RefObject | | The `ref` of element to receive focus when the drawer closes. |
+| initialFocusRef | RefObject | | The `ref` of the element to receive focus when the drawer opens. |
 | isClosable | boolean | false | If `true`, a close button will appear on the right side. |
 | isOpen | boolean | false | If `true`, the drawer is shown. |
 | onClose | function | | Callback fired when the drawer closes. |

--- a/packages/react-docs/pages/components/inputcontrol.mdx
+++ b/packages/react-docs/pages/components/inputcontrol.mdx
@@ -230,7 +230,7 @@ function Example() {
 | endAdornment | ReactNode | | End `InputAdornment` for this component. |
 | inputComponent | ElementType | InputBase | The input component to render. |
 | inputProps | object | | Props applied to the `input` element. |
-| inputRef | ReactRef | | A ref object to access the input element. |
+| inputRef | RefObject | | A ref object to access the input element. |
 | size | string | 'md' | The visual size of the `input` element. One of: 'sm', 'md', 'lg' |
 | variant | string | 'outline' | The variant of the input style to use. One of: 'outline', 'filled', 'unstyled' |
 | startAdornment | ReactNode | | Start `InputAdornment` for this component. |

--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -642,8 +642,8 @@ function Example() {
 | closeOnEsc | boolean | false | If `true`, close the modal when the `esc` key is pressed. |
 | closeOnOutsideClick | boolean | false | If `true`, close the modal when click outside of the modal. |
 | ensureFocus | boolean | false | If `true`, it will always bring the focus back to the `Modal` descendants, which does not allow the focus to escape while open. |
-| finalFocusRef | React.ref | | The `ref` of element to receive focus when the modal closes. |
-| initialFocusRef | React.ref | | The `ref` of the element to receive focus when the modal opens. |
+| finalFocusRef | RefObject | | The `ref` of element to receive focus when the modal closes. |
+| initialFocusRef | RefObject | | The `ref` of the element to receive focus when the modal opens. |
 | isClosable | boolean | false | If `true`, a close button will appear on the right side. |
 | isOpen | boolean | false | If `true`, the modal is shown. |
 | onClose | function | | Callback fired when the modal closes. |

--- a/packages/react-docs/pages/components/popover.mdx
+++ b/packages/react-docs/pages/components/popover.mdx
@@ -390,7 +390,7 @@ Use the `placement` prop to control the placement of the popover.
 | followCursor | boolean | | If `true`, the popover will follow the cursor. |
 | hideArrow | boolean | | If `true`, the arrow will not be displayed. |
 | id | string | | The id of the popover. |
-| initialFocusRef | React.Ref | | The reference of the element that will be focused when the popover opens. |
+| initialFocusRef | RefObject | | The reference of the element that will be focused when the popover opens. |
 | isOpen | boolean | | If `true`, the popover will be open. |
 | leaveDelay | number | 0 | The number of milliseconds to wait before hiding the popover if `trigger` is hover. |
 | nextToCursor | boolean | | If `true`, the popover will be positioned next to the cursor. |

--- a/packages/react-docs/pages/hooks/useMergeRefs.mdx
+++ b/packages/react-docs/pages/hooks/useMergeRefs.mdx
@@ -1,0 +1,53 @@
+# useMergeRefs
+
+A custom Hook that merges React refs into a single memoized function.
+
+```js
+// import
+import { useMergeRefs } from '@tonic-ui/react-hooks';
+
+// usage
+const refs = useMergeRefs(ref1, ref2);
+```
+
+### Parameters
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| ...refs | RefObject | | The refs to merge. |
+
+### Returns
+
+Returns a single function that can be used to set multiple refs.
+
+## Example
+
+```jsx noInline
+const Component = React.forwardRef(function Component(props, ref) {
+  const internalRef = React.useRef();
+  const refs = useMergeRefs(internalRef, ref);
+
+  React.useEffect(() => {
+    console.log('ref.current:', ref.current);
+    console.log('internalRef.current:', internalRef.current);
+  }, []);
+
+  return (
+    <Box ref={refs} {...props}>
+      A component with multiple refs
+    </Box>
+  );
+});
+
+render(() => {
+  const externalRef = React.useRef();
+
+  React.useEffect(() => {
+    console.log('externalRef.current:', externalRef.current);
+  }, []);
+
+  return (
+    <Component ref={externalRef} />
+  );
+});
+```

--- a/packages/react-hooks/src/index.js
+++ b/packages/react-hooks/src/index.js
@@ -9,6 +9,7 @@ export useIsomorphicEffect from './useIsomorphicEffect';
 export useLatest from './deprecated/useLatest'; // deprected: replaced by useLatestRef
 export useLatestRef from './useLatestRef';
 export useMediaQuery from './useMediaQuery';
+export useMergeRefs from './useMergeRefs';
 export useOnce from './useOnce';
 export useOnceWhen from './useOnceWhen';
 export useOutsideClick from './useOutsideClick';

--- a/packages/react-hooks/src/useMergeRefs.js
+++ b/packages/react-hooks/src/useMergeRefs.js
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+
+/**
+ * A custom Hook that merges React refs into a single memoized function.
+ *
+ * @param {...React.RefObject} refs
+ */
+const useForkRef = (...refs) => {
+  return useMemo(() => {
+    if (refs.every((ref) => (ref === null || ref === undefined))) {
+      return null;
+    }
+    return (node) => {
+      refs.forEach((ref) => {
+        if (!ref) {
+          return;
+        }
+
+        if (typeof ref === 'function') {
+          ref(node);
+          return;
+        }
+
+        try {
+          ref.current = node;
+        } catch (error) {
+          throw new Error(`Cannot assign value '${node}' to ref '${ref}'`);
+        }
+      });
+    };
+  }, refs); // eslint-disable-line react-hooks/exhaustive-deps
+};
+
+export default useForkRef;

--- a/packages/react-hooks/src/useMergeRefs.test.js
+++ b/packages/react-hooks/src/useMergeRefs.test.js
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+import React, { forwardRef, useRef } from 'react';
+import useMergeRefs from './useMergeRefs';
+
+describe('useMergeRefs', () => {
+  const TestComponent = forwardRef((props, ref) => {
+    const internalRef = useRef();
+    const mergedRefs = useMergeRefs(internalRef, ref);
+
+    return (
+      <div
+        ref={mergedRefs}
+        {...props}
+      >
+        Test Component
+      </div>
+    );
+  });
+
+  it('should be defined', () => {
+    expect(useMergeRefs).toBeDefined();
+  });
+
+  it('should merge refs', () => {
+    const ref = { current: undefined };
+    render(
+      <TestComponent ref={ref} />
+    );
+
+    expect(ref.current.innerHTML).toBe('Test Component');
+  });
+});

--- a/packages/react-hooks/test/index.js
+++ b/packages/react-hooks/test/index.js
@@ -14,6 +14,7 @@ test('should match expected exports', () => {
     'useLatest', // deprecated: replaced by useLatestRef
     'useLatestRef',
     'useMediaQuery',
+    'useMergeRefs',
     'useOnce',
     'useOnceWhen',
     'useOutsideClick',


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-608/hooks/useMergeRefs

# useMergeRefs

A custom Hook that merges React refs into a single memoized function.

```js
// import
import { useMergeRefs } from '@tonic-ui/react-hooks';

// usage
const refs = useMergeRefs(ref1, ref2);
```

### Parameters

| Name | Type | Default | Description |
| :--- | :--- | :------ | :---------- |
| ...refs | RefObject | | The refs to merge. |

### Returns

Returns a single function that can be used to set multiple refs.

## Example

```jsx noInline
const Component = React.forwardRef(function Component(props, ref) {
  const internalRef = React.useRef();
  const refs = useMergeRefs(internalRef, ref);

  React.useEffect(() => {
    console.log('ref.current:', ref.current);
    console.log('internalRef.current:', internalRef.current);
  }, []);

  return (
    <Box ref={refs} {...props}>
      A component with multiple refs
    </Box>
  );
});

render(() => {
  const externalRef = React.useRef();

  React.useEffect(() => {
    console.log('externalRef.current:', externalRef.current);
  }, []);

  return (
    <Component ref={externalRef} />
  );
});
```