### PR TITLE
feat(react): refactor close button components to allow passing custom props in `Alert`, `Drawer`, `Modal`, `Tag`, and `Toast` components

### DIFF
--- a/packages/react-docs/components/InputTag/styles.js
+++ b/packages/react-docs/components/InputTag/styles.js
@@ -108,8 +108,9 @@ const useEditableTagStyle = ({
   const [colorMode] = useColorMode();
   const baseStyle = {
     alignItems: 'center',
-    border: 1,
     borderColor: 'transparent',
+    borderStyle: 'solid',
+    borderWidth: '1q',
     borderRadius: 'sm',
     cursor: 'cursor',
     display: 'inline-flex',

--- a/packages/react-docs/config/sidebar-routes.js
+++ b/packages/react-docs/config/sidebar-routes.js
@@ -135,7 +135,8 @@ export const routes = [
       { title: 'Skeleton', path: 'components/skeleton' },
       { title: 'Spinner', path: 'components/spinner' },
       { title: 'Toast', path: 'components/toast' },
-      { title: 'useToast', path: 'components/toast/useToast' },
+      { title: 'ToastManager', path: 'components/toast-manager' },
+      { title: 'useToastManager', path: 'components/toast-manager/useToastManager' },
 
       { title: 'FORMS', heading: true },
       {

--- a/packages/react-docs/pages/_app.js
+++ b/packages/react-docs/pages/_app.js
@@ -2,7 +2,7 @@ import { MDXProvider } from '@mdx-js/react';
 import {
   Box,
   PortalManager,
-  ToastProvider,
+  ToastManager,
   TonicProvider,
   colorStyle as defaultColorStyle,
   useTheme,
@@ -71,12 +71,12 @@ const App = (props) => {
         useCSSBaseline
       >
         <PortalManager>
-          <ToastProvider>
+          <ToastManager>
             <MDXProvider components={MDXComponents}>
               <Page {...props} />
               <GlobalStyles />
             </MDXProvider>
-          </ToastProvider>
+          </ToastManager>
         </PortalManager>
       </TonicProvider>
     </InstantSearch>

--- a/packages/react-docs/pages/components/alert.mdx
+++ b/packages/react-docs/pages/components/alert.mdx
@@ -5,7 +5,10 @@ An alert is used to convey important information to the user through the use of 
 ## Import
 
 ```js
-import { Alert } from '@tonic-ui/react';
+import {
+  Alert,
+  AlertCloseButton,
+} from '@tonic-ui/react';
 ```
 
 ## Usage
@@ -79,72 +82,62 @@ If not specified, the default icon will be used based on the `severity` prop.
 ```jsx
 <Stack direction="column" spacing="6x">
   <Stack direction="column" spacing="2x">
-    <Alert variant="solid" severity="success" isClosable>
+    <Alert variant="solid" severity="success">
       This is a success alert.
     </Alert>
-    <Alert variant="solid" severity="success" icon="success" isClosable>
+    <Alert variant="solid" severity="success" icon="success">
       This is a success alert.
     </Alert>
-    <Alert variant="solid" severity="success" icon={<Icon icon="check-circle-o" />} isClosable>
+    <Alert variant="solid" severity="success" icon={<Icon icon="check-circle-o" />}>
       This is a success alert.
     </Alert>
-    <Alert variant="solid" severity="success" icon={false} isClosable>
+    <Alert variant="solid" severity="success" icon={false}>
       This is a success alert.
     </Alert>
   </Stack>
   <Stack direction="column" spacing="2x">
-    <Alert variant="outline" severity="success" isClosable>
+    <Alert variant="outline" severity="success">
       This is a success alert.
     </Alert>
-    <Alert variant="outline" severity="success" icon="success" isClosable>
+    <Alert variant="outline" severity="success" icon="success">
       This is a success alert.
     </Alert>
-    <Alert variant="outline" severity="success" icon={<Icon icon="check-circle-o" />} isClosable>
+    <Alert variant="outline" severity="success" icon={<Icon icon="check-circle-o" />}>
       This is a success alert.
     </Alert>
-    <Alert variant="outline" severity="success" icon={false} isClosable>
+    <Alert variant="outline" severity="success" icon={false}>
       This is a success alert.
     </Alert>
   </Stack>
 </Stack>
 ```
 
-### `isClosable` prop
+### How to close an alert
 
-Set `isClosable` to `true` to make the alert closable. The default value is `false`.
+#### Using the `isClosable` prop
 
-```jsx
-<Stack direction="column" spacing="6x">
-  <Stack direction="column" spacing="2x">
-    <Alert variant="solid" severity="success" isClosable>
-      <Text>This is a success alert.</Text>
-    </Alert>
-    <Alert variant="solid" severity="info" isClosable>
-      <Text>This is an info alert.</Text>
-    </Alert>
-    <Alert variant="solid" severity="warning" isClosable>
-      <Text>This is a warning alert.</Text>
-    </Alert>
-    <Alert variant="solid" severity="error" isClosable>
-      <Text>This is an error alert.</Text>
-    </Alert>
-  </Stack>
-  <Stack direction="column" spacing="2x">
-    <Alert variant="outline" severity="success" isClosable>
-      <Text>This is a success alert.</Text>
-    </Alert>
-    <Alert variant="outline" severity="info" isClosable>
-      <Text>This is an info alert.</Text>
-    </Alert>
-    <Alert variant="outline" severity="warning" isClosable>
-      <Text>This is a warning alert.</Text>
-    </Alert>
-    <Alert variant="outline" severity="error" isClosable>
-      <Text>This is an error alert.</Text>
-    </Alert>
-  </Stack>
-</Stack>
+The `isClosable` prop is used to make an alert closable by adding a close button to it. By default, the value of `isClosable` is false. To make an alert closable, set `isClosable` to true.
+
+```jsx disabled
+<Alert variant="solid" severity="success" isClosable onClose={onClose}>
+  <Text>This is a success alert.</Text>
+</Alert>
 ```
+
+#### Using the `AlertCloseButton` component
+
+The `AlertCloseButton` component provides an easy way to add a close button to an alert. This button is specifically designed to handle closing the alert, so you don't need to write any additional code to handle it. If you use `AlertCloseButton`, you can omit the `isClosable` prop in the `Alert` component.
+
+Besides the default functionality of the `AlertCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `AlertCloseButton` component as needed.
+
+```jsx disabled
+<Alert variant="solid" severity="success" onClose={onClose}>
+  <Text pr="10x">This is a success alert.</Text>
+  <AlertCloseButton top={3} right={7} position="absolute" data-test="alert-close-button" />
+</Alert>
+```
+
+When using the `AlertCloseButton` component, be sure to manually adjust its position. In the example above, the close button is positioned absolutely, with 3 pixels from the top and 7 pixels from the right of its parent element.
 
 ### Alert actions
 
@@ -356,6 +349,8 @@ function Example() {
 
 ## Props
 
+### Alert
+
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
 | isClosable | boolean | | If `true`, a close button will appear on the right side. |
@@ -363,3 +358,9 @@ function Example() {
 | variant | string | 'solid' | The variant to use. One of: 'solid', 'outline' |
 | severity | string | 'success' | The severity level to use. One of: 'success', 'info', 'warning', 'error' |
 | icon | string \| ReactNode \| false | | Override the icon displayed before the children. Unless provided, the icon is mapped to the value of the `severity` prop. |
+
+### AlertCloseButton
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| children | ReactNode | | |

--- a/packages/react-docs/pages/components/alert.mdx
+++ b/packages/react-docs/pages/components/alert.mdx
@@ -124,6 +124,19 @@ The `isClosable` prop is used to make an alert closable by adding a close button
 </Alert>
 ```
 
+```jsx noInline
+render(() => {
+  const [isOpen, onClose] = useToggle(true);
+  return (
+    <Collapse in={isOpen} unmountOnExit>
+      <Alert variant="solid" severity="success" isClosable onClose={onClose}>
+        <Text>This is a success alert.</Text>
+      </Alert>
+    </Collapse>
+  );
+});
+```
+
 #### Using the `AlertCloseButton` component
 
 The `AlertCloseButton` component provides an easy way to add a close button to an alert. This button is specifically designed to handle closing the alert, so you don't need to write any additional code to handle it. If you use `AlertCloseButton`, you can omit the `isClosable` prop in the `Alert` component.
@@ -138,6 +151,20 @@ Besides the default functionality of the `AlertCloseButton`, you can also pass a
 ```
 
 When using the `AlertCloseButton` component, be sure to manually adjust its position. In the example above, the close button is positioned absolutely, with 3 pixels from the top and 7 pixels from the right of its parent element.
+
+```jsx noInline
+render(() => {
+  const [isOpen, onClose] = useToggle(true);
+  return (
+    <Collapse in={isOpen} unmountOnExit>
+      <Alert variant="solid" severity="success" onClose={onClose}>
+        <Text pr="10x">This is a success alert.</Text>
+        <AlertCloseButton top={3} right={7} position="absolute" data-test="alert-close-button" />
+      </Alert>
+    </Collapse>
+  );
+});
+```
 
 ### Alert actions
 

--- a/packages/react-docs/pages/components/button.mdx
+++ b/packages/react-docs/pages/components/button.mdx
@@ -94,8 +94,7 @@ You can make buttons look inactive or active by adding the `disabled` or `select
 
 If the `disabled` prop is set (or set to `true`), the button will have a `disabled` attribute and not respond to user interactions.
 
-```
-// DOM element
+```jsx disabled
 <button type="button" disabled aria-disabled="true">Button</button>
 ```
 
@@ -136,12 +135,8 @@ function Example() {
 
 If the `selected` prop is set (or set to `true`), the button will have both `pointer-events: none` style and `tabindex="-1"` attribute. This will prevent the button from receiving pointer events and will not be reachable via sequential keyboard navigation.
 
-```
-// DOM element
+```jsx disabled
 <button type="button" aria-selected="true" tabindex="-1">Button</button>
-
-// Element style
-{ pointer-events: none; }
 ```
 
 To customize the visual appearance of the selected state, pass the `_selected` style prop to override the default style.

--- a/packages/react-docs/pages/components/drawer.mdx
+++ b/packages/react-docs/pages/components/drawer.mdx
@@ -404,13 +404,28 @@ function Example() {
 render(<Example />);
 ```
 
-### Using `DrawerCloseButton` to close a drawer
+### How to close a drawer
+
+#### Using the `isClosable` prop to
+
+The `isClosable` prop is used to make a drawer closable by adding a close button to it. By default, the value of `isClosable` is false. To make a drawer closable, set `isClosable` to true.
+
+```jsx disabled
+<Drawer isOpen={isOpen} isClosable onClose={onClose}>
+  <DrawerOverlay />
+  <DrawerContent>
+    <DrawerHeader />
+    <DrawerBody />
+    <DrawerFooter />
+  </DrawerContent>
+</Drawer>
+```
+
+#### Using the `DrawerCloseButton` component
 
 The `DrawerCloseButton` component provides an easy way to add a close button to a drawer. This button is specifically designed to handle closing the drawer, so you don't need to write any additional code to handle it. If you use `DrawerCloseButton`, you can omit the `isClosable` prop in the `Drawer` component.
 
 Besides the default functionality of the `DrawerCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `DrawerCloseButton` component as needed.
-
-Here's an example of how to use `DrawerCloseButton` in a `Drawer` component:
 
 ```jsx disabled
 <Drawer isOpen={isOpen} onClose={onClose}>

--- a/packages/react-docs/pages/components/drawer.mdx
+++ b/packages/react-docs/pages/components/drawer.mdx
@@ -6,13 +6,6 @@ interact with content behind the dialog.
 
 ## Import
 
-- `Drawer`: A `Provider` component that provides the context to the components it wraps.
-- `DrawerOverlay`: The overlay of the drawer.
-- `DrawerContent`: The content of the drawer.
-- `DrawerHeader`: The header of the drawer.
-- `DrawerBody`: The body of the drawer.
-- `DrawerFooter`: The footer of the drawer.
-
 ```js
 import {
   Drawer,
@@ -21,6 +14,7 @@ import {
   DrawerHeader,
   DrawerBody,
   DrawerFooter,
+  DrawerCloseButton
   useDrawer,
 } from '@tonic-ui/react';
 ```
@@ -378,7 +372,7 @@ function Example() {
                       py="2x"
                     >
                       <Text>
-                        This is a very long content that will overflow the modal
+                        This is a very long content that will overflow the drawer
                       </Text>
                     </Box>
                   </TabPanel>
@@ -408,6 +402,26 @@ function Example() {
 }
 
 render(<Example />);
+```
+
+### Using `DrawerCloseButton` to close a drawer
+
+The `DrawerCloseButton` component provides an easy way to add a close button to a drawer. This button is specifically designed to handle closing the drawer, so you don't need to write any additional code to handle it. If you use `DrawerCloseButton`, you can omit the `isClosable` prop in the `Drawer` component.
+
+Besides the default functionality of the `DrawerCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `DrawerCloseButton` component as needed.
+
+Here's an example of how to use `DrawerCloseButton` in a `Drawer` component:
+
+```jsx disabled
+<Drawer isOpen={isOpen} onClose={onClose}>
+  <DrawerOverlay />
+  <DrawerContent>
+    <DrawerHeader />
+    <DrawerBody />
+    <DrawerFooter />
+    <DrawerCloseButton data-test="drawer-close-button" />
+  </DrawerContent>
+</Drawer>
 ```
 
 ## Props
@@ -461,6 +475,12 @@ render(<Example />);
 | children | ReactNode | | |
 
 ### DrawerFooter
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| children | ReactNode | | |
+
+### DrawerCloseButton
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |

--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -549,6 +549,41 @@ function Example() {
 render(<Example />);
 ```
 
+### How to close a modal
+
+#### Using the `isClosable` prop
+
+The `isClosable` prop is used to make a modal closable by adding a close button to it. By default, the value of `isClosable` is false. To make a modal closable, set `isClosable` to true.
+
+```jsx disabled
+<Modal isOpen={isOpen} isClosable onClose={onClose}>
+  <ModalOverlay />
+  <ModalContent>
+    <ModalHeader />
+    <ModalBody />
+    <ModalFooter />
+  </ModalContent>
+</Modal>
+```
+
+#### Using the `ModalCloseButton` component
+
+The `ModalCloseButton` component provides an easy way to add a close button to a modal. This button is specifically designed to handle closing the modal, so you don't need to write any additional code to handle it. If you use `ModalCloseButton`, you can omit the `isClosable` prop in the `Modal` component.
+
+Besides the default functionality of the `ModalCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `ModalCloseButton` component as needed.
+
+```jsx disabled
+<Modal isOpen={isOpen} onClose={onClose}>
+  <ModalOverlay />
+  <ModalContent>
+    <ModalHeader />
+    <ModalBody />
+    <ModalFooter />
+    <ModalCloseButton data-test="modal-close-button" />
+  </ModalContent>
+</Modal>
+```
+
 ### Nested modals
 
 In some cases, you may need to open a modal that is positioned relative to its parent modal, especially when a confirmation is required.
@@ -626,26 +661,6 @@ function Example() {
     </>
   );
 }
-```
-
-### Using `ModalCloseButton` to close a modal
-
-The `ModalCloseButton` component provides an easy way to add a close button to a modal. This button is specifically designed to handle closing the modal, so you don't need to write any additional code to handle it. If you use `ModalCloseButton`, you can omit the `isClosable` prop in the `Modal` component.
-
-Besides the default functionality of the `ModalCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `ModalCloseButton` component as needed.
-
-Here's an example of how to use `ModalCloseButton` in a `Modal` component:
-
-```jsx disabled
-<Modal isOpen={isOpen} onClose={onClose}>
-  <ModalOverlay />
-  <ModalContent>
-    <ModalHeader />
-    <ModalBody />
-    <ModalFooter />
-    <ModalCloseButton data-test="modal-close-button" />
-  </ModalContent>
-</Modal>
 ```
 
 ## Props

--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -4,13 +4,6 @@ Modal dialogs are used to inform users about a task and can contain critical inf
 
 ## Import
 
-- `Modal`: A `Provider` component that provides the context to the components it wraps.
-- `ModalOverlay`: The overlay of the modal.
-- `ModalContent`: The content of the modal.
-- `ModalHeader`: The header of the modal.
-- `ModalBody`: The body of the modal.
-- `ModalFooter`: The footer of the modal.
-
 ```js
 import {
   Modal,
@@ -19,6 +12,7 @@ import {
   ModalHeader,
   ModalBody,
   ModalFooter,
+  ModalCloseButton,
   useModal,
 } from '@tonic-ui/react';
 ```
@@ -555,11 +549,13 @@ function Example() {
 render(<Example />);
 ```
 
-### Nested modal
+### Nested modals
 
-For some use cases, you may want to open a nested modal which is positioned relative to the parent modal, especially when a confirmation is needed.
+In some cases, you may need to open a modal that is positioned relative to its parent modal, especially when a confirmation is required.
 
-You can use the `useToggle` Hook to control modal visibility.
+To achieve this, you can create a nested modal. A nested modal is simply a modal that is opened from within another modal. This way, the nested modal is positioned relative to its parent modal.
+
+One way to implement a nested modal is to use the `useToggle` hook to control modal visibility. This hook can be used to toggle the state of a modal between open and closed, allowing you to easily show and hide nested modals.
 
 ```jsx
 function Example() {
@@ -632,6 +628,26 @@ function Example() {
 }
 ```
 
+### Using `ModalCloseButton` to close a modal
+
+The `ModalCloseButton` component provides an easy way to add a close button to a modal. This button is specifically designed to handle closing the modal, so you don't need to write any additional code to handle it. If you use `ModalCloseButton`, you can omit the `isClosable` prop in the `Modal` component.
+
+Besides the default functionality of the `ModalCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `ModalCloseButton` component as needed.
+
+Here's an example of how to use `ModalCloseButton` in a `Modal` component:
+
+```jsx disabled
+<Modal isOpen={isOpen} onClose={onClose}>
+  <ModalOverlay />
+  <ModalContent>
+    <ModalHeader />
+    <ModalBody />
+    <ModalFooter />
+    <ModalCloseButton data-test="modal-close-button" />
+  </ModalContent>
+</Modal>
+```
+
 ## Props
 
 ### Modal
@@ -682,6 +698,12 @@ function Example() {
 | children | ReactNode | | |
 
 ### ModalFooter
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| children | ReactNode | | |
+
+### ModalCloseButton
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |

--- a/packages/react-docs/pages/components/tag.mdx
+++ b/packages/react-docs/pages/components/tag.mdx
@@ -5,7 +5,10 @@
 ## Import
 
 ```js
-import { Tag } from '@tonic-ui/react';
+import {
+  Tag,
+  TagCloseButton,
+} from '@tonic-ui/react';
 ```
 
 ## Usage
@@ -278,32 +281,32 @@ Use the `size` prop to change the size of the `Tag`. You can set the value to `s
 </Stack>
 ```
 
-### With close button
+### How to close a tag
 
-```jsx
-<Stack spacing="4x">
-  <Stack direction="row" alignItems="center" spacing="2x">
-    <Tag isClosable size="sm" onClose={()=> { alert('Close small tag'); }}>Small</Tag>
-    <Tag isClosable size="md" onClose={()=> { alert('Close medium tag'); }}>Medium</Tag>
-    <Tag isClosable size="lg" onClose={()=> { alert('Close large tag'); }}>Large</Tag>
-  </Stack>
-  <Stack direction="row" alignItems="center" spacing="2x">
-    <Tag isClosable size="sm" borderRadius="lg" onClose={()=> { alert('Close small tag'); }}>Small</Tag>
-    <Tag isClosable size="md" borderRadius="lg" onClose={()=> { alert('Close medium tag'); }}>Medium</Tag>
-    <Tag isClosable size="lg" borderRadius="32px" onClose={()=> { alert('Close large tag'); }}>Large</Tag>
-  </Stack>
-  <Stack direction="row" alignItems="center" spacing="2x">
-    <Tag isClosable size="sm" variant="outline" onClose={()=> { alert('Close small tag'); }}>Small</Tag>
-    <Tag isClosable size="md" variant="outline" onClose={()=> { alert('Close medium tag'); }}>Medium</Tag>
-    <Tag isClosable size="lg" variant="outline" onClose={()=> { alert('Close large tag'); }}>Large</Tag>
-  </Stack>
-    <Stack direction="row" alignItems="center" spacing="2x">
-    <Tag isClosable size="sm" variant="outline" borderRadius="lg" onClose={()=> { alert('Close small tag'); }}>Small</Tag>
-    <Tag isClosable size="md" variant="outline" borderRadius="lg" onClose={()=> { alert('Close medium tag'); }}>Medium</Tag>
-    <Tag isClosable size="lg" variant="outline" borderRadius="32px" onClose={()=> { alert('Close large tag'); }}>Large</Tag>
-  </Stack>
-</Stack>
+#### Using the `isClosable` prop
+
+The `isClosable` prop is used to make a tag closable by adding a close button to it. By default, the value of `isClosable` is false. To make an alert closable, set `isClosable` to true.
+
+```jsx disabled
+<Tag variant="solid" isClosable onClose={onClose}>
+  <Text>tag</Text>
+</Alert>
 ```
+
+#### Using the `TagCloseButton` component
+
+The `TagCloseButton` component provides an easy way to add a close button to a tag. This button is specifically designed to handle closing the tag, so you don't need to write any additional code to handle it. If you use `TagCloseButton`, you can omit the `isClosable` prop in the `Tag` component.
+
+Besides the default functionality of the `TagCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `TagCloseButton` component as needed.
+
+```jsx disabled
+<Tag variant="solid" onClose={onClose}>
+  <Text>tag</Text>
+  <TagCloseButton ml="2x" data-test="tag-close-button" />
+</Tag>
+```
+
+When using the `TagCloseButton` component, be sure to manually adjust its position. In the example above, the close button is positioned with a `2x` (=8px) margin on the left side to ensure sufficient spacing between the tag and the button.
 
 ## Advanced usage
 
@@ -323,6 +326,8 @@ To create a tag, enter a value into the input and press enter, a tag will be cre
 
 ## Props
 
+### Tag
+
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
 | children | ReactNode | | |
@@ -332,3 +337,9 @@ To create a tag, enter a value into the input and press enter, a tag will be cre
 | onClose | function | | A callback called when the close button is clicked. |
 | size | string | 'md' | The size of the tag component. One of: 'sm', 'md', 'lg' |
 | variant | string | 'solid' | The variant style of the tag component. One of: 'solid', 'outline' |
+
+### TagCloseButton
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| children | ReactNode | | |

--- a/packages/react-docs/pages/components/tag.mdx
+++ b/packages/react-docs/pages/components/tag.mdx
@@ -289,8 +289,21 @@ The `isClosable` prop is used to make a tag closable by adding a close button to
 
 ```jsx disabled
 <Tag variant="solid" isClosable onClose={onClose}>
-  <Text>tag</Text>
-</Alert>
+  <Text>This is a tag</Text>
+</Tag>
+```
+
+```jsx noInline
+render(() => {
+  const [isOpen, onClose] = useToggle(true);
+  return (
+    <Fade in={isOpen} unmountOnExit>
+      <Tag variant="solid" isClosable onClose={onClose}>
+        <Text>This is a tag</Text>
+      </Tag>
+    </Fade>
+  );
+});
 ```
 
 #### Using the `TagCloseButton` component
@@ -301,12 +314,26 @@ Besides the default functionality of the `TagCloseButton`, you can also pass add
 
 ```jsx disabled
 <Tag variant="solid" onClose={onClose}>
-  <Text>tag</Text>
+  <Text>This is a tag</Text>
   <TagCloseButton ml="2x" data-test="tag-close-button" />
 </Tag>
 ```
 
 When using the `TagCloseButton` component, be sure to manually adjust its position. In the example above, the close button is positioned with a `2x` (=8px) margin on the left side to ensure sufficient spacing between the tag and the button.
+
+```jsx noInline
+render(() => {
+  const [isOpen, onClose] = useToggle(true);
+  return (
+    <Fade in={isOpen} unmountOnExit>
+      <Tag variant="solid" onClose={onClose}>
+        <Text>This is a tag</Text>
+        <TagCloseButton ml="2x" data-test="tag-close-button" />
+      </Tag>
+    </Fade>
+  );
+});
+```
 
 ## Advanced usage
 

--- a/packages/react-docs/pages/components/toast-manager/index.mdx
+++ b/packages/react-docs/pages/components/toast-manager/index.mdx
@@ -1,3 +1,93 @@
 # ToastManager
 
-WORK IN PROGRESS
+`ToastManager` allows you to create and manage toasts in your React application. Toasts are small messages that appear temporarily on the screen to inform the user about important events or actions.
+
+## Setup
+
+To use `ToastManager`, you should wrap your root component with it, along with the `TonicProvider` component, as shown in the example below:
+
+```jsx disabled
+import { TonicProvider, ToastManager } from '@tonic-ui/react';
+
+function App() {
+  return (
+    <TonicProvider>
+      <ToastManager placement="bottom-right">
+        {/* Your app goes here */}
+      </ToastManager>
+    </TonicProvider>
+  );
+}
+```
+
+Once `ToastManager` is set up, you can use the `useToastManager` Hook to create and manage toasts from any component:
+
+```jsx disabled
+import { useToastManager } from '@tonic-ui/react';
+
+function MyComponent() {
+  const toast = useToastManager();
+  const handleClickOpenToast = () => {
+    const render = ({ onClose, placement }) => {
+      const styleProps = {
+        'top-left': { pt: '2x', px: '4x' },
+        'top': { pt: '2x', px: '4x' },
+        'top-right': { pt: '2x', px: '4x' },
+        'bottom-left': { pb: '2x', px: '4x' },
+        'bottom': { pb: '2x', px: '4x' },
+        'bottom-right': { pb: '2x', px: '4x' },
+      }[placement];
+
+      return (
+        <Box
+          {...styleProps}
+          width={320}
+        >
+          <Toast isClosable onClose={onClose}>
+            This is a toast notification
+          </Toast>
+        </Box>
+      );
+    });
+    const options = {
+      placement: 'bottom-right',
+      duration: 5000,
+    };
+    toast(render, options);
+  };
+
+  return (
+    <Button onClick={handleClickOpenToast}>
+      Open Toast
+    </Button>
+  );
+}
+```
+
+The `toast` method takes a function that returns the toast element to be displayed. The function can also receive an `onClose` function and the `placement` string. The `onClose` function can be used to remove the toast when the user clicks on a close button or after a certain time period.
+
+```jsx disabled
+const id = toast(({ onClose, placement }) => (
+  <Toast isClosable onClose={onClose}>
+    This is a toast notification
+  </Toast>
+));
+```
+
+To remove a toast, you can either call the `onClose` function or use the `toast.remove` method, which takes the toast's unique id as an argument.
+
+```jsx disabled
+toast.remove(id);
+```
+
+See the [useToastManager](./toast-manager/useToastManager) Hook for detailed usage.
+
+## Props
+
+### ToastManager
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| children | ReactNode \| `(context) => ReactNode` | | A function child can be used intead of a React element. This function is called with the context object. |
+| container | HTMLElement | | The HTML element where the toasts will be mounted. |
+| placement | string | 'bottom-right' | The default placement to place toasts. One of: 'top', 'top-right', 'top-left', 'bottom', 'bottom-left', 'bottom-right' |

--- a/packages/react-docs/pages/components/toast-manager/index.mdx
+++ b/packages/react-docs/pages/components/toast-manager/index.mdx
@@ -1,0 +1,3 @@
+# ToastManager
+
+WORK IN PROGRESS

--- a/packages/react-docs/pages/components/toast-manager/useToastManager.mdx
+++ b/packages/react-docs/pages/components/toast-manager/useToastManager.mdx
@@ -1,20 +1,20 @@
-# useToast
+# useToastManager
 
-The `useToast` Hook provides several methods and properties for managing toasts in a React application.
+The `useToastManager` Hook provides several methods and properties for managing toasts in a React application.
 
 ## Import
 
 ```js
-import { useToast } from '@tonic-ui/react';
+import { useToastManager } from '@tonic-ui/react';
 ```
 
 ## Usage
 
 ```js
-const toast = useToast();
+const toast = useToastManager();
 ```
 
-The `useToast` Hook returns an object with the following methods and properties:
+The `useToastManager` Hook returns an object with the following methods and properties:
 
 ### toast(message, [options={'{}'}])
 
@@ -157,7 +157,7 @@ The toast state is a placement object, each placement contains an array of objec
 
 ```jsx
 function Example() {
-  const toast = useToast();
+  const toast = useToastManager();
   const handleClickOpenToast = () => {
     const render = ({ onClose, placement }) => {
       const styleProps = {

--- a/packages/react-docs/pages/components/toast.mdx
+++ b/packages/react-docs/pages/components/toast.mdx
@@ -493,6 +493,19 @@ The `isClosable` prop is used to make a toast closable by adding a close button 
 </Toast>
 ```
 
+```jsx noInline
+render(() => {
+  const [isOpen, onClose] = useToggle(true);
+  return (
+    <Collapse in={isOpen} unmountOnExit>
+      <Toast appearance="success" isClosable onClose={onClose} width={320}>
+        <Text>This is a success toast.</Text>
+      </Toast>
+    </Collapse>
+  );
+});
+```
+
 #### Using the `ToastCloseButton` component
 
 The `ToastCloseButton` component provides an easy way to add a close button to a toast. This button is specifically designed to handle closing the toast, so you don't need to write any additional code to handle it. If you use `ToastCloseButton`, you can omit the `isClosable` prop in the `Toast` component.
@@ -507,6 +520,20 @@ Besides the default functionality of the `ToastCloseButton`, you can also pass a
 ```
 
 When using the `ToastCloseButton` component, be sure to manually adjust its position. In the example above, the close button is positioned absolutely, with 10 pixels from the top and 8 pixels from the right of its parent element.
+
+```jsx noInline
+render(() => {
+  const [isOpen, onClose] = useToggle(true);
+  return (
+    <Collapse in={isOpen} unmountOnExit>
+      <Toast appearance="success" onClose={onClose} width={320}>
+        <Text pr="10x">This is a success toast.</Text>
+        <ToastCloseButton top={10} right={8} position="absolute" data-test="toast-close-button" />
+      </Toast>
+    </Collapse>
+  );
+});
+```
 
 ### Toast on modal and drawer
 

--- a/packages/react-docs/pages/components/toast.mdx
+++ b/packages/react-docs/pages/components/toast.mdx
@@ -8,37 +8,37 @@ A toast notification is a small popup that appears at either side of the screen,
 import {
   Toast,
   ToastController,
-  ToastProvider,
+  ToastManager,
   ToastTransition,
-  useToast,
+  useToastManager,
 } from '@tonic-ui/react';
 ```
 
 ## Setup
 
-To use global toast nofications, you must wrap your root component with the `ToastProvider` component. This provides a context that the `useToast` Hook can access.
+To use global toast nofications, you must wrap your root component with the `ToastManager` component. This provides a context that the `useToastManager` Hook can access.
 
 ```jsx disabled
-import { TonicProvider, ToastProvider } from '@tonic-ui/react';
+import { TonicProvider, ToastManager } from '@tonic-ui/react';
 
 function App() {
   return (
     <TonicProvider>
-      <ToastProvider placement="bottom-right">
+      <ToastManager placement="bottom-right">
         {/* Your app goes here */}
-      </ToastProvider>
+      </ToastManager>
     </TonicProvider>
   );
 }
 ```
 
-Once `ToastProvider` is in place, you can use the `useToast` hook to show a global toast notification.
+Once `ToastManager` is in place, you can use the `useToastManager` hook to show a global toast notification.
 
 ```jsx disabled
-import { useToast } from '@tonic-ui/react';
+import { useToastManager } from '@tonic-ui/react';
 
 function MyComponent() {
-  const toast = useToast();
+  const toast = useToastManager();
   const addToast = () => {
     toast(({ onClose, placement }) => (
       <Box>toast</Box>
@@ -51,7 +51,7 @@ function MyComponent() {
 }
 ```
 
-See the [useToast](./toast/useToast) Hook for detailed usage.
+See the [useToastManager](./toast/useToastManager) Hook for detailed usage.
 
 ### Layout
 
@@ -188,7 +188,7 @@ const ToastLayout = (props) => {
 };
 
 function Example() {
-  const toast = useToast();
+  const toast = useToastManager();
   const handleClickBy = (ToastNotification) => () => {
     toast(({ onClose, placement }) => {
       const styleProps = {
@@ -353,7 +353,7 @@ const ToastLayout = (props) => {
 };
 
 function Example() {
-  const toast = useToast();
+  const toast = useToastManager();
   const handleClickBy = (ToastNotification) => () => {
     toast(({ onClose, placement }) => {
       const styleProps = {
@@ -471,7 +471,7 @@ const ToastLayout = (props) => {
 };
 
 function Example() {
-  const toast = useToast();
+  const toast = useToastManager();
   const handleClickBy = (ToastNotification) => () => {
     toast(({ onClose, placement }) => {
       const styleProps = {
@@ -787,7 +787,7 @@ render(() => {
 | duration | number | null | The duration in milliseconds after which the toast will be automatically closed. Set to `null` to disable auto-closing. |
 | onClose | function | | A callback called when the toast is being closed. |
 
-### ToastProvider
+### ToastManager
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |

--- a/packages/react-docs/pages/components/toast.mdx
+++ b/packages/react-docs/pages/components/toast.mdx
@@ -8,50 +8,9 @@ A toast notification is a small popup that appears at either side of the screen,
 import {
   Toast,
   ToastController,
-  ToastManager,
   ToastTransition,
-  useToastManager,
 } from '@tonic-ui/react';
 ```
-
-## Setup
-
-To use global toast nofications, you must wrap your root component with the `ToastManager` component. This provides a context that the `useToastManager` Hook can access.
-
-```jsx disabled
-import { TonicProvider, ToastManager } from '@tonic-ui/react';
-
-function App() {
-  return (
-    <TonicProvider>
-      <ToastManager placement="bottom-right">
-        {/* Your app goes here */}
-      </ToastManager>
-    </TonicProvider>
-  );
-}
-```
-
-Once `ToastManager` is in place, you can use the `useToastManager` hook to show a global toast notification.
-
-```jsx disabled
-import { useToastManager } from '@tonic-ui/react';
-
-function MyComponent() {
-  const toast = useToastManager();
-  const addToast = () => {
-    toast(({ onClose, placement }) => (
-      <Box>toast</Box>
-    ));
-  };
-
-  return (
-    <Button onClick={addToast}>Add Toast</Button>
-  );
-}
-```
-
-See the [useToastManager](./toast/useToastManager) Hook for detailed usage.
 
 ### Layout
 
@@ -786,14 +745,6 @@ render(() => {
 | children | ReactNode | | |
 | duration | number | null | The duration in milliseconds after which the toast will be automatically closed. Set to `null` to disable auto-closing. |
 | onClose | function | | A callback called when the toast is being closed. |
-
-### ToastManager
-
-| Name | Type | Default | Description |
-| :--- | :--- | :------ | :---------- |
-| children | ReactNode \| `(context) => ReactNode` | | A function child can be used intead of a React element. This function is called with the context object. |
-| container | DOM element | | |
-| placement | string | 'bottom-right' | Set the default placement to place toasts. One of: 'top', 'top-right', 'top-left', 'bottom', 'bottom-left', 'bottom-right' |
 
 ### ToastTransition
 

--- a/packages/react-docs/pages/components/toast.mdx
+++ b/packages/react-docs/pages/components/toast.mdx
@@ -7,6 +7,7 @@ A toast notification is a small popup that appears at either side of the screen,
 ```js
 import {
   Toast,
+  ToastCloseButton,
   ToastController,
   ToastTransition,
 } from '@tonic-ui/react';
@@ -480,6 +481,33 @@ function Example() {
 render(<Example />);
 ```
 
+### How to close a toast
+
+#### Using the `isClosable` prop
+
+The `isClosable` prop is used to make a toast closable by adding a close button to it. By default, the value of `isClosable` is false. To make a toast closable, set `isClosable` to true.
+
+```jsx disabled
+<Toast appearance="success" isClosable onClose={onClose} width={320}>
+  <Text>This is a success toast.</Text>
+</Toast>
+```
+
+#### Using the `ToastCloseButton` component
+
+The `ToastCloseButton` component provides an easy way to add a close button to a toast. This button is specifically designed to handle closing the toast, so you don't need to write any additional code to handle it. If you use `ToastCloseButton`, you can omit the `isClosable` prop in the `Toast` component.
+
+Besides the default functionality of the `ToastCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `ToastCloseButton` component as needed.
+
+```jsx disabled
+<Toast appearance="success" onClose={onClose} width={320}>
+  <Text pr="10x">This is a success toast.</Text>
+  <ToastCloseButton top={10} right={8} position="absolute" data-test="toast-close-button" />
+</Toast>
+```
+
+When using the `ToastCloseButton` component, be sure to manually adjust its position. In the example above, the close button is positioned absolutely, with 10 pixels from the top and 8 pixels from the right of its parent element.
+
 ### Toast on modal and drawer
 
 Toast is a useful way to provide feedback to the user about an action that has been completed or failed within a modal or drawer. They can be displayed on top of a modal or drawer without interrupting the user's workflow.
@@ -737,6 +765,12 @@ render(() => {
 | onClose | function | | A callback called when the close button is clicked. |
 | appearance | string | 'none' | One of: 'none', 'success', 'info', 'warning', 'error' |
 | icon | ReactNode \| boolean \| string | | Override the icon displayed before the children. Unless provided, the icon is mapped to the value of the `appearance` prop. |
+
+### ToastCloseButton
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| children | ReactNode | | |
 
 ### ToastController
 

--- a/packages/react-docs/pages/components/toast/index.mdx
+++ b/packages/react-docs/pages/components/toast/index.mdx
@@ -112,7 +112,7 @@ const ToastWithTitle = ({ onClose }) => (
     <Box mb="2x">
       <Text fontWeight="bold">Notification Title</Text>
     </Box>
-    <Box mr="-9x">
+    <Box mr="-10x">
       <Text>This is a toast notification.</Text>
     </Box>
   </Toast>
@@ -123,7 +123,7 @@ const ToastWithActionButton = ({ onClose }) => (
     <Box mb="6x">
       <Text>This is a toast notification.</Text>
     </Box>
-    <Flex justifyContent="flex-end" mr="-9x">
+    <Flex justifyContent="flex-end" mr="-10x">
       <ActionButton
         // See above for the ActionButton component
         size="sm"
@@ -139,7 +139,7 @@ const ToastWithActionLink = ({ onClose }) => (
     <Box mb="6x">
       <Text>This is a toast notification.</Text>
     </Box>
-    <Flex justifyContent="flex-end" mr="-9x">
+    <Flex justifyContent="flex-end" mr="-10x">
       <Link>Action Link</Link>
     </Flex>
   </Toast>
@@ -159,7 +159,7 @@ const ToastWithAllTogether = ({ onClose }) => (
       <Space minWidth="4x" />
       <Text>This is a toast notification.</Text>
     </Flex>
-    <Flex justifyContent="flex-end" mr="-9x">
+    <Flex justifyContent="flex-end" mr="-10x">
       <ActionButton
         // See above for the ActionButton component
         size="sm"

--- a/packages/react-docs/pages/getting-started/usage.mdx
+++ b/packages/react-docs/pages/getting-started/usage.mdx
@@ -53,8 +53,8 @@ import React from 'react';
 import {
   Box,
   TonicProvider,
-  PortalManager, // enables the creation and management of portals in the application
-  ToastManager, // provides the ability to display global toast notifications
+  PortalManager, // allows you to create and manage portals in the application
+  ToastManager, // allows you to create and manage toasts in the application
   colorStyle, // provides customization options for the color styles used throughout the UI
   useColorMode,
   useTheme,

--- a/packages/react-docs/pages/getting-started/usage.mdx
+++ b/packages/react-docs/pages/getting-started/usage.mdx
@@ -54,7 +54,7 @@ import {
   Box,
   TonicProvider,
   PortalManager, // enables the creation and management of portals in the application
-  ToastProvider, // provides the ability to display global toast notifications
+  ToastManager, // provides the ability to display global toast notifications
   colorStyle, // provides customization options for the color styles used throughout the UI
   useColorMode,
   useTheme,
@@ -72,11 +72,11 @@ function App(props) {
       useCSSBaseline={true} // If `true`, apply CSS reset and base styles
     >
       <PortalManager>
-        <ToastProvider>
+        <ToastManager>
           <Layout>
             <Box {...props} />
           </Layout>
-        </ToastProvider>
+        </ToastManager>
       </PortalManager>
     </TonicProvider>
   );

--- a/packages/react/__tests__/index.js
+++ b/packages/react/__tests__/index.js
@@ -15,7 +15,7 @@ test('should match expected exports', () => {
 
     // alert
     'Alert',
-    'AlertCloseButton', // internal use only
+    'AlertCloseButton',
     'AlertIcon',
     'AlertMessage',
 
@@ -116,8 +116,8 @@ test('should match expected exports', () => {
     // modal
     'Modal',
     'ModalBody',
-    'ModalCloseButton', // internal use only
-    'ModalContainer', // internal use only
+    'ModalCloseButton',
+    'ModalContainer',
     'ModalContent',
     'ModalFooter',
     'ModalHeader',
@@ -204,7 +204,7 @@ test('should match expected exports', () => {
 
     // tag
     'Tag',
-    'TagCloseButton', // internal use only
+    'TagCloseButton',
 
     // text
     'Text',
@@ -220,14 +220,16 @@ test('should match expected exports', () => {
 
     // toast
     'Toast',
-    'ToastCloseButton', // internal use only
-    'ToastContainer', // internal use only
-    'ToastController', // internal use only
-    'ToastIcon', // internal use only
-    'ToastMessage', // internal use only
-    'ToastProvider',
-    'ToastTransition', // internal use only
-    'useToast',
+    'ToastCloseButton',
+    'ToastContainer',
+    'ToastController',
+    'ToastIcon',
+    'ToastManager',
+    'ToastMessage',
+    'ToastTransition',
+    'useToastManager',
+    'ToastProvider', // alias of ToastManager
+    'useToast', // alias of useToastManager
 
     // tooltip
     'Tooltip',

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -75,6 +75,7 @@
     "react-dom": "^16.14.0 || ^17 || ^18"
   },
   "jest": {
+    "clearMocks": true,
     "collectCoverage": true,
     "collectCoverageFrom": [
       "<rootDir>/src/**/*.js"

--- a/packages/react/src/alert/AlertCloseButton.js
+++ b/packages/react/src/alert/AlertCloseButton.js
@@ -1,27 +1,38 @@
+import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
-import {
-  defaultVariant,
-} from './defaults';
+import { Icon } from '../icon';
 import {
   useAlertCloseButtonStyle,
 } from './styles';
+import useAlert from './useAlert';
 
 const AlertCloseButton = forwardRef((
   {
-    variant = defaultVariant,
+    children,
+    onClick: onClickProp,
     ...rest
   },
   ref,
 ) => {
-  const styleProps = useAlertCloseButtonStyle({ variant });
+  const alertContext = useAlert(); // context might be an undefined value
+  const {
+    isClosable,
+    onClose,
+    variant,
+  } = { ...alertContext };
+  // The `isClosable` prop is used to control whether the close button should be positioned on the top-right corner of the alert.
+  const styleProps = useAlertCloseButtonStyle({ isClosable, variant });
 
   return (
     <ButtonBase
       ref={ref}
+      onClick={callEventHandlers(onClickProp, onClose)}
       {...styleProps}
       {...rest}
-    />
+    >
+      {children ?? <Icon icon="close-s" />}
+    </ButtonBase>
   );
 });
 

--- a/packages/react/src/alert/AlertCloseButton.js
+++ b/packages/react/src/alert/AlertCloseButton.js
@@ -17,11 +17,11 @@ const AlertCloseButton = forwardRef((
 ) => {
   const alertContext = useAlert(); // context might be an undefined value
   const {
+    // The `isClosable` prop determines whether the close button should be displayed and allows for control over its positioning
     isClosable,
     onClose,
     variant,
   } = { ...alertContext };
-  // The `isClosable` prop is used to control whether the close button should be positioned on the top-right corner of the alert.
   const styleProps = useAlertCloseButtonStyle({ isClosable, variant });
 
   return (

--- a/packages/react/src/alert/AlertIcon.js
+++ b/packages/react/src/alert/AlertIcon.js
@@ -1,29 +1,59 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import { Box } from '../box';
-import {
-  defaultSeverity,
-  defaultVariant,
-} from './defaults';
+import { Icon } from '../icon';
 import {
   useAlertIconStyle,
 } from './styles';
+import useAlert from './useAlert';
 
-const AlertIcon = forwardRef((
-  {
-    severity = defaultSeverity,
-    variant = defaultVariant,
-    ...rest
-  },
-  ref,
-) => {
+const getIconBySeverity = (severity) => {
+  const iconName = {
+    success: 'success',
+    info: 'info',
+    warning: 'warning-triangle',
+    error: 'error',
+  }[severity];
+
+  if (!iconName) {
+    return null;
+  }
+
+  return (
+    <Icon icon={`${iconName}`} />
+  );
+};
+
+const AlertIcon = forwardRef((props, ref) => {
+  const alertContext = useAlert(); // context might be an undefined value
+  const {
+    icon: iconProp,
+    severity,
+    variant,
+  } = { ...alertContext };
   const styleProps = useAlertIconStyle({ variant, severity });
+
+  const icon = useMemo(() => {
+    if (typeof iconProp === 'string') {
+      return (<Icon icon={iconProp} />);
+    }
+    if (iconProp === undefined) {
+      return getIconBySeverity(severity);
+    }
+    return iconProp;
+  }, [iconProp, severity]);
+
+  if (!icon) {
+    return null;
+  }
 
   return (
     <Box
       ref={ref}
       {...styleProps}
-      {...rest}
-    />
+      {...props}
+    >
+      {icon}
+    </Box>
   );
 });
 

--- a/packages/react/src/alert/AlertMessage.js
+++ b/packages/react/src/alert/AlertMessage.js
@@ -3,9 +3,14 @@ import { Box } from '../box';
 import {
   useAlertMessageStyle,
 } from './styles';
+import useAlert from './useAlert';
 
 const AlertMessage = forwardRef((props, ref) => {
-  const styleProps = useAlertMessageStyle({});
+  const alertContext = useAlert(); // context might be an undefined value
+  const {
+    isClosable,
+  } = { ...alertContext };
+  const styleProps = useAlertMessageStyle({ isClosable });
 
   return (
     <Box

--- a/packages/react/src/alert/__tests__/Alert.test.js
+++ b/packages/react/src/alert/__tests__/Alert.test.js
@@ -1,0 +1,46 @@
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@tonic-ui/react/test-utils/render';
+import { Alert, Collapse } from '@tonic-ui/react/src';
+import { useToggle } from '@tonic-ui/react-hooks/src';
+import { callEventHandlers, transitionDuration } from '@tonic-ui/utils/src';
+import React from 'react';
+
+describe('Alert', () => {
+  it('should render correctly', async () => {
+    const user = userEvent.setup();
+    const message = 'This is an alert message';
+    const handleClose = jest.fn();
+
+    const TestComponent = ({ onClose }) => {
+      const [isOpen, toggle] = useToggle(true);
+      return (
+        <Collapse in={isOpen} unmountOnExit>
+          <Alert
+            variant="solid"
+            severity="success"
+            isClosable
+            onClose={callEventHandlers(() => toggle(false), onClose)}
+            data-testid="alert"
+          >
+            {message}
+          </Alert>
+        </Collapse>
+      );
+    };
+
+    render(<TestComponent onClose={handleClose} />);
+
+    const alertElement = await screen.getByTestId('alert');
+    expect(alertElement).toBeInTheDocument();
+    expect(alertElement).toHaveTextContent(message);
+
+    const closeButton = await screen.getByRole('button');
+    await user.click(closeButton);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('alert'), {
+      timeout: transitionDuration.standard + 100, // see "transitions/Collapse.js"
+    });
+  });
+});

--- a/packages/react/src/alert/context.js
+++ b/packages/react/src/alert/context.js
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+const AlertContext = createContext();
+
+export {
+  AlertContext,
+};

--- a/packages/react/src/alert/index.js
+++ b/packages/react/src/alert/index.js
@@ -9,7 +9,7 @@ Alert.Message = AlertMessage;
 
 export {
   Alert,
-  AlertCloseButton, // internal use only
-  AlertIcon, // internal use only
-  AlertMessage, // internal use only
+  AlertCloseButton,
+  AlertIcon,
+  AlertMessage,
 };

--- a/packages/react/src/alert/styles.js
+++ b/packages/react/src/alert/styles.js
@@ -415,7 +415,7 @@ const useAlertMessageStyle = ({
  * ```jsx
  * <Alert variant="solid" severity="success">
  *   <Text pr="10x">This is a success alert.</Text>
- *   <AlertCloseButton right={7} top={3} position="absolute" />
+ *   <AlertCloseButton top={3} right={7} position="absolute" />
  * </Alert>
  * ```
  *

--- a/packages/react/src/alert/styles.js
+++ b/packages/react/src/alert/styles.js
@@ -1,5 +1,5 @@
-import _get from 'lodash.get';
 import { useColorMode } from '../color-mode';
+import { useIconButtonStyle } from '../shared/styles';
 import { useTheme } from '../theme';
 
 const getSolidSuccessStyle = ({
@@ -288,13 +288,9 @@ const useAlertStyle = ({
 }) => {
   const [colorMode] = useColorMode();
   const { sizes } = useTheme();
-  const _props = {
-    severity,
-    colorMode,
-  };
   const borderWidth = sizes['1q'];
-  const px = sizes['4x'];
-  const py = `calc(${sizes['2x']} - ${borderWidth})`;
+  const px = `calc(${sizes['4x']} - ${borderWidth})`;
+  const py = `calc(${sizes['10q']} - ${borderWidth})`; // (40px - 20px) / 2 = 10px
   const baseStyle = {
     display: 'flex',
     alignItems: 'flex-start',
@@ -302,6 +298,7 @@ const useAlertStyle = ({
     borderColor: 'transparent',
     borderStyle: 'solid',
     borderWidth,
+    position: 'relative',
     px,
     py,
   };
@@ -309,14 +306,14 @@ const useAlertStyle = ({
   if (variant === 'solid') {
     return {
       ...baseStyle,
-      ...getSolidStyle(_props),
+      ...getSolidStyle({ colorMode, severity }),
     };
   }
 
   if (variant === 'outline') {
     return {
       ...baseStyle,
-      ...getOutlineStyle(_props),
+      ...getOutlineStyle({ colorMode, severity }),
     };
   }
 
@@ -374,27 +371,23 @@ const useAlertIconStyle = ({
   severity,
 }) => {
   const [colorMode] = useColorMode();
-  const _props = {
-    severity,
-    colorMode,
-  };
   const iconStyle = {
-    display: 'flex',
-    py: '1x',
-    lineHeight: 1, // exactly the same height as the icon's height
+    display: 'inline-flex',
+    mr: '2x',
+    mt: '1h',
   };
 
   if (variant === 'solid') {
     return {
       ...iconStyle,
-      ...getSolidIconStyle(_props),
+      ...getSolidIconStyle({ colorMode, severity }),
     };
   }
 
   if (variant === 'outline') {
     return {
       ...iconStyle,
-      ...getOutlineIconStyle(_props),
+      ...getOutlineIconStyle({ colorMode, severity }),
     };
   }
 
@@ -403,141 +396,76 @@ const useAlertIconStyle = ({
   };
 };
 
-const useAlertMessageStyle = () => {
-  const theme = useTheme();
-
+const useAlertMessageStyle = ({
+  isClosable,
+}) => {
   return {
-    py: theme?.sizes['1h'],
-    mt: theme?.sizes['-1q'],
+    pr: isClosable ? '10x' : 0,
     width: '100%',
   };
 };
 
-const getSolidCloseButtonStyle = ({
-  colorMode,
-  theme,
-}) => {
-  const color = {
-    dark: 'black:tertiary',
-    light: 'black:tertiary',
-  }[colorMode];
-  const hoverColor = {
-    dark: 'black:primary',
-    light: 'black:primary',
-  }[colorMode];
-  const activeColor = color;
-  const focusColor = color;
-  const focusHoverColor = hoverColor;
-  const focusActiveColor = activeColor;
-  const focusBorderColor = _get(theme?.colors, 'blue:60');
-
-  return {
-    borderColor: 'transparent',
-    borderStyle: 'solid',
-    borderWidth: theme?.sizes['1q'],
-    color,
-    transition: 'all .2s',
-    lineHeight: 1,
-    height: '8x',
-    width: '8x',
-    minWidth: '8x', // ensure a minimum width for the close button
-    mt: '-1x',
-    mb: '-1x',
-    mr: '-2x',
-    px: 0,
-    py: 0,
-    _hover: {
-      color: hoverColor,
-    },
-    _active: {
-      color: activeColor,
-    },
-    _focus: {
-      borderColor: focusBorderColor,
-      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
-      color: focusColor,
-    },
-    _focusHover: {
-      color: focusHoverColor,
-    },
-    _focusActive: {
-      borderColor: focusBorderColor,
-      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
-      color: focusActiveColor,
-    },
-  };
-};
-
-const getOutlineCloseButtonStyle = ({
-  colorMode,
-  theme,
-}) => {
-  const color = {
-    dark: 'white:tertiary',
-    light: 'black:tertiary',
-  }[colorMode];
-  const hoverColor = {
-    dark: 'white:emphasis',
-    light: 'black:primary',
-  }[colorMode];
-  const activeColor = color;
-  const focusColor = color;
-  const focusHoverColor = hoverColor;
-  const focusActiveColor = activeColor;
-  const focusBorderColor = _get(theme?.colors, 'blue:60');
-
-  return {
-    borderColor: 'transparent',
-    borderStyle: 'solid',
-    borderWidth: theme?.sizes['1q'],
-    color,
-    transition: 'all .2s',
-    lineHeight: 1,
-    height: '8x',
-    width: '8x',
-    minWidth: '8x', // ensure a minimum width for the close button
-    mt: '-1x',
-    mb: '-1x',
-    mr: '-2x',
-    px: 0,
-    py: 0,
-    _hover: {
-      color: hoverColor,
-    },
-    _active: {
-      color: activeColor,
-    },
-    _focus: {
-      borderColor: focusBorderColor,
-      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
-      color: focusColor,
-    },
-    _focusHover: {
-      color: focusHoverColor,
-    },
-    _focusActive: {
-      borderColor: focusBorderColor,
-      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
-      color: focusActiveColor,
-    },
-  };
-};
-
+/**
+ * Returns a style object for the close button in an alert component.
+ *
+ * If `isClosable` is true, the button will be positioned absolutely in the top-right corner of the alert.
+ *
+ * You can also control the position of the close button declaratively by using the `AlertCloseButton` component within an `Alert` component:
+ *
+ * ```jsx
+ * <Alert variant="solid" severity="success">
+ *   <Text pr="10x">This is a success alert.</Text>
+ *   <AlertCloseButton right={7} top={3} position="absolute" />
+ * </Alert>
+ * ```
+ *
+ * In this case, the `isClosable` prop is not needed and can be omitted.
+ */
 const useAlertCloseButtonStyle = ({
+  isClosable,
   variant,
 }) => {
   const [colorMode] = useColorMode();
-  const theme = useTheme();
+  const { sizes } = useTheme();
+  const color = {
+    dark: {
+      solid: 'black:tertiary',
+      outline: 'white:tertiary',
+    }[variant],
+    light: {
+      solid: 'black:tertiary',
+      outline: 'black:tertiary',
+    }[variant],
+  }[colorMode];
+  const size = '8x';
+  const _focusBorderColor = 'blue:60';
+  const _focusBoxShadowBorderColor = 'blue:60';
+  const _hoverColor = {
+    dark: {
+      solid: 'black:primary',
+      outline: 'white:emphasis',
+    }[variant],
+    light: {
+      solid: 'black:primary',
+      outline: 'black:primary',
+    }[variant],
+  }[colorMode];
+  const baseStyle = useIconButtonStyle({ color, size, _focusBorderColor, _focusBoxShadowBorderColor, _hoverColor });
 
-  if (variant === 'solid') {
-    return getSolidCloseButtonStyle({ colorMode, theme });
+  if (isClosable) {
+    const parentBorderWidth = sizes['1q'];
+    const top = `calc(${sizes['1x']} - ${parentBorderWidth})`;
+    const right = `calc(${sizes['2x']} - ${parentBorderWidth})`;
+
+    return {
+      ...baseStyle,
+      position: 'absolute',
+      top,
+      right,
+    };
   }
 
-  if (variant === 'outline') {
-    return getOutlineCloseButtonStyle({ colorMode, theme });
-  }
-
-  return {};
+  return baseStyle;
 };
 
 export {

--- a/packages/react/src/alert/useAlert.js
+++ b/packages/react/src/alert/useAlert.js
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { AlertContext } from './context';
+
+const useAlert = () => {
+  if (!useContext) {
+    throw new Error('The `useContext` hook is not available with your React version.');
+  }
+
+  const context = useContext(AlertContext);
+  return context;
+};
+
+export default useAlert;

--- a/packages/react/src/button/styles.js
+++ b/packages/react/src/button/styles.js
@@ -1,4 +1,4 @@
-import { createTransitionStyle, transitionEasing } from '@tonic-ui/utils';
+import { createTransitionStyle } from '@tonic-ui/utils';
 import { useColorMode } from '../color-mode';
 import { useTheme } from '../theme';
 
@@ -346,10 +346,7 @@ const useButtonStyle = ({
     border: 1,
     borderRadius: 'sm',
     px: '3x',
-    transition: createTransitionStyle(['background-color', 'border-color', 'box-shadow', 'color'], {
-      duration: 250,
-      easing: transitionEasing.easeInOut,
-    }),
+    transition: createTransitionStyle(['background-color', 'border-color', 'box-shadow', 'color'], { duration: 200 }),
   };
   const orientationStyle = {
     'horizontal': {

--- a/packages/react/src/checkbox/styles.js
+++ b/packages/react/src/checkbox/styles.js
@@ -47,7 +47,7 @@ const indeterminateProps = ({ color, colorMode }) => {
     _indeterminateAndFocus: {
       outlineStyle: 'solid',
       outlineColor: focusOutlineColor,
-      outlineWidth: '2px',
+      outlineWidth: '1h',
     },
     _indeterminateAndDisabled: {
       borderColor: disabledBorderColor,
@@ -136,7 +136,7 @@ const interactionProps = ({ color, colorMode }) => {
     _focus: {
       outlineStyle: 'solid',
       outlineColor: focusOutlineColor,
-      outlineWidth: '2px',
+      outlineWidth: '1h',
     },
     _checked: {
       bg: checkedBgColor,

--- a/packages/react/src/drawer/DrawerCloseButton.js
+++ b/packages/react/src/drawer/DrawerCloseButton.js
@@ -1,20 +1,34 @@
+import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
 import { Icon } from '../icon';
 import {
   useDrawerCloseButtonStyle,
 } from './styles';
+import useDrawer from './useDrawer';
 
-const DrawerCloseButton = forwardRef((props, ref) => {
+const DrawerCloseButton = forwardRef((
+  {
+    children,
+    onClick: onClickProp,
+    ...rest
+  },
+  ref,
+) => {
+  const drawerContext = useDrawer(); // context might be an undefined value
+  const {
+    onClose,
+  } = { ...drawerContext };
   const styleProps = useDrawerCloseButtonStyle();
 
   return (
     <ButtonBase
       ref={ref}
+      onClick={callEventHandlers(onClickProp, onClose)}
       {...styleProps}
-      {...props}
+      {...rest}
     >
-      <Icon icon="close" />
+      {children ?? <Icon icon="close" />}
     </ButtonBase>
   );
 });

--- a/packages/react/src/drawer/DrawerContent.js
+++ b/packages/react/src/drawer/DrawerContent.js
@@ -66,7 +66,7 @@ const DrawerContent = forwardRef((
     >
       {children}
       {!!isClosable && (
-        <DrawerCloseButton onClick={onClose} />
+        <DrawerCloseButton />
       )}
     </TransitionComponent>
   );

--- a/packages/react/src/drawer/DrawerHeader.js
+++ b/packages/react/src/drawer/DrawerHeader.js
@@ -3,9 +3,14 @@ import { Box } from '../box';
 import {
   useDrawerHeaderStyle,
 } from './styles';
+import useDrawer from './useDrawer';
 
 const DrawerHeader = forwardRef((props, ref) => {
-  const styleProps = useDrawerHeaderStyle();
+  const drawerContext = useDrawer(); // context might be an undefined value
+  const {
+    isClosable,
+  } = { ...drawerContext };
+  const styleProps = useDrawerHeaderStyle({ isClosable });
 
   return (
     <Box

--- a/packages/react/src/drawer/index.js
+++ b/packages/react/src/drawer/index.js
@@ -17,8 +17,8 @@ Drawer.Overlay = DrawerOverlay;
 export {
   Drawer,
   DrawerBody,
-  DrawerCloseButton, // internal use only
-  DrawerContainer, // internal use only
+  DrawerCloseButton,
+  DrawerContainer,
   DrawerContent,
   DrawerFooter,
   DrawerHeader,

--- a/packages/react/src/drawer/styles.js
+++ b/packages/react/src/drawer/styles.js
@@ -1,6 +1,7 @@
 import _get from 'lodash.get';
 import { useColorMode } from '../color-mode';
 import { useColorStyle } from '../color-style';
+import { useIconButtonStyle } from '../shared/styles';
 import { useTheme } from '../theme';
 
 const defaultPlacement = 'right';
@@ -81,7 +82,7 @@ const useDrawerContentStyle = ({
     light: {
       color: 'black:primary',
       bg: 'white',
-      borderWidth: 1,
+      borderWidth: '1q',
       borderStyle: 'solid',
       borderColor: 'gray:30',
       boxShadow: colorStyle?.shadow?.thick,
@@ -89,7 +90,7 @@ const useDrawerContentStyle = ({
     dark: {
       color: 'white:primary',
       bg: 'gray:90',
-      borderWidth: 1,
+      borderWidth: '1q',
       borderStyle: 'solid',
       borderColor: 'gray:80',
       boxShadow: colorStyle?.shadow?.thick,
@@ -157,63 +158,39 @@ const useDrawerContentStyle = ({
 
 const useDrawerCloseButtonStyle = () => {
   const [colorMode] = useColorMode();
-  const { colors } = useTheme();
+  const { sizes } = useTheme();
   const color = {
     dark: 'white:tertiary',
     light: 'black:tertiary',
   }[colorMode];
-  const hoverColor = {
+  const size = '8x';
+  const _focusBorderColor = 'blue:60';
+  const _focusBoxShadowBorderColor = 'blue:60';
+  const _hoverColor = {
     dark: 'white:emphasis',
     light: 'black:primary',
   }[colorMode];
-  const activeColor = color;
-  const focusColor = color;
-  const focusHoverColor = hoverColor;
-  const focusActiveColor = activeColor;
-  const focusBorderColor = _get(colors, 'blue:60');
+  const baseStyle = useIconButtonStyle({ color, size, _focusBorderColor, _focusBoxShadowBorderColor, _hoverColor });
+  const parentBorderWidth = sizes['1q'];
+  const top = `calc(${sizes['2x']} - ${parentBorderWidth})`;
+  const right = `calc(${sizes['2x']} - ${parentBorderWidth})`;
 
   return {
+    ...baseStyle,
     position: 'absolute',
-    top: '2x',
-    right: '2x',
-    border: 1,
-    borderColor: 'transparent',
-    color: color,
-    transition: 'all .2s',
-    lineHeight: 1,
-    height: '8x',
-    width: '8x',
-    minWidth: '8x', // ensure a minimum width for the close button
-    px: 0,
-    py: 0,
-    _hover: {
-      color: hoverColor,
-    },
-    _active: {
-      color: activeColor,
-    },
-    _focus: {
-      borderColor: focusBorderColor,
-      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
-      color: focusColor,
-    },
-    _focusHover: {
-      color: focusHoverColor,
-    },
-    _focusActive: {
-      borderColor: focusBorderColor,
-      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
-      color: focusActiveColor,
-    },
+    top,
+    right,
   };
 };
 
-const useDrawerHeaderStyle = () => {
+const useDrawerHeaderStyle = ({
+  isClosable,
+}) => {
   return {
     pt: '4x',
     pb: '6x',
     pl: '4x',
-    pr: '12x',
+    pr: isClosable ? '12x' : '4x',
     position: 'relative',
     fontSize: 'xl',
     lineHeight: 'xl',

--- a/packages/react/src/modal/ModalCloseButton.js
+++ b/packages/react/src/modal/ModalCloseButton.js
@@ -1,20 +1,34 @@
+import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
 import { Icon } from '../icon';
 import {
   useModalCloseButtonStyle,
 } from './styles';
+import useModal from './useModal';
 
-const ModalCloseButton = forwardRef((props, ref) => {
+const ModalCloseButton = forwardRef((
+  {
+    children,
+    onClick: onClickProp,
+    ...rest
+  },
+  ref,
+) => {
+  const modalContext = useModal(); // context might be an undefined value
+  const {
+    onClose,
+  } = { ...modalContext };
   const styleProps = useModalCloseButtonStyle();
 
   return (
     <ButtonBase
       ref={ref}
+      onClick={callEventHandlers(onClickProp, onClose)}
       {...styleProps}
-      {...props}
+      {...rest}
     >
-      <Icon icon="close" />
+      {children ?? <Icon icon="close" />}
     </ButtonBase>
   );
 });

--- a/packages/react/src/modal/ModalContent.js
+++ b/packages/react/src/modal/ModalContent.js
@@ -60,7 +60,7 @@ const ModalContent = forwardRef((
     >
       {children}
       {!!isClosable && (
-        <ModalCloseButton onClick={onClose} />
+        <ModalCloseButton />
       )}
     </TransitionComponent>
   );

--- a/packages/react/src/modal/ModalHeader.js
+++ b/packages/react/src/modal/ModalHeader.js
@@ -3,9 +3,14 @@ import { Box } from '../box';
 import {
   useModalHeaderStyle,
 } from './styles';
+import useModal from './useModal';
 
 const ModalHeader = forwardRef((props, ref) => {
-  const styleProps = useModalHeaderStyle();
+  const modalContext = useModal(); // context might be an undefined value
+  const {
+    isClosable,
+  } = { ...modalContext };
+  const styleProps = useModalHeaderStyle({ isClosable });
 
   return (
     <Box

--- a/packages/react/src/modal/index.js
+++ b/packages/react/src/modal/index.js
@@ -17,8 +17,8 @@ Modal.Overlay = ModalOverlay;
 export {
   Modal,
   ModalBody,
-  ModalCloseButton, // internal use only
-  ModalContainer, // internal use only
+  ModalCloseButton,
+  ModalContainer,
   ModalContent,
   ModalFooter,
   ModalHeader,

--- a/packages/react/src/modal/styles.js
+++ b/packages/react/src/modal/styles.js
@@ -1,6 +1,7 @@
 import _get from 'lodash.get';
 import { useColorMode } from '../color-mode';
 import { useColorStyle } from '../color-style';
+import { useIconButtonStyle } from '../shared/styles';
 import { useTheme } from '../theme';
 
 const defaultSize = 'auto';
@@ -54,7 +55,7 @@ const useModalContentStyle = ({
     light: {
       color: 'black:primary',
       bg: 'white',
-      borderWidth: 1,
+      borderWidth: '1q',
       borderStyle: 'solid',
       borderColor: 'gray:30',
       boxShadow: colorStyle?.shadow?.thick,
@@ -62,7 +63,7 @@ const useModalContentStyle = ({
     dark: {
       color: 'white:primary',
       bg: 'gray:90',
-      borderWidth: 1,
+      borderWidth: '1q',
       borderStyle: 'solid',
       borderColor: 'gray:80',
       boxShadow: colorStyle?.shadow?.thick,
@@ -135,63 +136,39 @@ const useModalContentStyle = ({
 
 const useModalCloseButtonStyle = () => {
   const [colorMode] = useColorMode();
-  const { colors } = useTheme();
+  const { sizes } = useTheme();
   const color = {
     dark: 'white:tertiary',
     light: 'black:tertiary',
   }[colorMode];
-  const hoverColor = {
+  const size = '8x';
+  const _focusBorderColor = 'blue:60';
+  const _focusBoxShadowBorderColor = 'blue:60';
+  const _hoverColor = {
     dark: 'white:emphasis',
     light: 'black:primary',
   }[colorMode];
-  const activeColor = color;
-  const focusColor = color;
-  const focusHoverColor = hoverColor;
-  const focusActiveColor = activeColor;
-  const focusBorderColor = _get(colors, 'blue:60');
+  const baseStyle = useIconButtonStyle({ color, size, _focusBorderColor, _focusBoxShadowBorderColor, _hoverColor });
+  const parentBorderWidth = sizes['1q'];
+  const top = `calc(${sizes['2x']} - ${parentBorderWidth})`;
+  const right = `calc(${sizes['2x']} - ${parentBorderWidth})`;
 
   return {
+    ...baseStyle,
     position: 'absolute',
-    top: '2x',
-    right: '2x',
-    border: 1,
-    borderColor: 'transparent',
-    color: color,
-    transition: 'all .2s',
-    lineHeight: 1,
-    height: '8x',
-    width: '8x',
-    minWidth: '8x', // ensure a minimum width for the close button
-    px: 0,
-    py: 0,
-    _hover: {
-      color: hoverColor,
-    },
-    _active: {
-      color: activeColor,
-    },
-    _focus: {
-      borderColor: focusBorderColor,
-      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
-      color: focusColor,
-    },
-    _focusHover: {
-      color: focusHoverColor,
-    },
-    _focusActive: {
-      borderColor: focusBorderColor,
-      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
-      color: focusActiveColor,
-    },
+    top,
+    right,
   };
 };
 
-const useModalHeaderStyle = () => {
+const useModalHeaderStyle = ({
+  isClosable,
+}) => {
   return {
     pt: '4x',
     pb: '6x',
     pl: '6x',
-    pr: '12x',
+    pr: isClosable ? '12x' : '6x',
     position: 'relative',
     fontSize: 'xl',
     lineHeight: 'xl',

--- a/packages/react/src/pagination/__tests__/Pagination.test.js
+++ b/packages/react/src/pagination/__tests__/Pagination.test.js
@@ -35,6 +35,8 @@ describe('Pagination', () => {
   });
 
   it('should fire onChange when a different page is clicked', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     const onChange = jest.fn();
     const { getAllByRole } = render(
       <Pagination count={3} onChange={onChange} page={1} />
@@ -50,6 +52,9 @@ describe('Pagination', () => {
     expect(onChange).toHaveBeenCalledWith(
       expect.anything(),
       2,
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Pagination "onChange(event, page)" is deprecated and will be changed to "onChange(page)" in the next major release.')
     );
   });
 

--- a/packages/react/src/search-input/styles.js
+++ b/packages/react/src/search-input/styles.js
@@ -1,4 +1,4 @@
-import _get from 'lodash.get';
+import { createTransitionStyle } from '@tonic-ui/utils';
 import { useColorMode } from '../color-mode';
 import { useTheme } from '../theme';
 
@@ -18,7 +18,7 @@ const useSearchInputCloseButtonStyle = ({ size }) => {
   const focusColor = color;
   const focusHoverColor = hoverColor;
   const focusActiveColor = activeColor;
-  const focusBorderColor = _get(colors, 'blue:60');
+  const focusBorderColor = colors?.['blue:60'];
   const height = {
     sm: sizes['6x'],
     md: sizes['8x'], // default
@@ -41,8 +41,8 @@ const useSearchInputCloseButtonStyle = ({ size }) => {
     borderStyle: 'solid',
     borderWidth,
     color: color,
-    transition: 'all .2s',
-    lineHeight: 1,
+    transition: createTransitionStyle(['border-color', 'color'], { duration: 200 }),
+    lineHeight: 1, // Ensure the element height to match the height of the icon
     height: `calc(${height} - ${borderWidth} - ${borderWidth})`,
     width,
     minWidth, // ensure a minimum width for the close button

--- a/packages/react/src/select/styles.js
+++ b/packages/react/src/select/styles.js
@@ -1,28 +1,5 @@
 import { useColorMode } from '../color-mode';
-
-const baseProps = {
-  appearance: 'none',
-  border: 'none',
-  color: 'inherit',
-  outline: 0,
-  padding: 0,
-  position: 'relative',
-  display: 'flex',
-  alignItems: 'center',
-  transition: 'all .2s',
-};
-
-const sizes = {
-  'md': {
-    borderRadius: 'sm',
-    fontSize: 'sm',
-    lineHeight: 'sm',
-    pl: '3x',
-    pr: '8x',
-    py: 'calc(.375rem - 1px)', // 6px - 1px
-    width: '100%',
-  },
-};
+import { useTheme } from '../theme';
 
 const getOutlinedStyle = ({
   colorMode,
@@ -151,51 +128,61 @@ const getIconWrapperProps = () => {
   };
 };
 
-const getSizeProps = (props) => {
-  const defaultSize = 'md';
-
-  return sizes[defaultSize];
-};
-
-const getVariantProps = (props) => {
-  const { colorMode, variant } = props;
-
-  if (variant === 'outline') {
-    return getOutlinedStyle({ colorMode });
-  }
-
-  if (variant === 'filled') {
-    return getFilledStyle({ colorMode });
-  }
-
-  if (variant === 'unstyled') {
-    return getUnstyledStyle({ colorMode });
-  }
-
-  return {};
-};
-
 const useSelectStyle = ({
   variant,
   multiple,
 }) => {
   const [colorMode] = useColorMode();
-  const _props = {
-    colorMode,
-    variant,
+  const { sizes } = useTheme();
+  const sizeStyle = (() => {
+    const borderWidth = sizes['1q'];
+    const defaultSize = 'md';
+    const style = {
+      'md': {
+        borderRadius: 'sm',
+        fontSize: 'sm',
+        lineHeight: 'sm',
+        pl: '3x',
+        pr: '8x',
+        py: `calc(${sizes['3h']} - ${borderWidth})`, // 6px - 1px
+        width: '100%',
+      },
+    }[defaultSize];
+    return style;
+  })();
+  const variantStyle = (() => {
+    if (variant === 'outline') {
+      return getOutlinedStyle({ colorMode });
+    }
+    if (variant === 'filled') {
+      return getFilledStyle({ colorMode });
+    }
+    if (variant === 'unstyled') {
+      return getUnstyledStyle({ colorMode });
+    }
+    return {};
+  })();
+  const baseStyle = {
+    appearance: 'none',
+    border: 'none',
+    color: 'inherit',
+    outline: 0,
+    padding: 0,
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    transition: 'all .2s',
   };
-  const sizeProps = getSizeProps(_props); // use default size
-  const variantProps = getVariantProps(_props);
 
   if (multiple) {
-    variantProps.height = undefined;
-    variantProps.px = undefined;
+    variantStyle.height = undefined;
+    variantStyle.px = undefined;
   }
 
   return {
-    ...baseProps,
-    ...sizeProps,
-    ...variantProps,
+    ...baseStyle,
+    ...sizeStyle,
+    ...variantStyle,
   };
 };
 

--- a/packages/react/src/shared/styles.js
+++ b/packages/react/src/shared/styles.js
@@ -1,0 +1,55 @@
+import { createTransitionStyle } from '@tonic-ui/utils';
+import { useTheme } from '../theme';
+
+const useIconButtonStyle = ({
+  color: colorProp,
+  size = '8x',
+  _focusBorderColor: focusBorderColorProp,
+  _focusBoxShadowBorderColor: focusBoxShadowBorderColorProp,
+  _hoverColor: hoverColorProp,
+}) => {
+  const { colors } = useTheme();
+  const color = colors?.[colorProp] ?? colorProp;
+  const activeColor = color;
+  const hoverColor = colors?.[hoverColorProp] ?? hoverColorProp;
+  const focusColor = color;
+  const focusHoverColor = hoverColor;
+  const focusActiveColor = activeColor;
+  const focusBorderColor = colors?.[focusBorderColorProp] ?? focusBorderColorProp;
+  const focusBoxShadowBorderColor = colors?.[focusBoxShadowBorderColorProp] ?? focusBoxShadowBorderColorProp;
+
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: 1,
+    borderColor: 'transparent',
+    color,
+    width: size,
+    height: size,
+    transition: createTransitionStyle(['border-color', 'box-shadow', 'color'], { duration: 200 }),
+    _hover: {
+      color: hoverColor,
+    },
+    _active: {
+      color: activeColor,
+    },
+    _focus: {
+      borderColor: focusBorderColor,
+      boxShadow: focusBoxShadowBorderColor ? `inset 0 0 0 1px ${focusBoxShadowBorderColor}` : undefined,
+      color: focusColor,
+    },
+    _focusHover: {
+      color: focusHoverColor,
+    },
+    _focusActive: {
+      borderColor: focusBorderColor,
+      boxShadow: focusBoxShadowBorderColor ? `inset 0 0 0 1px ${focusBoxShadowBorderColor}` : undefined,
+      color: focusActiveColor,
+    },
+  };
+};
+
+export {
+  useIconButtonStyle,
+};

--- a/packages/react/src/switch/styles.js
+++ b/packages/react/src/switch/styles.js
@@ -1,24 +1,5 @@
+import { createTransitionStyle } from '@tonic-ui/utils';
 import { useColorMode } from '../color-mode';
-
-const defaultSize = 'md';
-
-const switchSizes = {
-  sm: {
-    width: 32,
-    height: 16,
-    radius: 6,
-  },
-  md: {
-    width: 48,
-    height: 24,
-    radius: 9,
-  },
-  lg: {
-    width: 64,
-    height: 32,
-    radius: 12,
-  },
-};
 
 const baseStyle = ({
   variantColor,
@@ -144,14 +125,32 @@ const switchThumbStyle = ({
     r: radius,
     fill: 'white:emphasis',
     transform: 'translateX(0)',
-    transition: 'transform .25s',
+    transition: createTransitionStyle(['transform'], { duration: 250 }),
     transformBox: 'fill-box',
   };
 };
 
 const useSwitchStyle = props => {
   const [colorMode] = useColorMode();
-  const size = switchSizes[props.size] ?? switchSizes[defaultSize];
+  const defaultSize = 'md';
+  const switchSize = {
+    sm: {
+      width: 32,
+      height: 16,
+      radius: 6,
+    },
+    md: {
+      width: 48,
+      height: 24,
+      radius: 9,
+    },
+    lg: {
+      width: 64,
+      height: 32,
+      radius: 12,
+    },
+  };
+  const size = switchSize[props.size] ?? switchSize[defaultSize];
   const { width, height, radius } = size;
   const switchMaxWidth = width + 6; //The border and halo width of the one side switching track is 1 and 2, so the sum of both sides is 6
   const switchMaxHeight = height + 6; // Same as width

--- a/packages/react/src/table/Table.js
+++ b/packages/react/src/table/Table.js
@@ -60,25 +60,33 @@ const Table = forwardRef((
 
 const VerticalLine = (props) => {
   const [colorMode] = useColorMode();
-  const isDark = colorMode === 'dark';
+  const borderColor = {
+    dark: 'gray:70',
+    light: 'gray:50',
+  }[colorMode];
+
   return (
     <Box
       borderLeft={1}
-      borderColor={isDark ? 'gray:70' : 'gray:50'}
+      borderLeftColor={borderColor}
       height="100%"
-      width="1px"
+      width="1q"
       {...props}
     />
   );
 };
 const HorizontalLine = (props) => {
   const [colorMode] = useColorMode();
-  const isDark = colorMode === 'dark';
+  const borderColor = {
+    dark: 'gray:70',
+    light: 'gray:50',
+  }[colorMode];
+
   return (
     <Box
       borderTop={1}
-      borderColor={isDark ? 'gray:70' : 'gray:50'}
-      height="1px"
+      borderTopColor={borderColor}
+      height="1q"
       width="100%"
       {...props}
     />

--- a/packages/react/src/tag/TagCloseButton.js
+++ b/packages/react/src/tag/TagCloseButton.js
@@ -1,18 +1,36 @@
+import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
 import { Icon } from '../icon';
 import { useTagCloseButtonStyle } from './styles';
+import useTag from './useTag';
 
-const TagCloseButton = forwardRef((props, ref) => {
-  const closeButtonStyleProps = useTagCloseButtonStyle();
+const TagCloseButton = forwardRef((
+  {
+    children,
+    onClick: onClickProp,
+    ...rest
+  },
+  ref,
+) => {
+  const tagContext = useTag(); // context might be an undefined value
+  const {
+    disabled,
+    // The `isClosable` prop determines whether the close button should be displayed and allows for control over its positioning
+    isClosable,
+    onClose,
+  } = { ...tagContext };
+  const styleProps = useTagCloseButtonStyle({ isClosable });
 
   return (
     <ButtonBase
       ref={ref}
-      {...closeButtonStyleProps}
-      {...props}
+      disabled={disabled}
+      onClick={callEventHandlers(onClickProp, onClose)}
+      {...styleProps}
+      {...rest}
     >
-      <Icon icon="close-s" verticalAlign="top" />
+      {children ?? <Icon icon="close-s" />}
     </ButtonBase>
   );
 });

--- a/packages/react/src/tag/context.js
+++ b/packages/react/src/tag/context.js
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+const TagContext = createContext();
+
+export {
+  TagContext,
+};

--- a/packages/react/src/tag/index.js
+++ b/packages/react/src/tag/index.js
@@ -3,5 +3,5 @@ import TagCloseButton from './TagCloseButton';
 
 export {
   Tag,
-  TagCloseButton, // internal use only
+  TagCloseButton,
 };

--- a/packages/react/src/tag/styles.js
+++ b/packages/react/src/tag/styles.js
@@ -1,3 +1,4 @@
+import { createTransitionStyle } from '@tonic-ui/utils';
 import { useColorMode } from '../color-mode';
 import { useTheme } from '../theme';
 
@@ -241,14 +242,18 @@ const useTagStyle = ({
 }) => {
   const [colorMode] = useColorMode();
   const theme = useTheme();
+  const { sizes } = theme;
+  const borderWidth = sizes['1q'];
+  const px = `calc(${sizes['2x']} - ${borderWidth})`;
   const baseStyle = {
     alignItems: 'center',
-    border: 1,
     borderColor: 'transparent',
     borderRadius: 'sm',
+    borderStyle: 'solid',
+    borderWidth,
     display: 'inline-flex',
-    pl: '2x',
-    pr: '2x',
+    position: 'relative',
+    px,
   };
   const sizeStyle = {
     sm: {
@@ -260,13 +265,13 @@ const useTagStyle = ({
       fontSize: 'xs',
       lineHeight: 'xs',
       minHeight: '6x',
-      py: '1h',
+      py: `calc(${sizes['1h']} - ${borderWidth})`,
     },
     lg: {
       fontSize: 'md',
       lineHeight: 'md',
       minHeight: '8x',
-      py: '1x',
+      py: `calc(${sizes['1x']} - ${borderWidth})`,
     },
   }[size];
   const variantStyle = {
@@ -281,9 +286,10 @@ const useTagStyle = ({
   };
 };
 
-const useTagCloseButtonStyle = () => {
+const useTagCloseButtonStyle = ({
+  isClosable,
+}) => {
   const [colorMode] = useColorMode();
-  const size = '4x';
   const color = {
     dark: 'white:tertiary',
     light: 'black:tertiary',
@@ -299,13 +305,15 @@ const useTagCloseButtonStyle = () => {
     dark: 'blue:60',
     light: 'blue:60',
   }[colorMode];
-
-  return {
-    backgroundColor: 'transparent',
-    color: color,
+  const size = '4x';
+  const baseStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color,
     height: size,
     width: size,
-    minWidth: size, // ensure a minimum width for the close button
+    transition: createTransitionStyle(['color'], { duration: 200 }),
     _hover: {
       color: hoverColor,
     },
@@ -322,6 +330,15 @@ const useTagCloseButtonStyle = () => {
       cursor: 'not-allowed',
     },
   };
+
+  if (isClosable) {
+    return {
+      ...baseStyle,
+      ml: '2x',
+    };
+  }
+
+  return baseStyle;
 };
 
 export {

--- a/packages/react/src/tag/useTag.js
+++ b/packages/react/src/tag/useTag.js
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { TagContext } from './context';
+
+const useTag = () => {
+  if (!useContext) {
+    throw new Error('The `useContext` hook is not available with your React version.');
+  }
+
+  const context = useContext(TagContext);
+  return context;
+};
+
+export default useTag;

--- a/packages/react/src/textarea/styles.js
+++ b/packages/react/src/textarea/styles.js
@@ -1,24 +1,5 @@
 import { useColorMode } from '../color-mode';
-
-const baseProps = {
-  position: 'relative',
-  display: 'flex',
-  alignItems: 'center',
-  transition: 'all .2s',
-};
-
-const sizes = {
-  'md': {
-    borderRadius: 'sm',
-    fontSize: 'sm',
-    lineHeight: 'sm',
-    minHeight: '9x', // 6px (top) + 20px + 10px (bottom) = 36px
-    px: '3x',
-    pt: 'calc(.375rem - 1px)', // 6px - 1px
-    pb: 'calc(.625rem - 1px)', // 10px - 1px
-    width: '100%',
-  },
-};
+import { useTheme } from '../theme';
 
 const getOutlinedStyle = ({
   colorMode,
@@ -122,45 +103,51 @@ const getUnstyledStyle = ({
   };
 };
 
-const getSizeProps = (props) => {
-  const defaultSize = 'md';
-
-  return sizes[defaultSize];
-};
-
-const getVariantProps = (props) => {
-  const { colorMode, variant } = props;
-
-  if (variant === 'outline') {
-    return getOutlinedStyle({ colorMode });
-  }
-
-  if (variant === 'filled') {
-    return getFilledStyle({ colorMode });
-  }
-
-  if (variant === 'unstyled') {
-    return getUnstyledStyle({ colorMode });
-  }
-
-  return {};
-};
-
 const useTextareaStyle = ({
   variant,
 }) => {
   const [colorMode] = useColorMode();
-  const _props = {
-    colorMode,
-    variant,
+  const { sizes } = useTheme();
+  const sizeStyle = (() => {
+    const borderWidth = sizes['1q'];
+    const defaultSize = 'md';
+    const style = {
+      'md': {
+        borderRadius: 'sm',
+        fontSize: 'sm',
+        lineHeight: 'sm',
+        minHeight: '9x', // 6px (top) + 20px + 10px (bottom) = 36px
+        px: '3x',
+        pt: `calc(${sizes['3h']} - ${borderWidth})`, // 6px - 1px
+        pb: `calc(${sizes['5h']} - ${borderWidth})`, // 10px - 1px
+        width: '100%',
+      },
+    }[defaultSize];
+    return style;
+  })();
+  const variantStyle = (() => {
+    if (variant === 'outline') {
+      return getOutlinedStyle({ colorMode });
+    }
+    if (variant === 'filled') {
+      return getFilledStyle({ colorMode });
+    }
+    if (variant === 'unstyled') {
+      return getUnstyledStyle({ colorMode });
+    }
+    return {};
+  })();
+  const baseStyle = {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    transition: 'all .2s',
   };
-  const sizeProps = getSizeProps(_props); // use default size
-  const variantProps = getVariantProps(_props);
 
   return {
-    ...baseProps,
-    ...sizeProps,
-    ...variantProps,
+    ...baseStyle,
+    ...sizeStyle,
+    ...variantStyle,
   };
 };
 

--- a/packages/react/src/toast/ToastCloseButton.js
+++ b/packages/react/src/toast/ToastCloseButton.js
@@ -1,18 +1,38 @@
+import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
+import { Icon } from '../icon';
 import {
   useToastCloseButtonStyle,
 } from './styles';
+import useToast from './useToast';
 
-const ToastCloseButton = forwardRef((props, ref) => {
-  const styleProps = useToastCloseButtonStyle({});
+const ToastCloseButton = forwardRef((
+  {
+    children,
+    onClick: onClickProp,
+    ...rest
+  },
+  ref,
+) => {
+  const alertContext = useToast(); // context might be an undefined value
+  const {
+    isClosable,
+    onClose,
+    variant,
+  } = { ...alertContext };
+  // The `isClosable` prop is used to control whether the close button should be positioned on the top-right corner of the alert.
+  const styleProps = useToastCloseButtonStyle({ isClosable, variant });
 
   return (
     <ButtonBase
       ref={ref}
+      onClick={callEventHandlers(onClickProp, onClose)}
       {...styleProps}
-      {...props}
-    />
+      {...rest}
+    >
+      {children ?? <Icon icon="close-s" />}
+    </ButtonBase>
   );
 });
 

--- a/packages/react/src/toast/ToastCloseButton.js
+++ b/packages/react/src/toast/ToastCloseButton.js
@@ -17,11 +17,11 @@ const ToastCloseButton = forwardRef((
 ) => {
   const alertContext = useToast(); // context might be an undefined value
   const {
+    // The `isClosable` prop determines whether the close button should be displayed and allows for control over its positioning
     isClosable,
     onClose,
     variant,
   } = { ...alertContext };
-  // The `isClosable` prop is used to control whether the close button should be positioned on the top-right corner of the alert.
   const styleProps = useToastCloseButtonStyle({ isClosable, variant });
 
   return (

--- a/packages/react/src/toast/ToastIcon.js
+++ b/packages/react/src/toast/ToastIcon.js
@@ -1,27 +1,57 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import { Box } from '../box';
-import {
-  defaultAppearance,
-} from './defaults';
+import { Icon } from '../icon';
 import {
   useToastIconStyle,
 } from './styles';
+import useToast from './useToast';
 
-const ToastIcon = forwardRef((
-  {
-    appearance = defaultAppearance,
-    ...rest
-  },
-  ref,
-) => {
+const getIconByAppearance = (appearance) => {
+  const iconName = {
+    success: 'success',
+    info: 'info',
+    warning: 'warning-triangle',
+    error: 'error',
+  }[appearance];
+
+  if (!iconName) {
+    return null;
+  }
+
+  return (
+    <Icon icon={`${iconName}`} />
+  );
+};
+
+const ToastIcon = forwardRef((props, ref) => {
+  const toastContext = useToast(); // context might be an undefined value
+  const {
+    appearance,
+    icon: iconProp,
+  } = { ...toastContext };
   const styleProps = useToastIconStyle({ appearance });
+  const icon = useMemo(() => {
+    if (typeof iconProp === 'string') {
+      return (<Icon icon={iconProp} />);
+    }
+    if (iconProp === undefined) {
+      return getIconByAppearance(appearance);
+    }
+    return iconProp;
+  }, [appearance, iconProp]);
+
+  if (!icon) {
+    return null;
+  }
 
   return (
     <Box
       ref={ref}
       {...styleProps}
-      {...rest}
-    />
+      {...props}
+    >
+      {icon}
+    </Box>
   );
 });
 

--- a/packages/react/src/toast/ToastManager.js
+++ b/packages/react/src/toast/ToastManager.js
@@ -42,8 +42,9 @@ const getToastPlacementByState = (state, id) => {
 
 const ToastManager = ({
   children,
+  container, // deprecated (remove in next major version)
+  //containerRef: containerRefProp,
   placement: placementProp = defaultPlacement,
-  container,
 }) => {
   const isHydrated = useHydrated();
   const [state, setState] = useState(() => (

--- a/packages/react/src/toast/ToastManager.js
+++ b/packages/react/src/toast/ToastManager.js
@@ -11,7 +11,7 @@ import {
 import ToastContainer from './ToastContainer';
 import ToastController from './ToastController';
 import ToastTransition from './ToastTransition';
-import { ToastContext } from './context';
+import { ToastManagerContext } from './context';
 
 const uniqueId = (() => {
   let id = 0;
@@ -40,7 +40,7 @@ const getToastPlacementByState = (state, id) => {
   return toast?.placement;
 };
 
-const ToastProvider = ({
+const ToastManager = ({
   children,
   placement: placementProp = defaultPlacement,
   container,
@@ -216,14 +216,14 @@ const ToastProvider = ({
 
   if (!portalTarget) {
     return (
-      <ToastContext.Provider value={context}>
+      <ToastManagerContext.Provider value={context}>
         {runIfFn(children, context)}
-      </ToastContext.Provider>
+      </ToastManagerContext.Provider>
     );
   }
 
   return (
-    <ToastContext.Provider value={context}>
+    <ToastManagerContext.Provider value={context}>
       {runIfFn(children, context)}
       {isHydrated && createPortal((
         Object.keys(state).map((placement) => {
@@ -268,10 +268,10 @@ const ToastProvider = ({
           );
         })
       ), portalTarget)}
-    </ToastContext.Provider>
+    </ToastManagerContext.Provider>
   );
 };
 
-ToastProvider.displayName = 'ToastProvider';
+ToastManager.displayName = 'ToastManager';
 
-export default ToastProvider;
+export default ToastManager;

--- a/packages/react/src/toast/ToastMessage.js
+++ b/packages/react/src/toast/ToastMessage.js
@@ -3,9 +3,14 @@ import { Box } from '../box';
 import {
   useToastMessageStyle,
 } from './styles';
+import useToast from './useToast';
 
 const ToastMessage = forwardRef((props, ref) => {
-  const styleProps = useToastMessageStyle({});
+  const alertContext = useToast(); // context might be an undefined value
+  const {
+    isClosable,
+  } = { ...alertContext };
+  const styleProps = useToastMessageStyle({ isClosable });
 
   return (
     <Box

--- a/packages/react/src/toast/context.js
+++ b/packages/react/src/toast/context.js
@@ -1,7 +1,9 @@
 import { createContext } from 'react';
 
 const ToastContext = createContext();
+const ToastManagerContext = createContext();
 
 export {
   ToastContext,
+  ToastManagerContext,
 };

--- a/packages/react/src/toast/index.js
+++ b/packages/react/src/toast/index.js
@@ -3,19 +3,22 @@ import ToastCloseButton from './ToastCloseButton';
 import ToastContainer from './ToastContainer';
 import ToastController from './ToastController';
 import ToastIcon from './ToastIcon';
+import ToastManager from './ToastManager';
 import ToastMessage from './ToastMessage';
-import ToastProvider from './ToastProvider';
 import ToastTransition from './ToastTransition';
-import useToast from './useToast';
+import useToastManager from './useToastManager';
 
 export {
   Toast,
-  ToastCloseButton, // internal use only
-  ToastContainer, // internal use only
+  ToastCloseButton,
+  ToastContainer,
   ToastController,
-  ToastIcon, // internal use only
-  ToastMessage, // internal use only
-  ToastProvider,
+  ToastIcon,
+  ToastManager,
+  ToastMessage,
   ToastTransition,
-  useToast,
+  useToastManager,
 };
+
+export const ToastProvider = ToastManager; // alias of ToastManager
+export const useToast = useToastManager; // alias of useToastManager

--- a/packages/react/src/toast/styles.js
+++ b/packages/react/src/toast/styles.js
@@ -99,7 +99,7 @@ const useToastMessageStyle = ({
  * ```jsx
  * <Toast appearance="success">
  *   <Text pr="10x">This is a success toast.</Text>
- *   <ToastCloseButton right={7} top={3} position="absolute" />
+ *   <ToastCloseButton top={9} right={7} position="absolute" />
  * </Toast>
  * ```
  *

--- a/packages/react/src/toast/styles.js
+++ b/packages/react/src/toast/styles.js
@@ -1,13 +1,11 @@
-import _get from 'lodash.get';
 import { useColorMode } from '../color-mode';
+import { useIconButtonStyle } from '../shared/styles';
 import { useTheme } from '../theme';
 
-const getAppearanceProps = ({
-  theme,
-  colorMode,
+const getAppearanceStyle = ({
   appearance,
+  colorMode,
 }) => {
-  const { sizes } = theme;
   const backgroundColor = {
     dark: 'gray:10',
     light: 'white',
@@ -17,25 +15,25 @@ const getAppearanceProps = ({
     success: {
       borderLeftColor: 'green:50',
       borderLeftStyle: 'solid',
-      borderLeftWidth: _get(sizes, '1x'),
+      borderLeftWidth: '1x',
       pl: '3x',
     },
     info: {
       borderLeftColor: 'blue:50',
       borderLeftStyle: 'solid',
-      borderLeftWidth: _get(sizes, '1x'),
+      borderLeftWidth: '1x',
       pl: '3x',
     },
     warning: {
       borderLeftColor: 'yellow:50',
       borderLeftStyle: 'solid',
-      borderLeftWidth: _get(sizes, '1x'),
+      borderLeftWidth: '1x',
       pl: '3x',
     },
     error: {
       borderLeftColor: 'red:60',
       borderLeftStyle: 'solid',
-      borderLeftWidth: _get(sizes, '1x'),
+      borderLeftWidth: '1x',
       pl: '3x',
     },
   }[appearance];
@@ -50,22 +48,17 @@ const getAppearanceProps = ({
 const useToastStyle = ({
   appearance,
 }) => {
-  const theme = useTheme();
   const [colorMode] = useColorMode();
-  const _props = {
-    theme,
-    colorMode,
-    appearance,
-  };
-  const appearanceProps = getAppearanceProps(_props);
+  const appearanceStyle = getAppearanceStyle({ appearance, colorMode });
 
   return {
     display: 'flex',
     alignItems: 'flex-start',
     justifyContent: 'space-between',
+    position: 'relative',
     px: '4x',
-    py: '2x',
-    ...appearanceProps,
+    py: '4x',
+    ...appearanceStyle,
   };
 };
 
@@ -80,72 +73,71 @@ const useToastIconStyle = ({
   }[appearance];
 
   return {
-    display: 'flex',
     color,
-    py: '1x',
-    lineHeight: 1, // exactly the same height as the icon's height
+    display: 'inline-flex',
+    mr: '2x',
+    mt: '1h',
   };
 };
 
-const useToastMessageStyle = () => {
+const useToastMessageStyle = ({
+  isClosable,
+}) => {
   return {
-    py: 2,
-    mt: -1,
+    pr: isClosable ? '10x' : 0,
     width: '100%',
   };
 };
 
-const useToastCloseButtonStyle = () => {
+/**
+ * Returns a style object for the close button in a toast component.
+ *
+ * If `isClosable` is true, the button will be positioned absolutely in the top-right corner of the toast.
+ *
+ * You can also control the position of the close button declaratively by using the `ToastCloseButton` component within an `Toast` component:
+ *
+ * ```jsx
+ * <Toast appearance="success">
+ *   <Text pr="10x">This is a success toast.</Text>
+ *   <ToastCloseButton right={7} top={3} position="absolute" />
+ * </Toast>
+ * ```
+ *
+ * In this case, the `isClosable` prop is not needed and can be omitted.
+ */
+const useToastCloseButtonStyle = ({
+  isClosable,
+  variant,
+}) => {
   const [colorMode] = useColorMode();
-  const { colors } = useTheme();
+  const { sizes } = useTheme();
   const color = {
     dark: 'black:tertiary',
     light: 'black:tertiary',
   }[colorMode];
-  const hoverColor = {
+  const size = '8x';
+  const _focusBorderColor = 'blue:60';
+  const _focusBoxShadowBorderColor = 'blue:60';
+  const _hoverColor = {
     dark: 'black:primary',
     light: 'black:primary',
   }[colorMode];
-  const activeColor = color;
-  const focusColor = color;
-  const focusHoverColor = hoverColor;
-  const focusActiveColor = activeColor;
-  const focusBorderColor = _get(colors, 'blue:60');
+  const baseStyle = useIconButtonStyle({ color, size, _focusBorderColor, _focusBoxShadowBorderColor, _hoverColor });
 
-  return {
-    border: 1,
-    borderColor: 'transparent',
-    color: color,
-    transition: 'all .2s',
-    lineHeight: 1,
-    height: '8x',
-    width: '8x',
-    minWidth: '8x', // ensure a minimum width for the close button
-    mt: -4,
-    mb: -4,
-    mr: -8,
-    px: 0,
-    py: 0,
-    _hover: {
-      color: hoverColor,
-    },
-    _active: {
-      color: activeColor,
-    },
-    _focus: {
-      borderColor: focusBorderColor,
-      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
-      color: focusColor,
-    },
-    _focusHover: {
-      color: focusHoverColor,
-    },
-    _focusActive: {
-      borderColor: focusBorderColor,
-      boxShadow: `inset 0 0 0 1px ${focusBorderColor}`,
-      color: focusActiveColor,
-    },
-  };
+  if (isClosable) {
+    const parentBorderWidth = sizes['1q'];
+    const top = `calc(${sizes['10q']} - ${parentBorderWidth})`; // (52px - 32px) / 2 = 10px
+    const right = `calc(${sizes['2x']} - ${parentBorderWidth})`;
+
+    return {
+      ...baseStyle,
+      position: 'absolute',
+      top,
+      right,
+    };
+  }
+
+  return baseStyle;
 };
 
 export {

--- a/packages/react/src/toast/styles.js
+++ b/packages/react/src/toast/styles.js
@@ -1,6 +1,5 @@
 import { useColorMode } from '../color-mode';
 import { useIconButtonStyle } from '../shared/styles';
-import { useTheme } from '../theme';
 
 const getAppearanceStyle = ({
   appearance,
@@ -110,7 +109,6 @@ const useToastCloseButtonStyle = ({
   variant,
 }) => {
   const [colorMode] = useColorMode();
-  const { sizes } = useTheme();
   const color = {
     dark: 'black:tertiary',
     light: 'black:tertiary',
@@ -125,9 +123,8 @@ const useToastCloseButtonStyle = ({
   const baseStyle = useIconButtonStyle({ color, size, _focusBorderColor, _focusBoxShadowBorderColor, _hoverColor });
 
   if (isClosable) {
-    const parentBorderWidth = sizes['1q'];
-    const top = `calc(${sizes['10q']} - ${parentBorderWidth})`; // (52px - 32px) / 2 = 10px
-    const right = `calc(${sizes['2x']} - ${parentBorderWidth})`;
+    const top = '10q'; // (52px - 32px) / 2 = 10px
+    const right = '2x';
 
     return {
       ...baseStyle,

--- a/packages/react/src/toast/useToast.js
+++ b/packages/react/src/toast/useToast.js
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
 import { ToastContext } from './context';
 
 const useToast = () => {
@@ -7,19 +7,7 @@ const useToast = () => {
   }
 
   const context = useContext(ToastContext);
-
-  if (!context) {
-    throw new Error('The `useToast` hook must be called from a descendent of the `ToastProvider`.');
-  }
-
-  const toast = useMemo(() => {
-    const fn = function (...args) {
-      return context.notify(...args);
-    };
-    return Object.assign(fn, context);
-  }, [context]);
-
-  return toast;
+  return context;
 };
 
 export default useToast;

--- a/packages/react/src/toast/useToastManager.js
+++ b/packages/react/src/toast/useToastManager.js
@@ -1,0 +1,25 @@
+import { useContext, useMemo } from 'react';
+import { ToastManagerContext } from './context';
+
+const useToastManager = () => {
+  if (!useContext) {
+    throw new Error('The `useContext` hook is not available with your React version.');
+  }
+
+  const context = useContext(ToastManagerContext);
+
+  if (!context) {
+    throw new Error('The `useToastManager` hook must be called from a descendent of the `ToastManager`.');
+  }
+
+  const toast = useMemo(() => {
+    const fn = function (...args) {
+      return context.notify(...args);
+    };
+    return Object.assign(fn, context);
+  }, [context]);
+
+  return toast;
+};
+
+export default useToastManager;


### PR DESCRIPTION
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-687/

This PR introduces new functionality to the `DrawerCloseButton`, `ModalCloseButton`, `AlertCloseButton`, `ToastCloseButton`, and `TagCloseButton` components, allowing custom props to be passed in. This provides greater flexibility for using these components.

If you choose to use above components, the `isClosable` prop is unnecessary and can be left out. However, for the `AlertCloseButton`, `ToastCloseButton`, and `TagCloseButton`, you must control the position by yourself.

To help illustrate usage, we have provided some examples below:

## Drawer

### How to close a drawer

#### Using the `isClosable` prop to

The `isClosable` prop is used to make a drawer closable by adding a close button to it. By default, the value of `isClosable` is false. To make a drawer closable, set `isClosable` to true.

```jsx disabled
<Drawer isOpen={isOpen} isClosable onClose={onClose}>
  <DrawerOverlay />
  <DrawerContent>
    <DrawerHeader />
    <DrawerBody />
    <DrawerFooter />
  </DrawerContent>
</Drawer>
```

#### Using the `DrawerCloseButton` component

The `DrawerCloseButton` component provides an easy way to add a close button to a drawer. This button is specifically designedto handle closing the drawer, so you don't need to write any additional code to handle it. If you use `DrawerCloseButton`, youcan omit the `isClosable` prop in the `Drawer` component.

Besides the default functionality of the `DrawerCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `DrawerCloseButton` component as needed.

```jsx disabled
<Drawer isOpen={isOpen} onClose={onClose}>
  <DrawerOverlay />
  <DrawerContent>
    <DrawerHeader />
    <DrawerBody />
    <DrawerFooter />
    <DrawerCloseButton data-test="drawer-close-button" />
  </DrawerContent>
</Drawer>
```

## Modal

### How to close a modal

#### Using the `isClosable` prop

The `isClosable` prop is used to make a modal closable by adding a close button to it. By default, the value of `isClosable` is false. To make a modal closable, set `isClosable` to true.

```jsx disabled
<Modal isOpen={isOpen} isClosable onClose={onClose}>
  <ModalOverlay />
  <ModalContent>
    <ModalHeader />
    <ModalBody />
    <ModalFooter />
  </ModalContent>
</Modal>
```

#### Using the `ModalCloseButton` component

The `ModalCloseButton` component provides an easy way to add a close button to a modal. This button is specifically designed to handle closing the modal, so you don't need to write any additional code to handle it. If you use `ModalCloseButton`, you canomit the `isClosable` prop in the `Modal` component.

Besides the default functionality of the `ModalCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `ModalCloseButton` component as needed.

```jsx disabled
<Modal isOpen={isOpen} onClose={onClose}>
  <ModalOverlay />
  <ModalContent>
    <ModalHeader />
    <ModalBody />
    <ModalFooter />
    <ModalCloseButton data-test="modal-close-button" />
  </ModalContent>
</Modal>
```

## Alert

### How to close an alert

#### Using the `isClosable` prop

The `isClosable` prop is used to make an alert closable by adding a close button to it. By default, the value of `isClosable` is false. To make an alert closable, set `isClosable` to true.

```jsx disabled
<Alert variant="solid" severity="success" isClosable onClose={onClose}>
  <Text>This is a success alert.</Text>
</Alert>
```

```jsx noInline
render(() => {
  const [isOpen, onClose] = useToggle(true);
  return (
    <Collapse in={isOpen} unmountOnExit>
      <Alert variant="solid" severity="success" isClosable onClose={onClose}>
        <Text>This is a success alert.</Text>
      </Alert>
    </Collapse>
  );
});
```

#### Using the `AlertCloseButton` component

The `AlertCloseButton` component provides an easy way to add a close button to an alert. This button is specifically designed to handle closing the alert, so you don't need to write any additional code to handle it. If you use `AlertCloseButton`, you can omit the `isClosable` prop in the `Alert` component.

Besides the default functionality of the `AlertCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `AlertCloseButton` component as needed.

```jsx disabled
<Alert variant="solid" severity="success" onClose={onClose}>
  <Text pr="10x">This is a success alert.</Text>
  <AlertCloseButton top={3} right={7} position="absolute" data-test="alert-close-button" />
</Alert>
```

When using the `AlertCloseButton` component, be sure to manually adjust its position. In the example above, the close button is positioned absolutely, with 3 pixels from the top and 7 pixels from the right of its parent element.

```jsx noInline
render(() => {
  const [isOpen, onClose] = useToggle(true);
  return (
    <Collapse in={isOpen} unmountOnExit>
      <Alert variant="solid" severity="success" onClose={onClose}>
        <Text pr="10x">This is a success alert.</Text>
        <AlertCloseButton top={3} right={7} position="absolute" data-test="alert-close-button" />
      </Alert>
    </Collapse>
  );
});
```

## Toast

### How to close a toast

#### Using the `isClosable` prop

The `isClosable` prop is used to make a toast closable by adding a close button to it. By default, the value of `isClosable` is false. To make a toast closable, set `isClosable` to true.

```jsx disabled
<Toast appearance="success" isClosable onClose={onClose} width={320}>
  <Text>This is a success toast.</Text>
</Toast>
```

```jsx noInline
render(() => {
  const [isOpen, onClose] = useToggle(true);
  return (
    <Collapse in={isOpen} unmountOnExit>
      <Toast appearance="success" isClosable onClose={onClose} width={320}>
        <Text>This is a success toast.</Text>
      </Toast>
    </Collapse>
  );
});
```

#### Using the `ToastCloseButton` component

The `ToastCloseButton` component provides an easy way to add a close button to a toast. This button is specifically designed to handle closing the toast, so you don't need to write any additional code to handle it. If you use `ToastCloseButton`, you canomit the `isClosable` prop in the `Toast` component.

Besides the default functionality of the `ToastCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `ToastCloseButton` component as needed.

```jsx disabled
<Toast appearance="success" onClose={onClose} width={320}>
  <Text pr="10x">This is a success toast.</Text>
  <ToastCloseButton top={10} right={8} position="absolute" data-test="toast-close-button" />
</Toast>
```

When using the `ToastCloseButton` component, be sure to manually adjust its position. In the example above, the close button is positioned absolutely, with 10 pixels from the top and 8 pixels from the right of its parent element.

```jsx noInline
render(() => {
  const [isOpen, onClose] = useToggle(true);
  return (
    <Collapse in={isOpen} unmountOnExit>
      <Toast appearance="success" onClose={onClose} width={320}>
        <Text pr="10x">This is a success toast.</Text>
        <ToastCloseButton top={10} right={8} position="absolute" data-test="toast-close-button" />
      </Toast>
    </Collapse>
  );
});
```

## Tag

### How to close a tag

#### Using the `isClosable` prop

The `isClosable` prop is used to make a tag closable by adding a close button to it. By default, the value of `isClosable` is false. To make an alert closable, set `isClosable` to true.

```jsx disabled
<Tag variant="solid" isClosable onClose={onClose}>
  <Text>This is a tag</Text>
</Tag>
```

```jsx noInline
render(() => {
  const [isOpen, onClose] = useToggle(true);
  return (
    <Fade in={isOpen} unmountOnExit>
      <Tag variant="solid" isClosable onClose={onClose}>
        <Text>This is a tag</Text>
      </Tag>
    </Fade>
  );
});
```

#### Using the `TagCloseButton` component

The `TagCloseButton` component provides an easy way to add a close button to a tag. This button is specifically designed to handle closing the tag, so you don't need to write any additional code to handle it. If you use `TagCloseButton`, you can omit the `isClosable` prop in the `Tag` component.

Besides the default functionality of the `TagCloseButton`, you can also pass additional props, such as `data-test` or `data-tracking` attributes, to the `TagCloseButton` component as needed.

```jsx disabled
<Tag variant="solid" onClose={onClose}>
  <Text>This is a tag</Text>
  <TagCloseButton ml="2x" data-test="tag-close-button" />
</Tag>
```

When using the `TagCloseButton` component, be sure to manually adjust its position. In the example above, the close button is positioned with a `2x` (=8px) margin on the left side to ensure sufficient spacing between the tag and the button.

```jsx noInline
render(() => {
  const [isOpen, onClose] = useToggle(true);
  return (
    <Fade in={isOpen} unmountOnExit>
      <Tag variant="solid" onClose={onClose}>
        <Text>This is a tag</Text>
        <TagCloseButton ml="2x" data-test="tag-close-button" />
      </Tag>
    </Fade>
  );
});
```
