### PR TITLE
docs: add support for instant search within documentation

### DIFF
--- a/.github/workflows/algolia-search-indexing.yml
+++ b/.github/workflows/algolia-search-indexing.yml
@@ -26,6 +26,7 @@ jobs:
       run: npm install -g yarn
     - name: Install and build
       run: |
+        yarn up
         yarn install
         yarn build
     - name: Algolia search indexing

--- a/packages/react-docs/components/Header.jsx
+++ b/packages/react-docs/components/Header.jsx
@@ -1,4 +1,3 @@
-import { ensureString } from 'ensure-type';
 import {
   Box,
   Button,
@@ -15,11 +14,15 @@ import {
   useColorMode,
   useColorStyle,
 } from '@tonic-ui/react';
+import { ensureString } from 'ensure-type';
 import NextLink from 'next/link';
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef, useCallback, useEffect } from 'react';
 import pkg from '../../../package.json';
 import persistColorMode from '../utils/persist-color-mode';
+import SearchButton from './SearchButton';
+import InstantSearchModal from './InstantSearchModal';
 import FontAwesomeIcon from './FontAwesomeIcon';
+import { usePortal } from './Portal';
 
 const BASE_PATH = ensureString(process.env.BASE_PATH);
 const TONIC_UI_REACT_VERSION = ensureString(process.env.TONIC_UI_REACT_VERSION);
