### PR TITLE
feat: add support for nested portals and stacking

### DIFF
--- a/packages/react-docs/config/sidebar-routes.js
+++ b/packages/react-docs/config/sidebar-routes.js
@@ -289,6 +289,7 @@ const routes = [
 
       { title: 'UTILITIES', heading: true },
       { title: 'CSSBaseline', path: 'components/cssbaseline' },
+      { title: 'Portal', path: 'components/portal' },
       { title: 'Scrollbar', path: 'components/scrollbar' },
       { title: 'VisuallyHidden', path: 'components/visually-hidden' },
     ],

--- a/packages/react-docs/pages/components/portal.mdx
+++ b/packages/react-docs/pages/components/portal.mdx
@@ -1,0 +1,100 @@
+# Portal
+
+A declarative component that allows you to render children into a DOM node that exists outside the DOM hierarchy of the parent component.
+
+## Import
+
+```js
+import { Portal } from '@tonic-ui/react';
+```
+
+## Usage
+
+Portal is used to transport any component or element to the end of the document body, and renders the children into it. This is useful for components that need to be rendered above other elements, such as drawers, modals, popovers, etc.
+
+```jsx
+function Example() {
+  const [colorMode] = useColorMode();
+  const [colorStyle] = useColorStyle({ colorMode });
+
+  return (
+    <>
+      <Portal>
+        <VisuallyHidden>
+          <Box bg={colorStyle.background.tertiary} px="3x" py="2x">
+            Portal - This is transported to the end of the document body
+          </Box>
+        </VisuallyHidden>
+      </Portal>
+      <Box bg={colorStyle.background.secondary} px="3x" py="2x">
+        I'm the container
+      </Box>
+    </>
+  );
+}
+```
+
+### Using a custom container
+
+Pass the `containerRef` prop and its value to the `ref` of the container that you want to render the children into.
+
+```jsx
+function Example() {
+  const ref = React.useRef();
+  const [colorMode] = useColorMode();
+  const [colorStyle] = useColorStyle({ colorMode });
+
+  return (
+    <>
+      <Portal containerRef={ref}>
+        <Box bg={colorStyle.background.tertiary} px="3x" py="2x">
+          Portal - This is transported to the container
+        </Box>
+      </Portal>
+      <Flex flexDirection="column" rowGap="2x">
+        <Box ref={ref} bg={colorStyle.background.secondary} px="3x" py="2x">
+          I'm the container
+        </Box>
+      </Flex>
+    </>
+  );
+}
+```
+
+### Nested portals
+
+You can nest portals inside a portal. Pass `appendToParentPortal={true}` to the nested portal to append the children to the container of the parent portal.
+
+```jsx
+function Example() {
+  const ref = React.useRef();
+  const [colorMode] = useColorMode();
+  const [colorStyle] = useColorStyle({ colorMode });
+
+  return (
+    <>
+      <Portal containerRef={ref}>
+        <Box bg={colorStyle.background.tertiary} px="3x" py="2x" mb="2x">
+          Parent portal - This is transported to the container
+          <Portal appendToParentPortal={true}>
+            <Box bg={colorStyle.background.tertiary} px="3x" py="2x" mb="2x">
+              Child portal - This is attached to its parent portal
+            </Box>
+          </Portal>
+        </Box>
+      </Portal>
+      <Box ref={ref} bg={colorStyle.background.secondary} px="3x" py="2x">
+        I'm the container
+      </Box>
+    </>
+  );
+}
+```
+
+## Props
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| appendToParentPortal | boolean | false | If `true`, the portal will check if it is within a parent portal and append itself to the parent's portal node. |
+| children | ReactNode | | |
+| containerRef | RefObject | | The `ref` to the component where the portal will be rendered. |

