### PR TITLE
docs: use pseudo elements to customize the browser's scrollbar

### DIFF
--- a/packages/react-docs/components/GlobalStyles.jsx
+++ b/packages/react-docs/components/GlobalStyles.jsx
@@ -8,6 +8,10 @@ import React from 'react';
 const GlobalStyles = () => {
   const [colorMode] = useColorMode();
   const theme = useTheme();
+
+  /**
+   * Body
+   */
   const backgroundColor = {
     light: 'white',
     dark: 'gray:100',
@@ -15,6 +19,26 @@ const GlobalStyles = () => {
   const color = {
     light: 'black:primary',
     dark: 'white:primary',
+  }[colorMode];
+
+  /**
+   * Scrollbar
+   */
+  const scrollbarThumbBackgroundColor = {
+    light: 'black:disabled',
+    dark: 'white:disabled',
+  }[colorMode];
+  const scrollbarThumbHoverBackgroundColor = {
+    light: 'black:tertiary',
+    dark: 'white:tertiary',
+  }[colorMode];
+  const scrollbarThumbHoverBorderColor = {
+    light: 'black:secondary',
+    dark: 'white:secondary',
+  }[colorMode];
+  const scrollbarTrackBackgroundColor = {
+    light: 'gray:30',
+    dark: 'gray:70',
   }[colorMode];
 
   return (
@@ -34,41 +58,18 @@ const GlobalStyles = () => {
         }
 
         ::-webkit-scrollbar {
-          position: relative;
           width: 8px;
-          height: 100%;
-          margin: 0 auto;
-          border-radius: 0;
-          text-align: center;
-          cursor: pointer;
-          border: 1px solid rgba(0, 0, 0, .1);
-          -webkit-transition: all .5s ease-in-out;
-          transition: all .5s ease-in-out;
-          background-color: rgba(0, 0, 0, .2);
+          height: 8px;
         }
-
-        ::-webkit-scrollbar:hover {
-          background-color: rgba(0, 0, 0, .45);
-          border: 1px solid rgba(0, 0, 0, .3);
-        }
-
-        ::-webkit-scrollbar-thumb {
-          background-color: hsla(0, 0%, 100%, .35);
-          border: 1px solid hsla(0, 0%, 100%, .2);
-        }
-
         ::-webkit-scrollbar-track {
-          width: 4px;
-          height: 100%;
-          margin: 0 auto;
-          border-radius: 0;
-          -webkit-transition: all .5s ease-in-out;
-          transition: all .5s ease-in-out;
-          background-color: #303030;
+          background-color: ${theme.colors[scrollbarTrackBackgroundColor]};
         }
-
-        ::-webkit-scrollbar-track:hover {
-          background-color: hsla(0, 0%, 100%, .15);
+        ::-webkit-scrollbar-thumb {
+          background-color: ${theme.colors[scrollbarThumbBackgroundColor]};
+        }
+        ::-webkit-scrollbar-thumb:hover {
+          background-color: ${theme.colors[scrollbarThumbHoverBackgroundColor]};
+          border: 1px solid ${theme.colors[scrollbarThumbHoverBorderColor]};
         }
       `}
     />

--- a/packages/react-docs/components/GlobalStyles.jsx
+++ b/packages/react-docs/components/GlobalStyles.jsx
@@ -1,41 +1,20 @@
 import { Global, css } from '@emotion/react';
 import {
   useColorMode,
+  useColorStyle,
   useTheme,
 } from '@tonic-ui/react';
 import React from 'react';
 
 const GlobalStyles = () => {
   const [colorMode] = useColorMode();
-  const theme = useTheme();
-
-  /**
-   * Body
-   */
-  const backgroundColor = {
-    light: 'white',
-    dark: 'gray:100',
-  }[colorMode];
-  const color = {
-    light: 'black:primary',
-    dark: 'white:primary',
-  }[colorMode];
-
-  /**
-   * Scrollbar
-   */
-  const scrollbarThumbBackgroundColor = {
-    light: 'black:disabled',
-    dark: 'white:disabled',
-  }[colorMode];
-  const scrollbarThumbHoverBackgroundColor = {
-    light: 'black:tertiary',
-    dark: 'white:tertiary',
-  }[colorMode];
-  const scrollbarThumbHoverBorderColor = {
-    light: 'black:secondary',
-    dark: 'white:secondary',
-  }[colorMode];
+  const [colorStyle] = useColorStyle({ colorMode });
+  const { colors, fontSizes, lineHeights } = useTheme();
+  const backgroundColor = colorStyle.background.primary;
+  const color = colorStyle.color.primary;
+  const scrollbarThumbBackgroundColor = colorStyle.color.disabled;
+  const scrollbarThumbHoverBackgroundColor = colorStyle.color.tertiary;
+  const scrollbarThumbHoverBorderColor = colorStyle.color.secondary;
   const scrollbarTrackBackgroundColor = {
     light: 'gray:30',
     dark: 'gray:70',
@@ -51,10 +30,10 @@ const GlobalStyles = () => {
           outline: none;
         }
         body {
-          background-color: ${theme.colors[backgroundColor]};
-          color: ${theme.colors[color]};
-          font-size: ${theme.fontSizes.sm};
-          line-height: ${theme.lineHeights.sm};
+          background-color: ${colors[backgroundColor]};
+          color: ${colors[color]};
+          font-size: ${fontSizes.sm};
+          line-height: ${lineHeights.sm};
         }
 
         ::-webkit-scrollbar {
@@ -62,14 +41,14 @@ const GlobalStyles = () => {
           height: 8px;
         }
         ::-webkit-scrollbar-track {
-          background-color: ${theme.colors[scrollbarTrackBackgroundColor]};
+          background-color: ${colors[scrollbarTrackBackgroundColor]};
         }
         ::-webkit-scrollbar-thumb {
-          background-color: ${theme.colors[scrollbarThumbBackgroundColor]};
+          background-color: ${colors[scrollbarThumbBackgroundColor]};
         }
         ::-webkit-scrollbar-thumb:hover {
-          background-color: ${theme.colors[scrollbarThumbHoverBackgroundColor]};
-          border: 1px solid ${theme.colors[scrollbarThumbHoverBorderColor]};
+          background-color: ${colors[scrollbarThumbHoverBackgroundColor]};
+          border: 1px solid ${colors[scrollbarThumbHoverBorderColor]};
         }
       `}
     />

--- a/packages/react-docs/components/GlobalStyles.jsx
+++ b/packages/react-docs/components/GlobalStyles.jsx
@@ -32,6 +32,44 @@ const GlobalStyles = () => {
           font-size: ${theme.fontSizes.sm};
           line-height: ${theme.lineHeights.sm};
         }
+
+        ::-webkit-scrollbar {
+          position: relative;
+          width: 8px;
+          height: 100%;
+          margin: 0 auto;
+          border-radius: 0;
+          text-align: center;
+          cursor: pointer;
+          border: 1px solid rgba(0, 0, 0, .1);
+          -webkit-transition: all .5s ease-in-out;
+          transition: all .5s ease-in-out;
+          background-color: rgba(0, 0, 0, .2);
+        }
+
+        ::-webkit-scrollbar:hover {
+          background-color: rgba(0, 0, 0, .45);
+          border: 1px solid rgba(0, 0, 0, .3);
+        }
+
+        ::-webkit-scrollbar-thumb {
+          background-color: hsla(0, 0%, 100%, .35);
+          border: 1px solid hsla(0, 0%, 100%, .2);
+        }
+
+        ::-webkit-scrollbar-track {
+          width: 4px;
+          height: 100%;
+          margin: 0 auto;
+          border-radius: 0;
+          -webkit-transition: all .5s ease-in-out;
+          transition: all .5s ease-in-out;
+          background-color: #303030;
+        }
+
+        ::-webkit-scrollbar-track:hover {
+          background-color: hsla(0, 0%, 100%, .15);
+        }
       `}
     />
   );

--- a/packages/react-docs/pages/components/scrollbar.mdx
+++ b/packages/react-docs/pages/components/scrollbar.mdx
@@ -89,7 +89,7 @@ Note: `overflowX` and `overflowY` are also available if you need to set the over
 ```jsx
 <Grid
   templateColumns="repeat(auto-fit, minmax(240px, 1fr))"
-  columnGap="4x"
+  columnGap="6x"
   rowGap="4x"
 >
   <Box>
@@ -141,7 +141,7 @@ Use the `minThumbWidth` and `minThumbHeight` props to set the minimum size of th
 ```jsx
 <Grid
   templateColumns="repeat(auto-fit, minmax(240px, 1fr))"
-  columnGap="4x"
+  columnGap="6x"
   rowGap="4x"
 >
   <Box>

--- a/packages/react-docs/pages/components/scrollbar.mdx
+++ b/packages/react-docs/pages/components/scrollbar.mdx
@@ -17,10 +17,8 @@ The scrollbar is hidden by default. You can mouse over the scrollable content to
 ```jsx
 <Scrollbar
   height={200}
-  border={1}
-  borderColor="#424242"
 >
-  <Lorem count={10} px="4x" py="3x" />
+  <Lorem count={10} />
 </Scrollbar>
 ```
 
@@ -36,12 +34,10 @@ To enable vertical scrolling, set the scrollbar height to a value less than the 
 <Scrollbar
   minHeight={100}
   maxHeight={200}
-  border={1}
-  borderColor="#424242"
   overflow="scroll"
   resize="vertical"
 >
-  <Lorem count={10} px="4x" py="3x" />
+  <Lorem count={10} />
 </Scrollbar>
 ```
 
@@ -53,12 +49,10 @@ To enable horizontal scrolling, set the scrollbar width to a value less than the
 <Scrollbar
   minWidth="10%"
   maxWidth="100%"
-  border={1}
-  borderColor="#424242"
   overflow="scroll"
   resize="horizontal"
 >
-  <Lorem count={6} px="4x" py="3x" whiteSpace="nowrap" />
+  <Lorem count={6} whiteSpace="nowrap" />
 </Scrollbar>
 ```
 
@@ -67,12 +61,10 @@ To enable horizontal scrolling, set the scrollbar width to a value less than the
 ```jsx
 <Scrollbar
   height={200}
-  border={1}
-  borderColor="#424242"
   overflow="scroll"
   resize="both"
 >
-  <Lorem count={10} px="4x" py="3x" whiteSpace="nowrap" />
+  <Lorem count={10} whiteSpace="nowrap" />
 </Scrollbar>
 ```
 
@@ -98,11 +90,9 @@ Note: `overflowX` and `overflowY` are also available if you need to set the over
     </Text>
     <Scrollbar
       height={200}
-      border={1}
-      borderColor="#424242"
       overflow="auto"
     >
-      <Lorem count={10} px="4x" py="3x" whiteSpace="nowrap" />
+      <Lorem count={10} whiteSpace="nowrap" />
     </Scrollbar>
   </Box>
   <Box>
@@ -111,11 +101,9 @@ Note: `overflowX` and `overflowY` are also available if you need to set the over
     </Text>
     <Scrollbar
       height={200}
-      border={1}
-      borderColor="#424242"
       overflow="scroll"
     >
-      <Lorem count={10} px="4x" py="3x" whiteSpace="nowrap" />
+      <Lorem count={10} whiteSpace="nowrap" />
     </Scrollbar>
   </Box>
   <Box>
@@ -124,11 +112,9 @@ Note: `overflowX` and `overflowY` are also available if you need to set the over
     </Text>
     <Scrollbar
       height={200}
-      border={1}
-      borderColor="#424242"
       overflow="hidden"
     >
-      <Lorem count={10} px="4x" py="3x" whiteSpace="nowrap" />
+      <Lorem count={10} whiteSpace="nowrap" />
     </Scrollbar>
   </Box>
 </Grid>
@@ -150,12 +136,10 @@ Use the `minThumbWidth` and `minThumbHeight` props to set the minimum size of th
     </Text>
     <Scrollbar
       height={200}
-      border={1}
-      borderColor="#424242"
       minThumbHeight={50}
       overflow="scroll"
     >
-      <Lorem count={10} px="4x" py="3x" />
+      <Lorem count={10} />
     </Scrollbar>
   </Box>
   <Box>
@@ -164,12 +148,10 @@ Use the `minThumbWidth` and `minThumbHeight` props to set the minimum size of th
     </Text>
     <Scrollbar
       height={200}
-      border={1}
-      borderColor="#424242"
       minThumbHeight={100}
       overflow="scroll"
     >
-      <Lorem count={10} px="4x" py="3x" />
+      <Lorem count={10} />
     </Scrollbar>
   </Box>
 </Grid>
@@ -181,6 +163,7 @@ The scroll indicator can visually indicate the current scroll position of the sc
 
 ```jsx noInline
 const ShadowScrollbar = (props) => {
+  const [colorMode] = useColorMode();
   const topIndicatorRef = React.useRef(null);
   const bottomIndicatorRef = React.useRef(null);
   const handleUpdate = ({ values }) => {
@@ -191,6 +174,14 @@ const ShadowScrollbar = (props) => {
     topIndicatorRef.current.style.opacity = topIndicatorOpacity;
     bottomIndicatorRef.current.style.opacity = bottomIndicatorOpacity;
   };
+  const topScrollIndicatorBackground = {
+    dark: 'linear-gradient(to bottom, rgba(33, 33, 33, 1) 0%, rgba(255, 255, 255, 0) 100%)', 
+    light: 'linear-gradient(to bottom, rgba(224, 224, 224, 1) 0%, rgba(255, 255, 255, 0) 100%)', 
+  }[colorMode];
+  const bottomScrollIndicatorBackground = {
+    dark: 'linear-gradient(to top, rgba(33, 33, 33, 1) 0%, rgba(255, 255, 255, 0) 100%)', 
+    light: 'linear-gradient(to top, rgba(224, 224, 224, 1) 0%, rgba(255, 255, 255, 0) 100%)', 
+  }[colorMode];
 
   return (
     <Box position="relative">
@@ -205,7 +196,7 @@ const ShadowScrollbar = (props) => {
         left="0"
         right="0"
         height="24px"
-        background="linear-gradient(to bottom, rgba(33, 33, 33, 1) 0%, rgba(255, 255, 255, 0) 100%)"
+        background={topScrollIndicatorBackground}
       />
       <Box
         ref={bottomIndicatorRef}
@@ -214,7 +205,7 @@ const ShadowScrollbar = (props) => {
         left="0"
         right="0"
         height="24px"
-        background="linear-gradient(to top, rgba(33, 33, 33, 1) 0%, rgba(255, 255, 255, 0) 100%)"
+        background={bottomScrollIndicatorBackground}
       />
     </Box>
   );
@@ -223,10 +214,8 @@ const ShadowScrollbar = (props) => {
 render(
   <ShadowScrollbar
     height={300}
-    border={1}
-    borderColor="#424242"
   >
-    <Lorem count={10} px="4x" py="3x" />
+    <Lorem count={10} />
   </ShadowScrollbar>
 );
 ```

--- a/packages/react-docs/pages/getting-started/usage.mdx
+++ b/packages/react-docs/pages/getting-started/usage.mdx
@@ -81,9 +81,16 @@ function App(props) {
 function Layout(props) {
   const [colorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
-  const { fontSizes, lineHeights } = useTheme();
+  const { colors, fontSizes, lineHeights } = useTheme();
   const backgroundColor = colorStyle.background.primary;
   const color = colorStyle.color.primary;
+  const scrollbarThumbBackgroundColor = colorStyle.color.disabled;
+  const scrollbarThumbHoverBackgroundColor = colorStyle.color.tertiary;
+  const scrollbarThumbHoverBorderColor = colorStyle.color.secondary;
+  const scrollbarTrackBackgroundColor = {
+    light: 'gray:30',
+    dark: 'gray:70',
+  }[colorMode];
 
   return (
     <>
@@ -98,6 +105,21 @@ function Layout(props) {
           body {
             font-size: ${fontSizes.sm};
             line-height: ${lineHeights.sm};
+          }
+
+          ::-webkit-scrollbar {
+            width: 8px;
+            height: 8px;
+          }
+          ::-webkit-scrollbar-track {
+            background-color: ${colors[scrollbarTrackBackgroundColor]};
+          }
+          ::-webkit-scrollbar-thumb {
+            background-color: ${colors[scrollbarThumbBackgroundColor]};
+          }
+          ::-webkit-scrollbar-thumb:hover {
+            background-color: ${colors[scrollbarThumbHoverBackgroundColor]};
+            border: 1px solid ${colors[scrollbarThumbHoverBorderColor]};
           }
         `}
       />

--- a/packages/react/src/scrollbar/styles.js
+++ b/packages/react/src/scrollbar/styles.js
@@ -60,19 +60,12 @@ const useScrollViewStyle = ({
 const useHorizontalTrackStyle = ({
   overflowX,
 }) => {
-  const [colorMode] = useColorMode();
-  const backgroundColor = {
-    dark: 'gray:70',
-    light: 'gray:30',
-  }[colorMode];
-
   return {
     position: 'absolute',
     height: '2x',
     right: 0,
     bottom: 0,
     left: 0,
-    backgroundColor,
     visibility: 'hidden',
     ...(overflowX === 'auto' && {
       transition: 'opacity 200ms',
@@ -87,19 +80,12 @@ const useHorizontalTrackStyle = ({
 const useVerticalTrackStyle = ({
   overflowY,
 }) => {
-  const [colorMode] = useColorMode();
-  const backgroundColor = {
-    dark: 'gray:70',
-    light: 'gray:30',
-  }[colorMode];
-
   return {
     position: 'absolute',
     width: '2x',
     right: 0,
     bottom: 0,
     top: 0,
-    backgroundColor,
     visibility: 'hidden',
     ...(overflowY === 'auto' && {
       transition: 'opacity 200ms',

--- a/packages/react/src/scrollbar/styles.js
+++ b/packages/react/src/scrollbar/styles.js
@@ -60,12 +60,19 @@ const useScrollViewStyle = ({
 const useHorizontalTrackStyle = ({
   overflowX,
 }) => {
+  const [colorMode] = useColorMode();
+  const backgroundColor = {
+    dark: 'gray:70',
+    light: 'gray:30',
+  }[colorMode];
+
   return {
     position: 'absolute',
     height: '2x',
     right: 0,
     bottom: 0,
     left: 0,
+    backgroundColor,
     visibility: 'hidden',
     ...(overflowX === 'auto' && {
       transition: 'opacity 200ms',
@@ -80,12 +87,19 @@ const useHorizontalTrackStyle = ({
 const useVerticalTrackStyle = ({
   overflowY,
 }) => {
+  const [colorMode] = useColorMode();
+  const backgroundColor = {
+    dark: 'gray:70',
+    light: 'gray:30',
+  }[colorMode];
+
   return {
     position: 'absolute',
     width: '2x',
     right: 0,
     bottom: 0,
     top: 0,
+    backgroundColor,
     visibility: 'hidden',
     ...(overflowY === 'auto' && {
       transition: 'opacity 200ms',
@@ -103,7 +117,7 @@ const useHorizontalThumbStyle = props => {
     dark: 'white:disabled',
     light: 'black:disabled',
   }[colorMode];
-  const hoverBgColor = {
+  const hoverBackgroundColor = {
     dark: 'white:tertiary',
     light: 'black:tertiary',
   }[colorMode];
@@ -116,13 +130,13 @@ const useHorizontalThumbStyle = props => {
     position: 'relative',
     height: '100%',
     cursor: 'pointer',
+    backgroundColor,
     borderRadius: 'inherit',
     border: 1,
     borderColor: 'transparent',
-    backgroundColor,
     _hover: {
+      backgroundColor: hoverBackgroundColor,
       borderColor: hoverBorderColor,
-      backgroundColor: hoverBgColor,
     },
   };
 };
@@ -133,7 +147,7 @@ const useVerticalThumbStyle = props => {
     dark: 'white:disabled',
     light: 'black:disabled',
   }[colorMode];
-  const hoverBgColor = {
+  const hoverBackgroundColor = {
     dark: 'white:tertiary',
     light: 'black:tertiary',
   }[colorMode];
@@ -147,13 +161,13 @@ const useVerticalThumbStyle = props => {
     display: 'block',
     width: '100%',
     cursor: 'pointer',
+    backgroundColor,
     borderRadius: 'inherit',
     border: 1,
     borderColor: 'transparent',
-    backgroundColor,
     _hover: {
+      backgroundColor: hoverBackgroundColor,
       borderColor: hoverBorderColor,
-      backgroundColor: hoverBgColor,
     },
   };
 };


### PR DESCRIPTION
Apply pseudo elements to customize the browser's scrollbar.

```js
  /**
   * Scrollbar
   */
  const scrollbarThumbBackgroundColor = {
    light: 'black:disabled',
    dark: 'white:disabled',
  }[colorMode];
  const scrollbarThumbHoverBackgroundColor = {
    light: 'black:tertiary',
    dark: 'white:tertiary',
  }[colorMode];
  const scrollbarThumbHoverBorderColor = {
    light: 'black:secondary',
    dark: 'white:secondary',
  }[colorMode];
  const scrollbarTrackBackgroundColor = {
    light: 'gray:30',
    dark: 'gray:70',
  }[colorMode];
```

```css
        ::-webkit-scrollbar {
          width: 8px;
          height: 8px;
        }
        ::-webkit-scrollbar-track {
          background-color: ${theme.colors[scrollbarTrackBackgroundColor]};
        }
        ::-webkit-scrollbar-thumb {
          background-color: ${theme.colors[scrollbarThumbBackgroundColor]};
        }
        ::-webkit-scrollbar-thumb:hover {
          background-color: ${theme.colors[scrollbarThumbHoverBackgroundColor]};
          border: 1px solid ${theme.colors[scrollbarThumbHoverBorderColor]};
        }
```

### Before
![image](https://user-images.githubusercontent.com/447801/203293157-90e18606-3190-4600-b704-6ac3e424a4d3.png)

### After
![image](https://user-images.githubusercontent.com/447801/203292936-4adc622b-94ef-44ad-b2cc-ac1cd0e2efcc.png)