@@ -46,6 +49,7 @@ const Header = forwardRef((
   },
   ref,
 ) => {
+  const portal = usePortal();
   const [colorMode, toggleColorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
   const version = (() => {
@@ -57,6 +61,12 @@ const Header = forwardRef((
     }
     return '';
   })();
+
+  const openInstantSearchModal = useCallback(() => {
+    portal.add((callback) => (
+      <InstantSearchModal onClose={callback} />
+    ));
+  }, [portal]);
 
   useEffect(() => {
     persistColorMode(colorMode);
@@ -155,6 +165,9 @@ const Header = forwardRef((
           columnGap="4x"
           px="4x"
         >
+          <SearchButton onClick={openInstantSearchModal}>
+            Search...
+          </SearchButton>
           <Box
             display="flex"
             flex="none"

--- a/packages/react-docs/components/InstantSearchInput.jsx
+++ b/packages/react-docs/components/InstantSearchInput.jsx
@@ -6,8 +6,13 @@ import {
   useSearchBox,
 } from 'react-instantsearch-hooks';
 
+// https://www.algolia.com/doc/api-reference/widgets/search-box/react-hooks/#hook-params
+const queryHook = (query, search) => {
+  search(query);
+};
+
 const InstantSearchInput = forwardRef((props, ref) => {
-  const { query, refine, clear, isSearchStalled } = useSearchBox(props);
+  const { query, refine, clear, isSearchStalled } = useSearchBox({ queryHook });
   const [inputValue, setInputValue] = useState(query);
 
   const onChange = useCallback((event) => {

--- a/packages/react-docs/components/InstantSearchInput.jsx
+++ b/packages/react-docs/components/InstantSearchInput.jsx
@@ -1,0 +1,38 @@
+import {
+  SearchInput,
+} from '@tonic-ui/react';
+import React, { forwardRef, useCallback, useState } from 'react';
+import {
+  useSearchBox,
+} from 'react-instantsearch-hooks';
+
+const InstantSearchInput = forwardRef((props, ref) => {
+  const { query, refine, clear, isSearchStalled } = useSearchBox(props);
+  const [inputValue, setInputValue] = useState(query);
+
+  const onChange = useCallback((event) => {
+    const value = event.currentTarget.value;
+    setInputValue(value);
+    refine(value);
+  }, [refine]);
+
+  const onClearInput = useCallback(() => {
+    setInputValue('');
+    clear();
+  }, [clear]);
+
+  return (
+    <SearchInput
+      ref={ref}
+      isLoading={isSearchStalled}
+      value={inputValue}
+      onChange={onChange}
+      onClearInput={onClearInput}
+      {...props}
+    />
+  );
+});
+
+InstantSearchInput.displayName = 'InstantSearchInput';
+
+export default InstantSearchInput;

--- a/packages/react-docs/components/InstantSearchModal.jsx
+++ b/packages/react-docs/components/InstantSearchModal.jsx
@@ -1,0 +1,45 @@
+import {
+  Box,
+  Divider,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+} from '@tonic-ui/react';
+import React, { forwardRef } from 'react';
+import InstantSearchInput from './InstantSearchInput';
+import InstantSearchRefinementList from './InstantSearchRefinementList';
+
+const InstantSearchModal = forwardRef((
+  {
+    onClose,
+    ...rest
+  },
+  ref,
+) => {
+  return (
+    <Modal
+      ref={ref}
+      autoFocus
+      ensureFocus
+      closeOnEsc
+      closeOnOutsideClick
+      isOpen
+      onClose={onClose}
+      size="md"
+      {...rest}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <Box p="4x">
+          <InstantSearchInput size="lg" />
+        </Box>
+        <Divider />
+        <InstantSearchRefinementList onClose={onClose} />
+      </ModalContent>
+    </Modal>
+  );
+});
+
+InstantSearchModal.displayName = 'InstantSearchModal';
+
+export default InstantSearchModal;

--- a/packages/react-docs/components/InstantSearchModal.jsx
+++ b/packages/react-docs/components/InstantSearchModal.jsx
@@ -31,7 +31,7 @@ const InstantSearchModal = forwardRef((
       <ModalOverlay />
       <ModalContent>
         <Box p="4x">
-          <InstantSearchInput size="lg" />
+          <InstantSearchInput size="lg" placeholder="Search..." />
         </Box>
         <Divider />
         <InstantSearchRefinementList onClose={onClose} />

--- a/packages/react-docs/components/InstantSearchModal.jsx
+++ b/packages/react-docs/components/InstantSearchModal.jsx
@@ -9,6 +9,8 @@ import React, { forwardRef } from 'react';
 import InstantSearchInput from './InstantSearchInput';
 import InstantSearchRefinementList from './InstantSearchRefinementList';
 
+const x = (value) => JSON.stringify(value);
+
 const InstantSearchModal = forwardRef((
   {
     onClose,
@@ -34,7 +36,30 @@ const InstantSearchModal = forwardRef((
           <InstantSearchInput size="lg" placeholder="Search..." />
         </Box>
         <Divider />
-        <InstantSearchRefinementList onClose={onClose} />
+        <InstantSearchRefinementList
+          onChange={(hit) => {
+            /**
+             * The function uses the `parent` property of the `hit` object to get the title of the parent refinement,
+             * and then uses this title to select a DOM element from #sidenav with a `data-title` attribute that matches the title.
+             * If the DOM element has a `data-expanded` attribute with a value of "false", the function simulates a mouse click
+             * on the element by creating a new MouseEvent and calling the dispatchEvent method on the element.
+             */
+            const parentTitle = hit?.parent?.title;
+            if (parentTitle) {
+              const button = document.querySelector(`#sidenav button[data-title=${x(parentTitle)}]`);
+              if (button?.dataset?.expanded === 'false') {
+                // Simulate a mouse click on the button
+                const event = new MouseEvent('click', {
+                  bubbles: true,
+                  cancelable: true,
+                });
+                button.dispatchEvent(event);
+              }
+            }
+
+            onClose();
+          }}
+        />
       </ModalContent>
     </Modal>
   );

--- a/packages/react-docs/components/InstantSearchPagination.jsx
+++ b/packages/react-docs/components/InstantSearchPagination.jsx
@@ -1,0 +1,37 @@
+import {
+  Pagination,
+} from '@tonic-ui/react';
+import React, { forwardRef } from 'react';
+import {
+  usePagination,
+} from 'react-instantsearch-hooks';
+
+/**
+ * See https://www.algolia.com/doc/api-reference/widgets/use-instantsearch/react-hooks/
+ */
+const InstantSearchPagination = forwardRef((props, ref) => {
+  const {
+    currentRefinement,
+    nbPages,
+    refine,
+  } = usePagination();
+
+  const page = currentRefinement + 1;
+
+  return (
+    <Pagination
+      ref={ref}
+      count={nbPages}
+      page={page}
+      onChange={(event, page) => {
+        const nextRefinement = (page - 1);
+        refine(nextRefinement);
+      }}
+      {...props}
+    />
+  );
+});
+
+InstantSearchPagination.displayName = 'InstantSearchPagination';
+
+export default InstantSearchPagination;

--- a/packages/react-docs/components/InstantSearchRefinementLink.jsx
+++ b/packages/react-docs/components/InstantSearchRefinementLink.jsx
@@ -1,0 +1,58 @@
+import {
+  Link,
+  useColorMode,
+  useColorStyle,
+} from '@tonic-ui/react';
+import NextLink from 'next/link';
+import React, { forwardRef } from 'react';
+
+const InstantSearchRefinementLink = forwardRef((props, ref) => {
+  const [colorMode] = useColorMode();
+  const [colorStyle] = useColorStyle({ colorMode });
+  const defaultColor = colorStyle.color.secondary;
+  const activeColor = colorStyle.color.primary;
+  const hoverColor = colorStyle.color.primary;
+  const visitedColor = colorStyle.color.secondary;
+  const hoverBorderColor = {
+    dark: 'blue:50',
+    light: 'blue:50',
+  }[colorMode];
+
+  return (
+    <NextLink
+      href={props?.href}
+      legacyBehavior
+      passHref
+    >
+      <Link
+        ref={ref}
+        display="flex"
+        alignItems="center"
+        columnGap="3x"
+        height="12x"
+        color={defaultColor}
+        border={1}
+        borderColor="transparent"
+        borderRadius="md"
+        px="3x"
+        textDecoration="none"
+        width="100%"
+        _active={{
+          color: activeColor,
+        }}
+        _hover={{
+          color: hoverColor,
+          borderColor: hoverBorderColor,
+        }}
+        _visited={{
+          color: visitedColor,
+        }}
+        {...props}
+      />
+    </NextLink>
+  );
+});
+
+InstantSearchRefinementLink.displayName = 'InstantSearchRefinementLink';
+
+export default InstantSearchRefinementLink;

--- a/packages/react-docs/components/InstantSearchRefinementList.jsx
+++ b/packages/react-docs/components/InstantSearchRefinementList.jsx
@@ -25,7 +25,7 @@ import InstantSearchPagination from './InstantSearchPagination';
  */
 const InstantSearchRefinementList = (
   {
-    onClose,
+    onChange,
   }
 ) => {
   const [colorMode] = useColorMode();
@@ -37,6 +37,9 @@ const InstantSearchRefinementList = (
     error,
   } = useInstantSearch({ catchError: true });
   const query = ensureString(results?.query);
+  const handleClickRefinementLinkBy = (hit) => () => {
+    onChange(hit);
+  };
 
   if (status === 'error') {
     return (
@@ -149,7 +152,7 @@ const InstantSearchRefinementList = (
               <Box key={hit.objectID}>
                 <InstantSearchRefinementLink
                   href={`/${hit.data.path}`}
-                  onClick={onClose}
+                  onClick={handleClickRefinementLinkBy(hit)}
                 >
                   <Icon
                     icon="menu"

--- a/packages/react-docs/components/InstantSearchRefinementList.jsx
+++ b/packages/react-docs/components/InstantSearchRefinementList.jsx
@@ -12,6 +12,7 @@ import {
 } from '@tonic-ui/react';
 import { ensureArray, ensureString } from 'ensure-type'
 import _groupBy from 'lodash/groupBy';
+import _orderBy from 'lodash/orderBy';
 import React from 'react';
 import Highlight from 'react-highlight-words';
 import {
@@ -131,7 +132,7 @@ const InstantSearchRefinementList = (
     );
   }
 
-  const groupedEntries = Object.entries(_groupBy(results.hits, 'parent.title'));
+  const groupedEntries = Object.entries(_groupBy(_orderBy(results.hits, 'data.title'), 'parent.title'));
 
   return (
     <>

--- a/packages/react-docs/components/InstantSearchRefinementList.jsx
+++ b/packages/react-docs/components/InstantSearchRefinementList.jsx
@@ -8,10 +8,12 @@ import {
   Text,
   useColorMode,
   useColorStyle,
+  useTheme,
 } from '@tonic-ui/react';
 import { ensureArray, ensureString } from 'ensure-type'
 import _groupBy from 'lodash/groupBy';
 import React from 'react';
+import Highlight from 'react-highlight-words';
 import {
   useInstantSearch,
 } from 'react-instantsearch-hooks';
@@ -28,6 +30,7 @@ const InstantSearchRefinementList = (
 ) => {
   const [colorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
+  const { colors } = useTheme();
   const {
     results,
     status, // One of: 'idle', 'loading', 'stalled', 'error'
@@ -135,11 +138,11 @@ const InstantSearchRefinementList = (
         py="2x"
         overflowY="auto"
       >
-        {groupedEntries.map(([group, hits]) => (
-          <>
+        {groupedEntries.map(([groupName, hits]) => (
+          <Box key={groupName}>
             <Box my="2x">
               <Text color={colorStyle.color.secondary}>
-                {group}
+                {groupName}
               </Text>
             </Box>
             {ensureArray(hits).map(hit => (
@@ -152,20 +155,30 @@ const InstantSearchRefinementList = (
                     icon="menu"
                     size="6x"
                   />
-                  <Text>
-                    {hit?.data?.title}
-                  </Text>
+                  <Highlight
+                    searchWords={hit?._highlightResult?.data?.title?.matchedWords}
+                    highlightTag="mark"
+                    textToHighlight={hit?.data?.title}
+                    highlightStyle={{
+                      backgroundColor: '#1E90FF',
+                      color: colors[colorStyle.color.primary],
+                    }}
+                  />
                 </InstantSearchRefinementLink>
                 <Divider my="2x" />
               </Box>
             ))}
-          </>
+          </Box>
         ))}
       </Stack>
-      <Divider />
-      <Flex my="3x" justifyContent="center">
-        <InstantSearchPagination />
-      </Flex>
+      {(results.nbPages > 1) && (
+        <>
+          <Divider />
+          <Flex my="3x" justifyContent="center">
+            <InstantSearchPagination />
+          </Flex>
+        </>
+      )}
     </>
   );
 };

--- a/packages/react-docs/components/InstantSearchRefinementList.jsx
+++ b/packages/react-docs/components/InstantSearchRefinementList.jsx
@@ -1,0 +1,175 @@
+import {
+  Box,
+  Divider,
+  Flex,
+  Icon,
+  Spinner,
+  Stack,
+  Text,
+  useColorMode,
+  useColorStyle,
+} from '@tonic-ui/react';
+import { ensureArray, ensureString } from 'ensure-type'
+import _groupBy from 'lodash/groupBy';
+import React from 'react';
+import {
+  useInstantSearch,
+} from 'react-instantsearch-hooks';
+import InstantSearchRefinementLink from './InstantSearchRefinementLink';
+import InstantSearchPagination from './InstantSearchPagination';
+
+/**
+ * See https://www.algolia.com/doc/api-reference/widgets/use-instantsearch/react-hooks/
+ */
+const InstantSearchRefinementList = (
+  {
+    onClose,
+  }
+) => {
+  const [colorMode] = useColorMode();
+  const [colorStyle] = useColorStyle({ colorMode });
+  const {
+    results,
+    status, // One of: 'idle', 'loading', 'stalled', 'error'
+    error,
+  } = useInstantSearch({ catchError: true });
+  const query = ensureString(results?.query);
+
+  if (status === 'error') {
+    return (
+      <Stack
+        spacing="4x"
+        py="10x"
+      >
+        <Flex
+          justifyContent="center"
+          position="relative"
+          height="10x"
+          mb="4x"
+        >
+          <Box
+            position="absolute"
+            width="10x"
+            height="10x"
+          >
+            <Icon
+              icon="connect-error"
+              size="10x"
+              position="absolute"
+              inset={0}
+            />
+          </Box>
+        </Flex>
+        <Stack spacing="2x">
+          <Text textAlign="center">
+            The search is currently unable to proceed. Please resolve the error and try again.
+          </Text>
+          {error && (
+            <Text textAlign="center">
+              Error: {error.message}
+            </Text>
+          )}
+        </Stack>
+      </Stack>
+    );
+  }
+
+  if ((query.length === 0) && (results.nbHits === 0)) {
+    return (
+      <Flex
+        justifyContent="center"
+        py="10x"
+      >
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  if ((query.length > 0) && (results.nbHits === 0)) {
+    return (
+      <Stack
+        spacing="4x"
+        py="10x"
+      >
+        <Flex
+          justifyContent="center"
+          position="relative"
+          height="10x"
+          mb="4x"
+        >
+          <Box
+            position="absolute"
+            width="10x"
+            height="10x"
+          >
+            <Icon
+              icon="search-o"
+              size="10x"
+              position="absolute"
+              inset={0}
+            />
+            <Icon
+              icon="close-s"
+              size="6x"
+              position="absolute"
+              inset={0}
+              top="1x"
+              left="1x"
+            />
+          </Box>
+        </Flex>
+        <Text textAlign="center">
+          No results found for &quot;{results.query}&quot;
+        </Text>
+      </Stack>
+    );
+  }
+
+  const groupedEntries = Object.entries(_groupBy(results.hits, 'parent.title'));
+
+  return (
+    <>
+      <Stack
+        flex="1" // Take up all available space
+        px="3x"
+        py="2x"
+        overflowY="auto"
+      >
+        {groupedEntries.map(([group, hits]) => (
+          <>
+            <Box my="2x">
+              <Text color={colorStyle.color.secondary}>
+                {group}
+              </Text>
+            </Box>
+            {ensureArray(hits).map(hit => (
+              <Box key={hit.objectID}>
+                <InstantSearchRefinementLink
+                  href={`/${hit.data.path}`}
+                  onClick={onClose}
+                >
+                  <Icon
+                    icon="menu"
+                    size="6x"
+                  />
+                  <Text>
+                    {hit?.data?.title}
+                  </Text>
+                </InstantSearchRefinementLink>
+                <Divider my="2x" />
+              </Box>
+            ))}
+          </>
+        ))}
+      </Stack>
+      <Divider />
+      <Flex my="3x" justifyContent="center">
+        <InstantSearchPagination />
+      </Flex>
+    </>
+  );
+};
+
+InstantSearchRefinementList.displayName = 'InstantSearchRefinementList';
+
+export default InstantSearchRefinementList;

--- a/packages/react-docs/components/Portal/PortalProvider.jsx
+++ b/packages/react-docs/components/Portal/PortalProvider.jsx
@@ -1,0 +1,52 @@
+import { Portal } from '@tonic-ui/react';
+import memoize from 'micro-memoize';
+import React, { useCallback, useState } from 'react';
+import { PortalContext } from './context';
+
+const uniqueId = (() => {
+  let id = 0;
+  return () => {
+    id += 1;
+    return String(id);
+  };
+})();
+
+const getMemoizedState = memoize(state => ({ ...state }));
+
+const PortalProvider = ({
+  children,
+  containerRef: containerRefProp,
+}) => {
+  const [portals, setPortals] = useState([]);
+  const add = useCallback((render, options) => {
+    const id = options?.id ?? uniqueId();
+    const containerRef = options?.containerRef ?? containerRefProp;
+    setPortals((portals) => ([
+      ...portals,
+      { id, containerRef, render },
+    ]));
+    return id;
+  }, []);
+  const remove = useCallback(id => {
+    setPortals(portals => portals.filter(portal => portal.id !== id));
+  }, []);
+  const context = getMemoizedState({ add, remove });
+
+  return (
+    <PortalContext.Provider value={context}>
+      {portals.map(portal => (
+        <Portal
+          key={portal.id}
+          containerRef={portal.containerRef}
+        >
+          {portal.render(() => remove(portal.id))}
+        </Portal>
+      ))}
+      {children}
+    </PortalContext.Provider>
+  );
+};
+
+PortalProvider.displayName = 'PortalProvider';
+
+export default PortalProvider;

--- a/packages/react-docs/components/Portal/context.js
+++ b/packages/react-docs/components/Portal/context.js
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+const PortalContext = createContext();
+
+export {
+  PortalContext,
+};

--- a/packages/react-docs/components/Portal/index.js
+++ b/packages/react-docs/components/Portal/index.js
@@ -1,0 +1,7 @@
+import PortalProvider from './PortalProvider';
+import usePortal from './usePortal';
+
+export {
+  PortalProvider,
+  usePortal,
+};

--- a/packages/react-docs/components/Portal/usePortal.js
+++ b/packages/react-docs/components/Portal/usePortal.js
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { PortalContext } from './context';
+
+const usePortal = () => {
+  const portal = useContext(PortalContext);
+
+  return portal;
+};
+
+export default usePortal;

--- a/packages/react-docs/components/SearchButton.jsx
+++ b/packages/react-docs/components/SearchButton.jsx
@@ -1,0 +1,81 @@
+import {
+  ButtonBase,
+  Flex,
+  Icon,
+  Text,
+  useColorMode,
+  useColorStyle,
+} from '@tonic-ui/react';
+import React, { forwardRef } from 'react';
+
+const SearchButton = forwardRef((
+  {
+    children,
+    ...rest
+  },
+  ref,
+) => {
+  const [colorMode] = useColorMode();
+  const [colorStyle] = useColorStyle({ colorMode });
+  const borderColor = {
+    dark: 'gray:60',
+    light: 'gray:30',
+  }[colorMode];
+  const hoverBorderColor = {
+    dark: 'blue:50',
+    light: 'blue:50',
+  }[colorMode];
+  const focusBorderColor = {
+    dark: 'blue:60',
+    light: 'blue:60',
+  }[colorMode];
+
+  return (
+    <ButtonBase
+      ref={ref}
+      display="flex"
+      alignItems="center"
+      justifyContent="space-between"
+      color={colorStyle.color.primary}
+      border={1}
+      borderColor={borderColor}
+      borderRadius="sm"
+      _focus={{
+        borderColor: focusBorderColor,
+      }}
+      _hover={{
+        borderColor: hoverBorderColor,
+      }}
+      fontSize="sm"
+      lineHeight="sm"
+      px="3x"
+      height="8x"
+      minWidth={{
+        sm: 34,
+        md: 200,
+      }}
+      transition="min-width 0.2s"
+      {...rest}
+    >
+      <Flex
+        alignItems="center"
+        columnGap="2x"
+      >
+        <Icon icon="search-o" />
+        <Text
+          display={{
+            sm: 'none',
+            md: 'block',
+          }}
+          color={colorStyle.color.secondary}
+        >
+          {children}
+        </Text>
+      </Flex>
+    </ButtonBase>
+  );
+});
+
+SearchButton.displayName = 'SearchButton';
+
+export default SearchButton;

--- a/packages/react-docs/components/Sidebar.jsx
+++ b/packages/react-docs/components/Sidebar.jsx
@@ -75,6 +75,7 @@ const Sidebar = forwardRef((
   return (
     <Box
       as="nav"
+      id="sidenav"
       ref={combinedRef}
       backgroundColor={colorStyle.background.primary}
       borderRight={1}
@@ -134,111 +135,118 @@ const Sidebar = forwardRef((
         </Flex>
       </Box>
       <Accordion>
-        {routes.map(({ title, icon, path, routes }) => {
-          const isExpanded = currentPath.startsWith(path);
+        {routes.map(({ title, icon, routes }) => {
+          const defaultIsExpanded = routes.some((route) => currentPath.startsWith(route.path));
 
           return (
             <Box
               key={title}
-              data-path={path}
               mb="4x"
               _lastOfType={{
                 mb: 0,
               }}
             >
               <AccordionItem
-                defaultIsExpanded={isExpanded}
+                defaultIsExpanded={defaultIsExpanded}
               >
-                <AccordionToggle>
-                  <Flex
-                    alignItems="center"
-                    justifyContent="space-between"
-                    px="3x"
-                  >
-                    <Flex
-                      alignItems="center"
-                      columnGap="2x"
+                {({ isExpanded }) => (
+                  <>
+                    <AccordionToggle
+                      // The following data attributes are used by the instant search to toggle and scroll to the correct accordion section
+                      data-expanded={isExpanded}
+                      data-title={title}
                     >
-                      {(typeof icon === 'function')
-                        ? icon({
-                            color: colorStyle?.color?.tertiary,
-                            size: '4x',
-                          })
-                        : <Icon
-                            icon={icon}
-                            color={colorStyle?.color?.tertiary}
-                            size="4x"
-                          />
-                      }
-                      <Text
-                        color={colorStyle?.color?.primary}
-                        fontSize="sm"
-                        lineHeight="sm"
-                      >
-                        {title}
-                      </Text>
-                    </Flex>
-                    <AccordionToggleIcon />
-                  </Flex>
-                </AccordionToggle>
-                <AccordionCollapse
-                  TransitionProps={{
-                    unmountOnExit: true,
-                  }}
-                >
-                  {routes.map(({ heading, title, path, render }) => {
-                    if (heading) {
-                      return (
-                        <Text
-                          key={title}
-                          color={colorStyle?.color?.tertiary}
-                          fontSize="xs"
-                          lineHeight="xs"
-                          pl="9x"
-                          mt="4x"
-                          mb="2x"
-                          textTransform="uppercase"
-                          letterSpacing="0.08rem"
-                          _firstOfType={{
-                            mt: '2x',
-                          }}
-                        >
-                          {title}
-                        </Text>
-                      );
-                    }
-
-                    const isActive = (currentPath === path);
-
-                    return (
-                      <NavLink
-                        key={title}
-                        data-path={path}
-                        isActive={isActive}
-                        href={`/${path}`}
-                        onClick={onClick}
-                        pl={0}
+                      <Flex
+                        alignItems="center"
+                        justifyContent="space-between"
                         px="3x"
                       >
                         <Flex
-                          columnGap="2x"
                           alignItems="center"
-                          justifyContent="space-between"
-                          width="100%"
+                          columnGap="2x"
                         >
+                          {(typeof icon === 'function')
+                            ? icon({
+                                color: colorStyle?.color?.tertiary,
+                                size: '4x',
+                              })
+                            : <Icon
+                                icon={icon}
+                                color={colorStyle?.color?.tertiary}
+                                size="4x"
+                              />
+                          }
                           <Text
+                            color={colorStyle?.color?.primary}
                             fontSize="sm"
                             lineHeight="sm"
-                            pl="9x"
                           >
                             {title}
                           </Text>
-                          {(typeof render === 'function') && render()}
                         </Flex>
-                      </NavLink>
-                    );
-                  })}
-                </AccordionCollapse>
+                        <AccordionToggleIcon />
+                      </Flex>
+                    </AccordionToggle>
+                    <AccordionCollapse
+                      TransitionProps={{
+                        unmountOnExit: true,
+                      }}
+                    >
+                      {routes.map(({ heading, title, path, render }) => {
+                        if (heading) {
+                          return (
+                            <Text
+                              key={title}
+                              color={colorStyle?.color?.tertiary}
+                              fontSize="xs"
+                              lineHeight="xs"
+                              pl="9x"
+                              mt="4x"
+                              mb="2x"
+                              textTransform="uppercase"
+                              letterSpacing="0.08rem"
+                              _firstOfType={{
+                                mt: '2x',
+                              }}
+                            >
+                              {title}
+                            </Text>
+                          );
+                        }
+
+                        const isActive = (currentPath === path);
+
+                        return (
+                          <NavLink
+                            key={title}
+                            data-path={path}
+                            isActive={isActive}
+                            href={`/${path}`}
+                            onClick={onClick}
+                            pl={0}
+                            px="3x"
+                          >
+                            <Flex
+                              columnGap="2x"
+                              alignItems="center"
+                              justifyContent="space-between"
+                              width="100%"
+                            >
+                              <Text
+                                fontSize="sm"
+                                lineHeight="sm"
+                                pl="9x"
+                              >
+                                {title}
+                              </Text>
+                              {(typeof render === 'function') && render()}
+                            </Flex>
+                          </NavLink>
+                        );
+                      })}
+                    </AccordionCollapse>
+                  </>
+                )}
               </AccordionItem>
             </Box>
           );

--- a/packages/react-docs/components/Sidebar.jsx
+++ b/packages/react-docs/components/Sidebar.jsx
@@ -139,7 +139,7 @@ const Sidebar = forwardRef((
 
           return (
             <Box
-              key={path}
+              key={title}
               data-path={path}
               mb="4x"
               _lastOfType={{
@@ -212,7 +212,7 @@ const Sidebar = forwardRef((
 
                     return (
                       <NavLink
-                        key={path}
+                        key={title}
                         data-path={path}
                         isActive={isActive}
                         href={`/${path}`}

--- a/packages/react-docs/next.config.mjs
+++ b/packages/react-docs/next.config.mjs
@@ -27,7 +27,12 @@ plugins.push(withMDX);
 const nextConfig = {
   env: {
     BASE_PATH: process.env.BASE_PATH,
+    // Google Analytics
     GA_TRACKING_ID: 'UA-187145735-1',
+    // Algolia
+    ALGOLIA_APPLICATION_ID: '7V00GBK8V8',
+    ALGOLIA_API_KEY: 'c87cfe40f6ec7c43d4caf4316afd1816',
+    ALGOLIA_INDEX_NAME: 'tonic-ui-v1',
     // see `.circleci/config.yml`
     TONIC_UI_REACT_VERSION: process.env.TONIC_UI_REACT_VERSION,
     // v1

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -67,6 +67,7 @@
     "react-dom": "^16.14.0 || ^17 || ^18",
     "react-focus-lock": "^2.9.2",
     "react-ga": "^3.3.1",
+    "react-highlight-words": "^0.18.0",
     "react-instantsearch-hooks": "^6.38.1",
     "react-live": "^3.1.1",
     "react-movable": "^3.0.4",

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -67,6 +67,7 @@
     "react-dom": "^16.14.0 || ^17 || ^18",
     "react-focus-lock": "^2.9.2",
     "react-ga": "^3.3.1",
+    "react-instantsearch-hooks": "^6.38.1",
     "react-live": "^3.1.1",
     "react-movable": "^3.0.4",
     "react-table": "^7.8.0",

--- a/packages/react-docs/pages/_app.js
+++ b/packages/react-docs/pages/_app.js
@@ -9,17 +9,23 @@ import {
 import {
   useToggle,
 } from '@tonic-ui/react-hooks';
+import algoliasearch from 'algoliasearch/lite';
 import NextApp from 'next/app';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import ReactGA from 'react-ga';
+import { InstantSearch } from 'react-instantsearch-hooks';
 import Content from '../components/Content';
 import GlobalStyles from '../components/GlobalStyles';
 import Header from '../components/Header';
 import MDXComponents from '../components/MDXComponents';
 import Main from '../components/Main';
+import { PortalProvider } from '../components/Portal';
 import Sidebar from '../components/Sidebar';
 import useMediaQuery from '../hooks/useMediaQuery';
+ 
+// Algolia search client
+const searchClient = algoliasearch(process.env.ALGOLIA_APPLICATION_ID, process.env.ALGOLIA_API_KEY);
 
 const pageview = () => {
   ReactGA.set({ page: window.location.pathname });
@@ -69,23 +75,30 @@ const App = (props) => {
   const Page = (router.pathname === '/') ? DefaultPage : DocsPage;
 
   return (
-    <TonicProvider
-      key={initialColorMode} // Force re-render if color mode changes
-      colorMode={{
-        defaultValue: initialColorMode,
-      }}
-      colorStyle={{
-        defaultValue: defaultColorStyle,
-      }}
-      useCSSBaseline
+    <InstantSearch
+      indexName={process.env.ALGOLIA_INDEX_NAME}
+      searchClient={searchClient}
     >
-      <ToastProvider>
-        <MDXProvider components={MDXComponents}>
-          <Page {...props} />
-          <GlobalStyles />
-        </MDXProvider>
-      </ToastProvider>
-    </TonicProvider>
+      <TonicProvider
+        key={initialColorMode} // Force re-render if color mode changes
+        colorMode={{
+          defaultValue: initialColorMode,
+        }}
+        colorStyle={{
+          defaultValue: defaultColorStyle,
+        }}
+        useCSSBaseline
+      >
+        <PortalProvider>
+          <ToastProvider>
+            <MDXProvider components={MDXComponents}>
+              <Page {...props} />
+              <GlobalStyles />
+            </MDXProvider>
+          </ToastProvider>
+        </PortalProvider>
+      </TonicProvider>
+    </InstantSearch>
   );
 };
 

--- a/packages/react-docs/pages/_app.js
+++ b/packages/react-docs/pages/_app.js
@@ -14,7 +14,7 @@ import NextApp from 'next/app';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import ReactGA from 'react-ga';
-import { InstantSearch } from 'react-instantsearch-hooks';
+import { InstantSearch, Configure } from 'react-instantsearch-hooks';
 import Content from '../components/Content';
 import GlobalStyles from '../components/GlobalStyles';
 import Header from '../components/Header';
@@ -79,6 +79,12 @@ const App = (props) => {
       indexName={process.env.ALGOLIA_INDEX_NAME}
       searchClient={searchClient}
     >
+      <Configure
+        // https://www.algolia.com/doc/api-reference/search-api-parameters/
+        hitsPerPage={1000}
+        highlightPreTag="<mark>"
+        highlightPostTag="</mark>"
+      />
       <TonicProvider
         key={initialColorMode} // Force re-render if color mode changes
         colorMode={{

--- a/packages/react-docs/pages/index.js
+++ b/packages/react-docs/pages/index.js
@@ -41,10 +41,13 @@ import {
 } from '@tonic-ui/react';
 import { ensureString } from 'ensure-type';
 import NextLink from 'next/link';
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef, useCallback, useEffect } from 'react';
 import pkg from '../../../package.json';
 import persistColorMode from '../utils/persist-color-mode';
 import FontAwesomeIcon from '../components/FontAwesomeIcon';
+import InstantSearchModal from '../components/InstantSearchModal';
+import { usePortal } from '../components/Portal';
+import SearchButton from '../components/SearchButton';
 import SkeletonBody from '../components/SkeletonBody';
 
 const BASE_PATH = ensureString(process.env.BASE_PATH);
@@ -76,7 +79,7 @@ const DefaultPage = (props) => {
       height="100vh"
       {...props}
     >
-      <Header />
+      <DefaultPageHeader />
       <Box
         maxWidth={{
           lg: '1024px',
@@ -357,7 +360,8 @@ const DefaultPage = (props) => {
   );
 };
 
-const Header = forwardRef((props, ref) => {
+const DefaultPageHeader = forwardRef((props, ref) => {
+  const portal = usePortal();
   const [colorMode, toggleColorMode] = useColorMode();
   const [colorStyle] = useColorStyle({ colorMode });
   const logo = {
@@ -368,6 +372,12 @@ const Header = forwardRef((props, ref) => {
     light: 'rgba(0, 0, 0, 0.12)',
     dark: 'rgba(255, 255, 255, 0.12)',
   }[colorMode];
+
+  const openInstantSearchModal = useCallback(() => {
+    portal.add((callback) => (
+      <InstantSearchModal onClose={callback} />
+    ));
+  }, [portal]);
 
   useEffect(() => {
     persistColorMode(colorMode);
@@ -434,6 +444,9 @@ const Header = forwardRef((props, ref) => {
           columnGap="4x"
           px="4x"
         >
+          <SearchButton onClick={openInstantSearchModal}>
+            Search...
+          </SearchButton>
           <Box
             as="a"
             color={colorStyle.color.secondary}
@@ -482,7 +495,7 @@ const Header = forwardRef((props, ref) => {
     </Box>
   );
 });
-Header.displayName = 'Header';
+DefaultPageHeader.displayName = 'DefaultPageHeader';
 
 const Round = (props) => {
   const [colorMode] = useColorMode();

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,6 +92,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/events@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@algolia/events@npm:4.0.1"
+  checksum: 4f63943f4554cfcfed91d8b8c009a49dca192b81056d8c75e532796f64828cd69899852013e81ff3fff07030df8782b9b95c19a3da0845786bdfe22af42442c2
+  languageName: node
+  linkType: hard
+
 "@algolia/logger-common@npm:4.14.2":
   version: 4.14.2
   resolution: "@algolia/logger-common@npm:4.14.2"
@@ -141,6 +148,23 @@ __metadata:
     "@algolia/logger-common": 4.14.2
     "@algolia/requester-common": 4.14.2
   checksum: 72c72013f3edb4d4484e7a43fb3c2555646ab04f422249514ed0309e20f41f5563f4c4dcf5623ca64c293624ecc74f87acaf2d9820e8c829cb5de067bdfe0257
+  languageName: node
+  linkType: hard
+
+"@algolia/ui-components-highlight-vdom@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@algolia/ui-components-highlight-vdom@npm:1.2.1"
+  dependencies:
+    "@algolia/ui-components-shared": 1.2.1
+    "@babel/runtime": ^7.0.0
+  checksum: d06721372406678d7d3dcbc75894ff727994e7f71d9d53a0c7b94705d694826977082b4ae2cd1bd847a271661d2b6921ba9ffed26401289d06b1c609415b7e74
+  languageName: node
+  linkType: hard
+
+"@algolia/ui-components-shared@npm:1.2.1, @algolia/ui-components-shared@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@algolia/ui-components-shared@npm:1.2.1"
+  checksum: e0e7c06fbfc855c24283446a903adff3e4523c9a1652cfb187f3d701278d246f9ef23b7d80c0ec9e933f9a835d0a2227906f6e92b4fca5e315e89abcf8049b2f
   languageName: node
   linkType: hard
 
@@ -1701,7 +1725,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.20.6
   resolution: "@babel/runtime@npm:7.20.6"
   dependencies:
@@ -2229,13 +2253,13 @@ __metadata:
   linkType: hard
 
 "@humanwhocodes/config-array@npm:^0.11.6":
-  version: 0.11.7
-  resolution: "@humanwhocodes/config-array@npm:0.11.7"
+  version: 0.11.8
+  resolution: "@humanwhocodes/config-array@npm:0.11.8"
   dependencies:
     "@humanwhocodes/object-schema": ^1.2.1
     debug: ^4.1.1
     minimatch: ^3.0.5
-  checksum: cf506dc45d9488af7fbf108ea6ac2151ba1a25e6d2b94b9b4fc36d2c1e4099b89ff560296dbfa13947e44604d4ca4a90d97a4fb167370bf8dd01a6ca2b6d83ac
+  checksum: 0fd6b3c54f1674ce0a224df09b9c2f9846d20b9e54fabae1281ecfc04f2e6ad69bf19e1d6af6a28f88e8aa3990168b6cb9e1ef755868c3256a630605ec2cb1d3
   languageName: node
   linkType: hard
 
@@ -3384,20 +3408,20 @@ __metadata:
   linkType: hard
 
 "@mdx-js/loader@npm:^2.1.2":
-  version: 2.1.5
-  resolution: "@mdx-js/loader@npm:2.1.5"
+  version: 2.2.1
+  resolution: "@mdx-js/loader@npm:2.2.1"
   dependencies:
     "@mdx-js/mdx": ^2.0.0
     source-map: ^0.7.0
   peerDependencies:
     webpack: ">=4"
-  checksum: a4108e5ba8075a7369d0279e8bee09dcee4483474e7a621a805fc4e3af53b79b5b59219dc78249a8c97906b15a1e47b036626725697d8cf227c849fafaf7d3d1
+  checksum: b2659c5095af072ee341264b127407bbebbba8fd51885f610fe9aeefc15450a6bbcaee3eec34adcfa92e4fe208c7ac2a0ff2fa6aff75485aa9903b4adf521590
   languageName: node
   linkType: hard
 
 "@mdx-js/mdx@npm:^2.0.0, @mdx-js/mdx@npm:^2.1.2":
-  version: 2.1.5
-  resolution: "@mdx-js/mdx@npm:2.1.5"
+  version: 2.2.1
+  resolution: "@mdx-js/mdx@npm:2.2.1"
   dependencies:
     "@types/estree-jsx": ^1.0.0
     "@types/mdx": ^2.0.0
@@ -3416,26 +3440,26 @@ __metadata:
     unist-util-stringify-position: ^3.0.0
     unist-util-visit: ^4.0.0
     vfile: ^5.0.0
-  checksum: 51b8b40aafbbeee618fd289ef6e0311e28e2598c514016aefb094237fa9cdf3e1c1407267a08dc7f8da9673de354b5b946f3ceb7ba5735bdf869d18c2a49117d
+  checksum: 3985e37a22af541ee3840020b74a804409ff49f8b307ee607feb889b159f4e3d526141fb2725a753d31acce945250d814eac96b8d923bb47ddb46296ffeb5348
   languageName: node
   linkType: hard
 
 "@mdx-js/react@npm:^2.1.2":
-  version: 2.1.5
-  resolution: "@mdx-js/react@npm:2.1.5"
+  version: 2.2.1
+  resolution: "@mdx-js/react@npm:2.2.1"
   dependencies:
     "@types/mdx": ^2.0.0
     "@types/react": ">=16"
   peerDependencies:
     react: ">=16"
-  checksum: e47fb7086a4dd3e4d75d9ef0bf530009f72437a5ea91048e65d2e2f53955015a8c81b5058ac56fa00f401843305518e9f298183645d56c7e34336df4cc0b62bf
+  checksum: 4462dad1d7d658bda1c2eabc3960fb843fdbcb5788ce5f863b674752e4db1b7048b5587aa85661283b5196e4641385e6b594205c2482202446ecb5f5433c975b
   languageName: node
   linkType: hard
 
-"@next/env@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/env@npm:13.0.6"
-  checksum: 89ca41c63d720128164ec19eb0a8cf95ad7dbfdc4bc153e027eb0e95a774c5e19563c5649ae2d06304ddfee70c0aec94e2a8e7c72e9172a41560c492db1e13bd
+"@next/env@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/env@npm:13.0.7"
+  checksum: d2c5914eefa8a5cbda14239c0899aa30f7413901d03758b9ee857ef9f1c6399d79664b9f8a824bbcb2bba9ef6c60c5d2eeac5d795fd2cb8587bc2e8a8a0405e3
   languageName: node
   linkType: hard
 
@@ -3449,104 +3473,104 @@ __metadata:
   linkType: hard
 
 "@next/mdx@npm:^13.0.5":
-  version: 13.0.6
-  resolution: "@next/mdx@npm:13.0.6"
+  version: 13.0.7
+  resolution: "@next/mdx@npm:13.0.7"
   dependencies:
     source-map: ^0.7.0
   peerDependencies:
     "@mdx-js/loader": ">=0.15.0"
     "@mdx-js/react": "*"
-  checksum: 511a9a8807bf4a611f38d50b5abf682718ff02aabbc33f48f59984aa67cb9cc183142fcbbb847307c2ffab8c2d073fe7f9b68086a2d80efc2bd744b9e1514dc9
+  checksum: 8fd0c447608df184c09500d9afd53ff45af6e52e5c4b0f5aa5a401f41ebc6eb34f09f34c2b4e0bd3479ec9e727473b2bc39c30cb038501c43f19db5c645ee850
   languageName: node
   linkType: hard
 
-"@next/swc-android-arm-eabi@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-android-arm-eabi@npm:13.0.6"
+"@next/swc-android-arm-eabi@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-android-arm-eabi@npm:13.0.7"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@next/swc-android-arm64@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-android-arm64@npm:13.0.6"
+"@next/swc-android-arm64@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-android-arm64@npm:13.0.7"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-darwin-arm64@npm:13.0.6"
+"@next/swc-darwin-arm64@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-darwin-arm64@npm:13.0.7"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-darwin-x64@npm:13.0.6"
+"@next/swc-darwin-x64@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-darwin-x64@npm:13.0.7"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-freebsd-x64@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-freebsd-x64@npm:13.0.6"
+"@next/swc-freebsd-x64@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-freebsd-x64@npm:13.0.7"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm-gnueabihf@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-linux-arm-gnueabihf@npm:13.0.6"
+"@next/swc-linux-arm-gnueabihf@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-linux-arm-gnueabihf@npm:13.0.7"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-linux-arm64-gnu@npm:13.0.6"
+"@next/swc-linux-arm64-gnu@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-linux-arm64-gnu@npm:13.0.7"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-linux-arm64-musl@npm:13.0.6"
+"@next/swc-linux-arm64-musl@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-linux-arm64-musl@npm:13.0.7"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-linux-x64-gnu@npm:13.0.6"
+"@next/swc-linux-x64-gnu@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-linux-x64-gnu@npm:13.0.7"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-linux-x64-musl@npm:13.0.6"
+"@next/swc-linux-x64-musl@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-linux-x64-musl@npm:13.0.7"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-win32-arm64-msvc@npm:13.0.6"
+"@next/swc-win32-arm64-msvc@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-win32-arm64-msvc@npm:13.0.7"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-ia32-msvc@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-win32-ia32-msvc@npm:13.0.6"
+"@next/swc-win32-ia32-msvc@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-win32-ia32-msvc@npm:13.0.7"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:13.0.6":
-  version: 13.0.6
-  resolution: "@next/swc-win32-x64-msvc@npm:13.0.6"
+"@next/swc-win32-x64-msvc@npm:13.0.7":
+  version: 13.0.7
+  resolution: "@next/swc-win32-x64-msvc@npm:13.0.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4188,6 +4212,7 @@ __metadata:
     react-dom: ^16.14.0 || ^17 || ^18
     react-focus-lock: ^2.9.2
     react-ga: ^3.3.1
+    react-instantsearch-hooks: ^6.38.1
     react-live: ^3.1.1
     react-movable: ^3.0.4
     react-table: ^7.8.0
@@ -4577,6 +4602,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/google.maps@npm:^3.45.3":
+  version: 3.51.0
+  resolution: "@types/google.maps@npm:3.51.0"
+  checksum: fb2dbf823814a6380e6b32abfabc30eed72166f0a08f107a0adbd84ad868ea751f826651af91cf745082cefd59813bac26ab757a1fe938633e7404d4df742ae8
+  languageName: node
+  linkType: hard
+
 "@types/graceful-fs@npm:^4.1.3":
   version: 4.1.5
   resolution: "@types/graceful-fs@npm:4.1.5"
@@ -4592,6 +4624,13 @@ __metadata:
   dependencies:
     "@types/unist": "*"
   checksum: fff47998f4c11e21a7454b58673f70478740ecdafd95aaf50b70a3daa7da9cdc57315545bf9c039613732c40b7b0e9e49d11d03fe9a4304721cdc3b29a88141e
+  languageName: node
+  linkType: hard
+
+"@types/hogan.js@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "@types/hogan.js@npm:3.0.1"
+  checksum: 93b6a7b31a8905f6bb5cedd95c6fc8db85b07efcb7ef840b3e610108be4ded504c575f68882f0cec1f37db880eabdbdcdf70cbd0039f5c783c751782f2adc897
   languageName: node
   linkType: hard
 
@@ -4734,6 +4773,13 @@ __metadata:
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
   checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
+  languageName: node
+  linkType: hard
+
+"@types/qs@npm:^6.5.3":
+  version: 6.9.7
+  resolution: "@types/qs@npm:6.9.7"
+  checksum: 7fd6f9c25053e9b5bb6bc9f9f76c1d89e6c04f7707a7ba0e44cc01f17ef5284adb82f230f542c2d5557d69407c9a40f0f3515e8319afd14e1e16b5543ac6cdba
   languageName: node
   linkType: hard
 
@@ -5051,6 +5097,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"algoliasearch-helper@npm:^3.11.1":
+  version: 3.11.1
+  resolution: "algoliasearch-helper@npm:3.11.1"
+  dependencies:
+    "@algolia/events": ^4.0.1
+  peerDependencies:
+    algoliasearch: ">= 3.1 < 6"
+  checksum: 207616ca4549e2d06a278357ce478951a37c606f40f5b39b8e2d13bba143023a10814f065cd89629e5f2c121935d61a97d96bfb687ae7a98ef25b63da37fcf70
+  languageName: node
+  linkType: hard
+
 "algoliasearch@npm:^4.14.2":
   version: 4.14.2
   resolution: "algoliasearch@npm:4.14.2"
@@ -5361,9 +5418,9 @@ __metadata:
   linkType: hard
 
 "axe-core@npm:^4.4.3":
-  version: 4.6.0
-  resolution: "axe-core@npm:4.6.0"
-  checksum: ed112f76bbb2e2ab52dda623fc4baf882b2d00045a55b2cc15358e891f7f164d674be1a2fbcfd49e11d064b146c387c5c9c3c29d7d59c9de6c22c65b86eb68ac
+  version: 4.6.1
+  resolution: "axe-core@npm:4.6.1"
+  checksum: a376c9e29499711d67219b9f9b5e97bcf9d8e4cd11316e4d68807054a1eae5054d93ccb37785851c0db64e54d132586ded807d18fb206c668138b53c6ae24d4d
   languageName: node
   linkType: hard
 
@@ -8368,6 +8425,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hogan.js@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "hogan.js@npm:3.0.2"
+  dependencies:
+    mkdirp: 0.3.0
+    nopt: 1.0.10
+  bin:
+    hulk: ./bin/hulk
+  checksum: c7bbff84faa9ca265c39f4a2100546ba0388fcc9c5bac8526f488592ce3fcaa042eba6ac25db277f4478ec3855b9bc28ce59acffbf6e8a28d45a17df7590c6aa
+  languageName: node
+  linkType: hard
+
 "hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
@@ -8417,6 +8486,13 @@ __metadata:
   dependencies:
     lru-cache: ^7.5.1
   checksum: fa35df185224adfd69141f3b2f8cc31f50e705a5ebb415ccfbfd055c5b94bd08d3e658edf1edad9e2ac7d81831ac7cf261f5d219b3adc8d744fb8cdacaaf2ead
+  languageName: node
+  linkType: hard
+
+"htm@npm:^3.0.0":
+  version: 3.1.1
+  resolution: "htm@npm:3.1.1"
+  checksum: 1827a0cafffcff69690b048a4df59944086d7503fe5eb7c10b40834439205bdf992941e7aa25e92b3c2c086170565b4ed7c365bc072d31067c6e7a4e478776bd
   languageName: node
   linkType: hard
 
@@ -8653,6 +8729,28 @@ __metadata:
     through: ^2.3.6
     wrap-ansi: ^7.0.0
   checksum: f13ee4c444187786fb393609dedf6b30870115a57b603f2e6424f29a99abc13446fd45ee22461c33c9c40a92a60a8df62d0d6b25d74fc6676fa4cb211de55b55
+  languageName: node
+  linkType: hard
+
+"instantsearch.js@npm:^4.47.0":
+  version: 4.49.2
+  resolution: "instantsearch.js@npm:4.49.2"
+  dependencies:
+    "@algolia/events": ^4.0.1
+    "@algolia/ui-components-highlight-vdom": ^1.2.1
+    "@algolia/ui-components-shared": ^1.2.1
+    "@types/google.maps": ^3.45.3
+    "@types/hogan.js": ^3.0.0
+    "@types/qs": ^6.5.3
+    algoliasearch-helper: ^3.11.1
+    hogan.js: ^3.0.2
+    htm: ^3.0.0
+    preact: ^10.10.0
+    qs: ^6.5.1 < 6.10
+    search-insights: ^2.1.0
+  peerDependencies:
+    algoliasearch: ">= 3.1 < 6"
+  checksum: 7f91bbef19a393a4142837d3a63e5e1da9014510851a70c40bce61e1a5158bde96d5a2b07665d860fd319b7779a3482b718311c18ee89949d3e0fe1235e310d9
   languageName: node
   linkType: hard
 
@@ -9957,11 +10055,11 @@ __metadata:
   linkType: hard
 
 "language-tags@npm:^1.0.5":
-  version: 1.0.6
-  resolution: "language-tags@npm:1.0.6"
+  version: 1.0.7
+  resolution: "language-tags@npm:1.0.7"
   dependencies:
     language-subtag-registry: ^0.3.20
-  checksum: dc2927f7ce8f108ffd1d02ae0284b78ff6b4e03e631642794fa79d554d77b653f3f64cd1fb83acc9f3746ef7c18d43241b97feb712c05cc26e25aacd68f7a006
+  checksum: 2f1ca8ffe4e549893817456ca1974dbff0f3cc8aea4e123e666dc6df85f3cf2d828b8143084388a7e2bec15fac77b7194151e43b5b32e63526dafe17a08a9fd0
   languageName: node
   linkType: hard
 
@@ -11261,6 +11359,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mkdirp@npm:0.3.0":
+  version: 0.3.0
+  resolution: "mkdirp@npm:0.3.0"
+  checksum: 3ec9cda8bd89b64892728e5092bc79e88382e444d4bbde040c2fb8d7034dc70682cfdd729e93241fd5243d2397324c420ef68c717d806db51bf96c0fc80f4b1d
+  languageName: node
+  linkType: hard
+
 "mkdirp@npm:^1.0.3, mkdirp@npm:^1.0.4":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
@@ -11374,23 +11479,23 @@ __metadata:
   linkType: hard
 
 "next@npm:^13.0.5":
-  version: 13.0.6
-  resolution: "next@npm:13.0.6"
+  version: 13.0.7
+  resolution: "next@npm:13.0.7"
   dependencies:
-    "@next/env": 13.0.6
-    "@next/swc-android-arm-eabi": 13.0.6
-    "@next/swc-android-arm64": 13.0.6
-    "@next/swc-darwin-arm64": 13.0.6
-    "@next/swc-darwin-x64": 13.0.6
-    "@next/swc-freebsd-x64": 13.0.6
-    "@next/swc-linux-arm-gnueabihf": 13.0.6
-    "@next/swc-linux-arm64-gnu": 13.0.6
-    "@next/swc-linux-arm64-musl": 13.0.6
-    "@next/swc-linux-x64-gnu": 13.0.6
-    "@next/swc-linux-x64-musl": 13.0.6
-    "@next/swc-win32-arm64-msvc": 13.0.6
-    "@next/swc-win32-ia32-msvc": 13.0.6
-    "@next/swc-win32-x64-msvc": 13.0.6
+    "@next/env": 13.0.7
+    "@next/swc-android-arm-eabi": 13.0.7
+    "@next/swc-android-arm64": 13.0.7
+    "@next/swc-darwin-arm64": 13.0.7
+    "@next/swc-darwin-x64": 13.0.7
+    "@next/swc-freebsd-x64": 13.0.7
+    "@next/swc-linux-arm-gnueabihf": 13.0.7
+    "@next/swc-linux-arm64-gnu": 13.0.7
+    "@next/swc-linux-arm64-musl": 13.0.7
+    "@next/swc-linux-x64-gnu": 13.0.7
+    "@next/swc-linux-x64-musl": 13.0.7
+    "@next/swc-win32-arm64-msvc": 13.0.7
+    "@next/swc-win32-ia32-msvc": 13.0.7
+    "@next/swc-win32-x64-msvc": 13.0.7
     "@swc/helpers": 0.4.14
     caniuse-lite: ^1.0.30001406
     postcss: 8.4.14
@@ -11437,7 +11542,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 2de1d9975f90ba67b4fb0ca6ec16d91eff3f7e05cea218cf2abb214c28cf8969b4fa7e81df23fe2025bceda676dda2db90e873f0909b17df1d395f6a275a2715
+  checksum: de001a674ccf1d1c9812e9b775128581582cfec08efe9eabe00ce467fb063f2d04645b03f094e485f458481e65161a3d184874e8994052322b458b99b683c6ad
   languageName: node
   linkType: hard
 
@@ -11525,6 +11630,17 @@ __metadata:
   version: 2.0.7
   resolution: "node-releases@npm:2.0.7"
   checksum: d1c5af091d788b7f9dfce5aa77cbf76c28e8e326b891fe64a05b96943a90cd6ba19eae94ef32777c23f5898a7b00d9cf8266adba33d61ebe6611cca74ccfc0b1
+  languageName: node
+  linkType: hard
+
+"nopt@npm:1.0.10":
+  version: 1.0.10
+  resolution: "nopt@npm:1.0.10"
+  dependencies:
+    abbrev: 1
+  bin:
+    nopt: ./bin/nopt.js
+  checksum: f62575aceaa3be43f365bf37a596b89bbac2e796b001b6d2e2a85c2140a4e378ff919e2753ccba959c4fd344776fc88c29b393bc167fa939fb1513f126f4cd45
   languageName: node
   linkType: hard
 
@@ -12389,6 +12505,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"preact@npm:^10.10.0":
+  version: 10.11.3
+  resolution: "preact@npm:10.11.3"
+  checksum: 9387115aa0581e8226309e6456e9856f17dfc0e3d3e63f774de80f3d462a882ba7c60914c05942cb51d51e23e120dcfe904b8d392d46f29ad15802941fe7a367
+  languageName: node
+  linkType: hard
+
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -12558,6 +12681,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.5.1 < 6.10":
+  version: 6.9.7
+  resolution: "qs@npm:6.9.7"
+  checksum: 5bbd263332ccf320a1f36d04a2019a5834dc20bcb736431eaccde2a39dcba03fb26d2fd00174f5d7bc26aaad1cad86124b18440883ac042ea2a0fca6170c1bf1
+  languageName: node
+  linkType: hard
+
 "querystringify@npm:^2.1.1":
   version: 2.2.0
   resolution: "querystringify@npm:2.2.0"
@@ -12695,6 +12825,21 @@ __metadata:
     prop-types: ^15.6.0
     react: ^15.6.2 || ^16.0 || ^17 || ^18
   checksum: 3026976d0249fbf80e7b5dad7707964198064d7ac460f3397de40524e76dd6c29dead0900f850e2bd3135a86a9b083af8cda9cfa087f195852bf8d2b17c1fcfb
+  languageName: node
+  linkType: hard
+
+"react-instantsearch-hooks@npm:^6.38.1":
+  version: 6.38.1
+  resolution: "react-instantsearch-hooks@npm:6.38.1"
+  dependencies:
+    "@babel/runtime": ^7.1.2
+    algoliasearch-helper: ^3.11.1
+    instantsearch.js: ^4.47.0
+    use-sync-external-store: ^1.0.0
+  peerDependencies:
+    algoliasearch: ">= 3.1 < 5"
+    react: ">= 16.8.0 < 19"
+  checksum: 81b06743f374f8ed26c93ac2489a6fd803c4c101fdc44ce278807150bd46c9dc6002d8034ad081f486c450121c0a83477e998684fca2cf806a00730229588e87
   languageName: node
   linkType: hard
 
@@ -13158,12 +13303,12 @@ __metadata:
   linkType: hard
 
 "remark-mdx@npm:^2.0.0":
-  version: 2.1.5
-  resolution: "remark-mdx@npm:2.1.5"
+  version: 2.2.1
+  resolution: "remark-mdx@npm:2.2.1"
   dependencies:
     mdast-util-mdx: ^2.0.0
     micromark-extension-mdxjs: ^1.0.0
-  checksum: a5b2ccaa2bdb9d236e418e4b1868539b3dc4f8df0476b5574c9beb0cc8cf8a09573fa91aeb24f56a5c3bb4ed00d9b6db6afe36a53450985fdbdcf9736bed115b
+  checksum: 2e4488cd81fc2186dc0b079455c03b4e50cfd32d7a2a3f8f59d7ccb5d77ce9cab595f83f105fbf9e9a7e20a63a95ac2ef8e29c75d4c79bd78b1ace79e88b4c45
   languageName: node
   linkType: hard
 
@@ -13432,6 +13577,13 @@ __metadata:
   dependencies:
     loose-envify: ^1.1.0
   checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
+  languageName: node
+  linkType: hard
+
+"search-insights@npm:^2.1.0":
+  version: 2.2.3
+  resolution: "search-insights@npm:2.2.3"
+  checksum: cf828b5677ff2108963965cc55a23ea2e751a55eabdcb0a1ef575a9b3b148510c0a6f29805e649eb99638d016dcdf3ff4274e62f0b993d05a13fe243e1c8fea8
   languageName: node
   linkType: hard
 
@@ -14686,6 +14838,15 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 925d1922f9853e516eaad526b6fed1be38008073067274f0ecc3f56b17bb8ab63480140dd7c271f94150027c996cea4efe83d3e3525e8f3eda22055f6a39220b
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "use-sync-external-store@npm:1.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 5c639e0f8da3521d605f59ce5be9e094ca772bd44a4ce7322b055a6f58eeed8dda3c94cabd90c7a41fb6fa852210092008afe48f7038792fd47501f33299116a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4212,6 +4212,7 @@ __metadata:
     react-dom: ^16.14.0 || ^17 || ^18
     react-focus-lock: ^2.9.2
     react-ga: ^3.3.1
+    react-highlight-words: ^0.18.0
     react-instantsearch-hooks: ^6.38.1
     react-live: ^3.1.1
     react-movable: ^3.0.4
@@ -8425,6 +8426,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"highlight-words-core@npm:^1.2.0":
+  version: 1.2.2
+  resolution: "highlight-words-core@npm:1.2.2"
+  checksum: 737758a8a572c82919552b031df300016164b7d0db6a819d24bc6c7ca2279d3cd6d03497728930d6402423c7a3fc2f42c628a9b01b025c704a0b56a635377511
+  languageName: node
+  linkType: hard
+
 "hogan.js@npm:^3.0.2":
   version: 3.0.2
   resolution: "hogan.js@npm:3.0.2"
@@ -9960,11 +9968,11 @@ __metadata:
   linkType: hard
 
 "json5@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "json5@npm:2.2.1"
+  version: 2.2.2
+  resolution: "json5@npm:2.2.2"
   bin:
     json5: lib/cli.js
-  checksum: 74b8a23b102a6f2bf2d224797ae553a75488b5adbaee9c9b6e5ab8b510a2fc6e38f876d4c77dea672d4014a44b2399e15f2051ac2b37b87f74c0c7602003543b
+  checksum: 9a878d66b72157b073cf0017f3e5d93ec209fa5943abcb38d37a54b208917c166bd473c26a24695e67a016ce65759aeb89946592991f8f9174fb96c8e2492683
   languageName: node
   linkType: hard
 
@@ -10669,6 +10677,13 @@ __metadata:
   version: 3.1.0
   resolution: "mdast-util-to-string@npm:3.1.0"
   checksum: f42ddd4e22f2215a75715b92ea6e3149c4ba356e7781d7b94fc86ded1c79cec3f986afeecef3a4a80068c9b224a6520099783a12146b957de24f020a3e47dd29
+  languageName: node
+  linkType: hard
+
+"memoize-one@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "memoize-one@npm:4.0.3"
+  checksum: addd18c046542f57440ba70bf8ebd48663d17626cade681f777522ef70900a87ec72c5041bed8ece4f6d40a2cb58803bae388b50a4b740d64f36bcda20c147b7
   languageName: node
   linkType: hard
 
@@ -12621,7 +12636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:15.x, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:15.x, prop-types@npm:^15.5.8, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -12825,6 +12840,19 @@ __metadata:
     prop-types: ^15.6.0
     react: ^15.6.2 || ^16.0 || ^17 || ^18
   checksum: 3026976d0249fbf80e7b5dad7707964198064d7ac460f3397de40524e76dd6c29dead0900f850e2bd3135a86a9b083af8cda9cfa087f195852bf8d2b17c1fcfb
+  languageName: node
+  linkType: hard
+
+"react-highlight-words@npm:^0.18.0":
+  version: 0.18.0
+  resolution: "react-highlight-words@npm:0.18.0"
+  dependencies:
+    highlight-words-core: ^1.2.0
+    memoize-one: ^4.0.0
+    prop-types: ^15.5.8
+  peerDependencies:
+    react: ^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+  checksum: ff9759e7ebeb140067854d8cad3021123ba0e3b78bda14d35d9b21dd7890986c858955885ddbcb537e9f88472aebe4a23a1841b7af190989efb0a8ecf7dc2a57
   languageName: node
   linkType: hard
 
@@ -13513,11 +13541,11 @@ __metadata:
   linkType: hard
 
 "rxjs@npm:^7.5.5":
-  version: 7.6.0
-  resolution: "rxjs@npm:7.6.0"
+  version: 7.8.0
+  resolution: "rxjs@npm:7.8.0"
   dependencies:
     tslib: ^2.1.0
-  checksum: b3abbbfe1ddfd06fca9314b83cbd13bcddc3320429218136f75c79a4802ac430dd13873364aac1ded54fd457f8c77df332d205a92d8a1c61656565bb718c50af
+  checksum: 61b4d4fd323c1043d8d6ceb91f24183b28bcf5def4f01ca111511d5c6b66755bc5578587fe714ef5d67cf4c9f2e26f4490d4e1d8cabf9bd5967687835e9866a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-659/

## Todos
- [x] When a user selects a refinement, expand the side menu and set the selected menu item.
- [x] When pagination is used, group similar results together.
- [x] If there is only one page of results, hide the pagination controls.
- [x] Highlight the search terms in the search results (e.g. `highlightPreTag=<mark>`, `highlightPostTag=</mark>`)
- [x] Sort in ascending order

## Screenshots

### Initial loading
![tw-cheton-debian11_3000_components (2)](https://user-images.githubusercontent.com/447801/208005964-206f100f-7828-40fb-9cf1-1a38a0a4b34d.png)

### Encountered an error
![tw-cheton-debian11_3000_components](https://user-images.githubusercontent.com/447801/208004961-ab0917f0-e80c-4f0c-bf57-7758bff17159.png)

### Display search results

Pagination is used

![tw-cheton-debian11_3000_components_tag (1)](https://user-images.githubusercontent.com/447801/208008263-75df632b-bbd7-4a86-9d0d-22fccf01a360.png)

Single page

![tw-cheton-debian11_3000_](https://user-images.githubusercontent.com/447801/208048647-67aa5275-8fdb-41ac-9498-0324bb4926f6.png)

Hover over an item

![tw-cheton-debian11_3000_ (1)](https://user-images.githubusercontent.com/447801/208048754-c3619c1a-8fd0-4d09-9e82-f1299f9cc2c1.png)