--- a/packages/react-docs/pages/components/portal.mdx
+++ b/packages/react-docs/pages/components/portal.mdx
@@ -21,6 +21,7 @@ function Example() {
     <>
       <Portal>
         <VisuallyHidden>
+          {/* Open developer tool to inspect elements inside the body tag */}
           <Box bg={colorStyle.background.tertiary} px="3x" py="2x">
             Portal - This is transported to the end of the document body
           </Box>

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     'react-hooks',
   ],
   rules: {
+    'camelcase': ['error', { 'allow': ['^DEPRECATED_'] }],
     'react/function-component-definition': 0,
     'react/prop-types': 0,
     'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks

--- a/packages/react/src/drawer/Drawer.js
+++ b/packages/react/src/drawer/Drawer.js
@@ -1,12 +1,12 @@
 import { useOnceWhen } from '@tonic-ui/react-hooks';
 import { getAllFocusable, runIfFn, warnDeprecatedProps } from '@tonic-ui/utils';
-import FocusLock from 'react-focus-lock/dist/cjs';
 import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import FocusLock from 'react-focus-lock/dist/cjs';
 import { Portal } from '../portal';
 import { AnimatePresence } from '../utils/animate-presence';
 import DrawerContainer from './DrawerContainer';
-import { DrawerProvider } from './context';
+import { DrawerContext } from './context';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
@@ -111,7 +111,7 @@ const Drawer = forwardRef((
   }, [isOpen, isMounted]);
 
   return (
-    <DrawerProvider value={context}>
+    <DrawerContext.Provider value={context}>
       <AnimatePresence
         in={isOpen}
         onExitComplete={onExitComplete}
@@ -137,7 +137,7 @@ const Drawer = forwardRef((
           </Portal>
         )}
       </AnimatePresence>
-    </DrawerProvider>
+    </DrawerContext.Provider>
   );
 });
 

--- a/packages/react/src/drawer/context.js
+++ b/packages/react/src/drawer/context.js
@@ -2,9 +2,6 @@ import { createContext } from 'react';
 
 const DrawerContext = createContext();
 
-const DrawerProvider = DrawerContext.Provider;
-
 export {
   DrawerContext,
-  DrawerProvider,
 };

--- a/packages/react/src/menu/Menu.js
+++ b/packages/react/src/menu/Menu.js
@@ -6,7 +6,7 @@ import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'rea
 import { Box } from '../box';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
-import { MenuProvider } from './context';
+import { MenuContext } from './context';
 import { useMenuStyle } from './styles';
 
 const getMemoizedState = memoize(state => ({ ...state }));
@@ -189,7 +189,7 @@ const Menu = forwardRef((
   const styleProps = useMenuStyle({});
 
   return (
-    <MenuProvider value={context}>
+    <MenuContext.Provider value={context}>
       <Box
         ref={ref}
         {...styleProps}
@@ -197,7 +197,7 @@ const Menu = forwardRef((
       >
         {runIfFn(children, context)}
       </Box>
-    </MenuProvider>
+    </MenuContext.Provider>
   );
 });
 

--- a/packages/react/src/menu/Submenu.js
+++ b/packages/react/src/menu/Submenu.js
@@ -4,7 +4,7 @@ import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'rea
 import { Box } from '../box';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
-import { SubmenuProvider } from './context';
+import { SubmenuContext } from './context';
 import { useSubmenuStyle } from './styles';
 
 const getMemoizedState = memoize(state => ({ ...state }));
@@ -75,7 +75,7 @@ const Submenu = forwardRef((
   });
 
   return (
-    <SubmenuProvider value={context}>
+    <SubmenuContext.Provider value={context}>
       <Box
         ref={ref}
         {...styleProps}
@@ -83,7 +83,7 @@ const Submenu = forwardRef((
       >
         {runIfFn(children, context)}
       </Box>
-    </SubmenuProvider>
+    </SubmenuContext.Provider>
   );
 });
 

--- a/packages/react/src/menu/context.js
+++ b/packages/react/src/menu/context.js
@@ -1,14 +1,9 @@
 import { createContext } from 'react';
 
 const MenuContext = createContext();
-const MenuProvider = MenuContext.Provider;
-
 const SubmenuContext = createContext();
-const SubmenuProvider = SubmenuContext.Provider;
 
 export {
   MenuContext,
-  MenuProvider,
   SubmenuContext,
-  SubmenuProvider,
 };

--- a/packages/react/src/modal/Modal.js
+++ b/packages/react/src/modal/Modal.js
@@ -6,7 +6,7 @@ import FocusLock from 'react-focus-lock/dist/cjs';
 import { Portal } from '../portal';
 import { AnimatePresence } from '../utils/animate-presence';
 import ModalContainer from './ModalContainer';
-import { ModalProvider } from './context';
+import { ModalContext } from './context';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
@@ -109,7 +109,7 @@ const Modal = forwardRef((
   }, [isOpen, isMounted]);
 
   return (
-    <ModalProvider value={context}>
+    <ModalContext.Provider value={context}>
       <AnimatePresence
         in={isOpen}
         onExitComplete={onExitComplete}
@@ -135,7 +135,7 @@ const Modal = forwardRef((
           </Portal>
         )}
       </AnimatePresence>
-    </ModalProvider>
+    </ModalContext.Provider>
   );
 });
 

