### PR TITLE
docs: adjust Toast sample code for smooth animation

### DIFF
--- a/packages/react-docs/pages/components/toast.mdx
+++ b/packages/react-docs/pages/components/toast.mdx
@@ -189,9 +189,11 @@ function Example() {
       }[placement];
 
       return (
-        <ToastLayout {...styleProps}>
-          <ToastNotification onClose={onClose} />
-        </ToastLayout>
+        <Box {...styleProps}>
+          <ToastLayout>
+            <ToastNotification onClose={onClose} />
+          </ToastLayout>
+        </Box>
       );
     }, {
       placement: 'bottom-right',
@@ -352,9 +354,11 @@ function Example() {
       }[placement];
 
       return (
-        <ToastLayout {...styleProps}>
-          <ToastNotification onClose={onClose} />
-        </ToastLayout>
+        <Box {...styleProps}>
+          <ToastLayout>
+            <ToastNotification onClose={onClose} />
+          </ToastLayout>
+        </Box>
       );
     }, {
       placement: 'bottom-right',
@@ -468,9 +472,11 @@ function Example() {
       }[placement];
 
       return (
-        <ToastLayout {...styleProps}>
-          <ToastNotification onClose={onClose} />
-        </ToastLayout>
+        <Box {...styleProps}>
+          <ToastLayout>
+            <ToastNotification onClose={onClose} />
+          </ToastLayout>
+        </Box>
       );
     }, {
       placement: 'bottom-right',
@@ -491,9 +497,11 @@ function Example() {
           <Button variant="secondary" onClick={handleClickBy(ToastNotification)}>
             Show
           </Button>
-          <ToastLayout mt="4x">
-            <ToastNotification />
-          </ToastLayout>
+          <Box mt="4x">
+            <ToastLayout>
+              <ToastNotification />
+            </ToastLayout>
+          </Box>
         </Box>
       ))}
     </Stack>

--- a/packages/react-docs/pages/components/toast.mdx
+++ b/packages/react-docs/pages/components/toast.mdx
@@ -497,11 +497,9 @@ function Example() {
           <Button variant="secondary" onClick={handleClickBy(ToastNotification)}>
             Show
           </Button>
-          <Box mt="4x">
-            <ToastLayout>
-              <ToastNotification />
-            </ToastLayout>
-          </Box>
+          <ToastLayout mt="4x">
+            <ToastNotification />
+          </ToastLayout>
         </Box>
       ))}
     </Stack>


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-619/components/toast

### Issue
在 `<ToastLayout>` 設定`margin-bottom="48px"`動畫會頓
https://user-images.githubusercontent.com/24446505/190077406-d4cbe37f-0bf2-4f5b-acfd-0c87f3bf0163.mov

### Fix
外面再包一層`<Box>`且改用 `padding-bottom="48px"`來調整`Toast`的位置，這樣子動畫效果就不會頓了
https://user-images.githubusercontent.com/24446505/190077993-c9187f1e-10aa-406d-95b1-02759b8667ca.mov


![Screenshot2022_09_14_113942](https://user-images.githubusercontent.com/24446505/190077780-9aafceda-8442-4429-bc6d-42b25988bf16.jpg)

原本的sample code:
![Screenshot2022_09_14_114013](https://user-images.githubusercontent.com/24446505/190077802-3b5369fc-faa8-4a1d-99d9-da72677f4ab5.jpg)


