### PR TITLE
feat: add `scrollMarginBlock` and `scrollMarginInline` style props

### DIFF
--- a/packages/styled-system/src/config/__tests__/scroll.test.js
+++ b/packages/styled-system/src/config/__tests__/scroll.test.js
@@ -3,7 +3,13 @@ import scroll from '../scroll';
 test('returns style objects', () => {
   const styles = scroll({
     scrollBehavior: 'smooth',
-    scrollMargin: '0 0',
+    scrollMargin: '1em 0.5em 1em 1em',
+    scrollMarginBlock: '1em 0.5em',
+    scrollMarginBlockEnd: '1em',
+    scrollMarginBlockStart: '1em',
+    scrollMarginInline: '1em 0.5em',
+    scrollMarginInlineEnd: '1em',
+    scrollMarginInlineStart: '1em',
     scrollMarginTop: 0,
     scrollMarginRight: 0,
     scrollMarginBottom: 0,
@@ -14,11 +20,18 @@ test('returns style objects', () => {
     scrollPaddingBottom: '12px',
     scrollPaddingLeft: '16px',
     scrollSnapAlign: 'start',
+    scrollSnapStop: 'normal',
     scrollSnapType: 'x mandatory',
   });
   expect(styles).toEqual({
     scrollBehavior: 'smooth',
-    scrollMargin: '0 0',
+    scrollMargin: '1em 0.5em 1em 1em',
+    scrollMarginBlock: '1em 0.5em',
+    scrollMarginBlockEnd: '1em',
+    scrollMarginBlockStart: '1em',
+    scrollMarginInline: '1em 0.5em',
+    scrollMarginInlineEnd: '1em',
+    scrollMarginInlineStart: '1em',
     scrollMarginTop: 0,
     scrollMarginRight: 0,
     scrollMarginBottom: 0,
@@ -29,6 +42,7 @@ test('returns style objects', () => {
     scrollPaddingBottom: '12px',
     scrollPaddingLeft: '16px',
     scrollSnapAlign: 'start',
+    scrollSnapStop: 'normal',
     scrollSnapType: 'x mandatory',
   });
 });

--- a/packages/styled-system/src/config/scroll.js
+++ b/packages/styled-system/src/config/scroll.js
@@ -9,6 +9,36 @@ const config = {
     scale: 'space',
     transform: positiveOrNegativeTransform, // multi-value
   },
+  scrollMarginBlock: {
+    property: 'scrollMarginBlock',
+    scale: 'space',
+    transform: positiveOrNegativeTransform, // multi-value
+  },
+  scrollMarginBlockEnd: {
+    property: 'scrollMarginBlockEnd',
+    scale: 'space',
+    transform: positiveOrNegativeTransform,
+  },
+  scrollMarginBlockStart: {
+    property: 'scrollMarginBlockStart',
+    scale: 'space',
+    transform: positiveOrNegativeTransform,
+  },
+  scrollMarginInline: {
+    property: 'scrollMarginInline',
+    scale: 'space',
+    transform: positiveOrNegativeTransform, // multi-value
+  },
+  scrollMarginInlineEnd: {
+    property: 'scrollMarginInlineEnd',
+    scale: 'space',
+    transform: positiveOrNegativeTransform,
+  },
+  scrollMarginInlineStart: {
+    property: 'scrollMarginInlineStart',
+    scale: 'space',
+    transform: positiveOrNegativeTransform,
+  },
   scrollMarginTop: {
     property: 'scrollMarginTop',
     scale: 'space',
@@ -50,6 +80,7 @@ const config = {
     scale: 'space',
   },
   scrollSnapAlign: true,
+  scrollSnapStop: true,
   scrollSnapType: true,
 };
 


### PR DESCRIPTION
## Overview

This PR adds two new style props, `scrollMarginBlock` and `scrollMarginInline`, to the component. These props allow users to specify the margins around the block and inline axis of the component when it is being scrolled. This can be useful for creating a smooth scrolling experience in the component.

```
scrollMargin
scrollMarginBlock
scrollMarginBlockEnd
scrollMarginBlockStart
scrollMarginInline
scrollMarginInlineEnd
scrollMarginInlineStart
scrollSnapStop
```