--- a/packages/react/src/modal/context.js
+++ b/packages/react/src/modal/context.js
@@ -2,9 +2,6 @@ import { createContext } from 'react';
 
 const ModalContext = createContext();
 
-const ModalProvider = ModalContext.Provider;
-
 export {
   ModalContext,
-  ModalProvider,
 };

--- a/packages/react/src/popover/Popover.js
+++ b/packages/react/src/popover/Popover.js
@@ -4,7 +4,7 @@ import memoize from 'micro-memoize';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
-import { PopoverProvider } from './context';
+import { PopoverContext } from './context';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
@@ -219,9 +219,9 @@ const Popover = ({
   });
 
   return (
-    <PopoverProvider value={context}>
+    <PopoverContext.Provider value={context}>
       {runIfFn(children, context)}
-    </PopoverProvider>
+    </PopoverContext.Provider>
   );
 };
 

--- a/packages/react/src/popover/context.js
+++ b/packages/react/src/popover/context.js
@@ -2,9 +2,6 @@ import { createContext } from 'react';
 
 const PopoverContext = createContext();
 
-const PopoverProvider = PopoverContext.Provider;
-
 export {
   PopoverContext,
-  PopoverProvider,
 };

--- a/packages/react/src/portal/Portal.js
+++ b/packages/react/src/portal/Portal.js
@@ -5,8 +5,9 @@ import { createPortal } from 'react-dom';
 import { Box } from '../box';
 
 const Portal = ({
-  isDisabled, // deprecated
-  onRender, // deprecated
+  container: DEPRECATED_container, // deprecated
+  isDisabled: DEPRECATED_isDisabled, // deprecated
+  onRender: DEPRECATED_onRender, // deprecated
 
   children,
   containerRef,
@@ -15,16 +16,23 @@ const Portal = ({
     const prefix = `${Portal.displayName}:`;
 
     useOnceWhen(() => {
+      warnRemovedProps('container', {
+        prefix,
+        alternative: 'containerRef',
+      });
+    }, (DEPRECATED_container !== undefined));
+
+    useOnceWhen(() => {
       warnRemovedProps('isDisabled', {
         prefix,
       });
-    }, (isDisabled !== undefined));
+    }, (DEPRECATED_isDisabled !== undefined));
 
     useOnceWhen(() => {
       warnRemovedProps('onRender', {
         prefix,
       });
-    }, (onRender !== undefined));
+    }, (DEPRECATED_onRender !== undefined));
   }
 
   const [tempNode, setTempNode] = useState(null);

--- a/packages/react/src/portal/Portal.js
+++ b/packages/react/src/portal/Portal.js
@@ -1,14 +1,20 @@
 import { useIsomorphicEffect, useOnceWhen } from '@tonic-ui/react-hooks';
