### PR TITLE
fix(`SearchInput`): retain focus on input field after clearing with "x" icon

### DIFF
--- a/packages/react/src/search-input/SearchInput.js
+++ b/packages/react/src/search-input/SearchInput.js
@@ -44,7 +44,11 @@ const SearchInput = React.forwardRef((
       return;
     }
 
-    inputRef.current.value = '';
+    if (inputRef.current) {
+      inputRef.current.value = '';
+      inputRef.current.focus(); // Retain focus on the input after clearing
+    }
+
     setIsClearable(false);
 
     if (typeof onClearInputProp === 'function') {


### PR DESCRIPTION
### Expected Result

1. Clearing with "x" icon

    ![tw-cheton-debian11_8080_ (1)](https://user-images.githubusercontent.com/447801/216255397-a0ba19eb-bfff-41be-bbcf-d82eb4a9f650.png)

2. Maintaining focus on input field

    ![image](https://user-images.githubusercontent.com/447801/216255659-b51379e5-fd45-4a57-bdc4-8d5bdb2fb470.png)