-import { canUseDOM, getOwnerDocument, noop, warnRemovedProps } from '@tonic-ui/utils';
+import { getOwnerDocument, noop, warnRemovedProps } from '@tonic-ui/utils';
 import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Box } from '../box';
+import { PortalContext } from './context';
+import usePortal from './usePortal';
+
+const PORTAL_CLASSNAME = 'tonic-ui-portal';
+const PORTAL_SELECTOR = `.${PORTAL_CLASSNAME}`;
 
 const Portal = ({
   container: DEPRECATED_container, // deprecated
   isDisabled: DEPRECATED_isDisabled, // deprecated
   onRender: DEPRECATED_onRender, // deprecated
 
+  appendToParentPortal = false,
   children,
   containerRef,
 }) => {
@@ -35,27 +41,39 @@ const Portal = ({
     }, (DEPRECATED_onRender !== undefined));
   }
 
-  const [tempNode, setTempNode] = useState(null);
+  const [doc, setDoc] = useState(null);
   const portalRef = useRef(null);
-  const [, forceUpdate] = useState({});
+  const parentPortal = usePortal();
 
+  const [, forceUpdate] = useState({});
   useIsomorphicEffect(() => {
     forceUpdate({});
   }, []);
 
   useIsomorphicEffect(() => {
-    if (!tempNode) {
+    if (!doc) {
       return noop;
     }
 
-    const doc = getOwnerDocument(tempNode);
     const containerEl = containerRef?.current;
-    const host = containerEl ?? (canUseDOM() ? doc.body : undefined);
+    const host = (() => {
+      if (containerEl) {
+        return containerEl;
+      }
+
+      if (appendToParentPortal) {
+        return parentPortal ?? doc.body;
+      }
+
+      return doc.body;
+    })();
+
     if (!host) {
       return noop;
     }
 
     portalRef.current = doc.createElement('div');
+    portalRef.current.className = PORTAL_CLASSNAME;
 
     host.appendChild(portalRef.current);
     forceUpdate({});
@@ -67,22 +85,31 @@ const Portal = ({
         host.removeChild(portalNode);
       }
     };
-  }, [tempNode]);
+  }, [doc]);
 
   if (!portalRef.current) {
     return (
       <Box
         ref={(node) => {
           if (node) {
-            setTempNode(node);
+            const ownerDocument = getOwnerDocument(node);
+            setDoc(ownerDocument);
           }
         }}
       />
     );
   }
 
-  return createPortal(children, portalRef.current);
+  return createPortal(
+    <PortalContext.Provider value={portalRef.current}>
+      {children}
+    </PortalContext.Provider>,
+    portalRef.current,
+  );
 };
+
+Portal.className = PORTAL_CLASSNAME;
+Portal.selector = PORTAL_SELECTOR;
 
 Portal.displayName = 'Portal';
 

--- a/packages/react/src/portal/context.js
+++ b/packages/react/src/portal/context.js
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+const PortalContext = createContext();
+
+export {
+  PortalContext,
+};

--- a/packages/react/src/portal/usePortal.js
+++ b/packages/react/src/portal/usePortal.js
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+import { PortalContext } from './context';
+
+const usePortal = () => {
+  if (!useContext) {
+    throw new Error('The `useContext` hook is not available with your React version.');
+  }
+
+  const context = useContext(PortalContext);
+
+  return context;
+};
+
+export default usePortal;

--- a/packages/react/src/table/Table.js
+++ b/packages/react/src/table/Table.js
@@ -1,10 +1,13 @@
 import { useOnceWhen } from '@tonic-ui/react-hooks';
 import { warnRemovedProps } from '@tonic-ui/utils';
+import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { useColorMode } from '../color-mode';
-import { TableProvider } from './context';
+import { TableContext } from './context';
 import { useTableStyle } from './styles';
+
+const getMemoizedState = memoize(state => ({ ...state }));
 
 const Table = forwardRef((
   {
@@ -29,13 +32,13 @@ const Table = forwardRef((
 
   const styleProps = useTableStyle({});
   const minimalist = (variant === 'default');
-  const context = {
+  const context = getMemoizedState({
     variant,
     size,
-  };
+  });
 
   return (
-    <TableProvider value={context}>
+    <TableContext.Provider value={context}>
       <Box
         ref={ref}
         {...styleProps}
@@ -51,7 +54,7 @@ const Table = forwardRef((
           </>
         )}
       </Box>
-    </TableProvider>
+    </TableContext.Provider>
   );
 });
 

--- a/packages/react/src/table/TableCell.js
+++ b/packages/react/src/table/TableCell.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
-import { useTableContext } from './context';
 import { useTableCellStyle } from './styles';
+import useTable from './useTable';
 
 const TableCell = forwardRef((
   {
@@ -11,7 +11,7 @@ const TableCell = forwardRef((
   },
   ref,
 ) => {
-  const { size, variant } = useTableContext();
+  const { size, variant } = useTable();
   const tableCellStyle = useTableCellStyle({
     size,
     variant,

--- a/packages/react/src/table/TableHeaderCell.js
+++ b/packages/react/src/table/TableHeaderCell.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
-import { useTableContext } from './context';
 import { useTableHeaderCellStyle } from './styles';
+import useTable from './useTable';
 
 const TableHeaderCell = forwardRef((
   {
@@ -11,7 +11,7 @@ const TableHeaderCell = forwardRef((
   },
   ref
 ) => {
-  const { size, variant } = useTableContext();
+  const { size, variant } = useTable();
   const tableHeaderCellStyle = useTableHeaderCellStyle({
     size,
     variant,

--- a/packages/react/src/table/context.js
+++ b/packages/react/src/table/context.js
@@ -1,20 +1,7 @@
-import { createContext, useContext } from 'react';
+import { createContext } from 'react';
 
 const TableContext = createContext();
 
-const TableProvider = TableContext.Provider;
-
-const useTableContext = () => {
-  if (!useContext) {
-    throw new Error('The `useContext` hook is not available with your React version.');
-  }
-
-  const context = useContext(TableContext);
-  return context;
-};
-
 export {
   TableContext,
-  TableProvider,
-  useTableContext,
 };

--- a/packages/react/src/table/useTable.js
+++ b/packages/react/src/table/useTable.js
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { TableContext } from './context';
+
+const useTable = () => {
+  if (!useContext) {
+    throw new Error('The `useContext` hook is not available with your React version.');
+  }
+
+  const context = useContext(TableContext);
+  return context;
+};
+
+export default useTable;

--- a/packages/react/src/toast/useToast.js
+++ b/packages/react/src/toast/useToast.js
@@ -1,17 +1,15 @@
 import { useContext } from 'react';
 import { ToastContext } from './context';
 
-const useToast = (options) => {
-  const { context: Context = ToastContext } = { ...options };
-
+const useToast = () => {
   if (!useContext) {
     throw new Error('The `useContext` hook is not available with your React version.');
   }
 
-  const context = useContext(Context);
+  const context = useContext(ToastContext);
 
   if (!context) {
-    throw new Error('The `useToast` hook must be called from a descendent of the `ToastManager`.');
+    throw new Error('The `useToast` hook must be called from a descendent of the `ToastProvider`.');
   }
 
   const toast = function (...args) {

--- a/packages/react/src/tooltip/Tooltip.js
+++ b/packages/react/src/tooltip/Tooltip.js
@@ -8,7 +8,7 @@ import { Grow } from '../transitions';
 import useAutoId from '../utils/useAutoId';
 import TooltipContent from './TooltipContent';
 import TooltipTrigger from './TooltipTrigger';
-import { TooltipProvider } from './context';
+import { TooltipContext } from './context';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
@@ -173,7 +173,7 @@ const Tooltip = forwardRef((
   });
 
   return (
-    <TooltipProvider value={context}>
+    <TooltipContext.Provider value={context}>
       <TooltipTrigger
         shouldWrapChildren={shouldWrapChildren}
       >
@@ -190,7 +190,7 @@ const Tooltip = forwardRef((
       >
         {label}
       </TooltipContent>
-    </TooltipProvider>
+    </TooltipContext.Provider>
   );
 });
 

--- a/packages/react/src/tooltip/context.js
+++ b/packages/react/src/tooltip/context.js
@@ -2,9 +2,6 @@ import { createContext } from 'react';
 
 const TooltipContext = createContext();
 
-const TooltipProvider = TooltipContext.Provider;
-
 export {
   TooltipContext,
-  TooltipProvider,
 };


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-629/components/portal

Inspired from:
* https://github.com/chakra-ui/chakra-ui/tree/main/packages/components/portal
* https://chakra-ui.com/docs/components/portal

This PR does not implement portal manager because it only provides the context of a `z-index` value. This can be added within portals.

# Portal

A declarative component that allows you to render children into a DOM node that exists outside the DOM hierarchy of the parent component.

## Import

```js
import { Portal } from '@tonic-ui/react';
```

## Usage

Portal is used to transport any component or element to the end of the document body, and renders the children into it. This is useful for components that need to be rendered above other elements, such as drawers, modals, popovers, etc.

```jsx
function Example() {
  const [colorMode] = useColorMode();
  const [colorStyle] = useColorStyle({ colorMode });
  return (
    <>
      <Portal>
        <VisuallyHidden>
          {/* Open developer tool to inspect elements inside the body tag */}
          <Box bg={colorStyle.background.tertiary} px="3x" py="2x">
            Portal - This is transported to the end of the document body
          </Box>
        </VisuallyHidden>
      </Portal>
      <Box bg={colorStyle.background.secondary} px="3x" py="2x">
        I'm the container
      </Box>
    </>
  );
}
```

### Using a custom container

Pass the `containerRef` prop and its value to the `ref` of the container that you want to render the children into.

```jsx
function Example() {
  const ref = React.useRef();
  const [colorMode] = useColorMode();
  const [colorStyle] = useColorStyle({ colorMode });
  return (
    <>
      <Portal containerRef={ref}>
        <Box bg={colorStyle.background.tertiary} px="3x" py="2x">
          Portal - This is transported to the container
        </Box>
      </Portal>
      <Flex flexDirection="column" rowGap="2x">
        <Box ref={ref} bg={colorStyle.background.secondary} px="3x" py="2x">
          I'm the container
        </Box>
      </Flex>
    </>
  );
}
```

### Nested portals

You can nest portals inside a portal. Pass `appendToParentPortal={true}` to the nested portal to append the children to the container of the parent portal.

```jsx
function Example() {
  const ref = React.useRef();
  const [colorMode] = useColorMode();
  const [colorStyle] = useColorStyle({ colorMode });
  return (
    <>
      <Portal containerRef={ref}>
        <Box bg={colorStyle.background.tertiary} px="3x" py="2x" mb="2x">
          Parent portal - This is transported to the container
          <Portal appendToParentPortal={true}>
            <Box bg={colorStyle.background.tertiary} px="3x" py="2x" mb="2x">
              Child portal - This is attached to its parent portal
            </Box>
          </Portal>
        </Box>
      </Portal>
      <Box ref={ref} bg={colorStyle.background.secondary} px="3x" py="2x">
        I'm the container
      </Box>
    </>
  );
}
```

## Props

| Name | Type | Default | Description |
| :--- | :--- | :------ | :---------- |
| appendToParentPortal | boolean | false | If `true`, the portal will check if it is within a parent portal and append itself to the parent's portal node. |
| children | ReactNode | | |
| containerRef | RefObject | | The `ref` to the component where the portal will be rendered. |