### PR TITLE
feat(styled-system): add `outlineTransform` to transform the `outline` property to fit the needs of high-contrast mode users

### DIFF
--- a/packages/styled-system/src/config/__tests__/outline.test.js
+++ b/packages/styled-system/src/config/__tests__/outline.test.js
@@ -1,18 +1,30 @@
 import outline from '../outline';
 
-test('returns outline styles', () => {
-  const style = outline({
-    outline: 'thick double #32a1ce',
-  });
-  expect(style).toEqual({
-    outline: 'thick double #32a1ce',
+const defaultTheme = {
+  breakpoints: [40, 52, 64].map(n => n + 'em'),
+  size: [0, 4, 8, 16, 32, 64, 128, 256, 512],
+  space: [0, 4, 8, 16, 32, 64, 128, 256, 512],
+};
+
+describe('outline in high-contrast mode', () => {
+  test('should add "outline" and "outlineOffset" properties', () => {
+    const expected = {
+      outline: '2px solid transparent',
+      outlineOffset: '2px',
+    };
+
+    expect(outline({ outline: 'none' })).toEqual(expected);
+    expect(outline({ outline: '0' })).toEqual(expected);
+    expect(outline({ outline: 0 })).toEqual(expected);
   });
 });
 
-test('returns individual outline styles', () => {
+test('returns outline styles', () => {
   const style = outline({
     theme: {
+      ...defaultTheme,
       sizes: {
+        ...defaultTheme?.sizes,
         thin: 1,
         thick: 4,
       },
@@ -20,12 +32,16 @@ test('returns individual outline styles', () => {
         primary: 'red',
       },
     },
+    outline: 'thick double #32a1ce',
     outlineColor: 'primary',
+    outlineOffset: -1,
     outlineWidth: 'thin',
     outlineStyle: 'solid',
   });
   expect(style).toEqual({
+    outline: 'thick double #32a1ce',
     outlineColor: 'red',
+    outlineOffset: -4,
     outlineWidth: 1,
     outlineStyle: 'solid',
   });

--- a/packages/styled-system/src/config/outline.js
+++ b/packages/styled-system/src/config/outline.js
@@ -1,11 +1,21 @@
 import system from '../core/system';
-import { positiveOrNegative as positiveOrNegativeTransform } from '../utils/transforms';
+import {
+  outline as outlineTransform,
+  positiveOrNegative as positiveOrNegativeTransform,
+} from '../utils/transforms';
 
 const group = 'outline';
 const config = {
   outline: {
-    property: 'outline',
+    // If the "outline" property value is "0", "none", or 0, transform it to:
+    // {
+    //   outline: "2px solid transparent"
+    //   outlineOffset: "2px"
+    // }
+    // Otherwise, leave the "outline" property value as-is
+    properties: ['outline', 'outlineOffset'],
     scale: 'outlines',
+    transform: outlineTransform,
   },
   outlineColor: {
     property: 'outlineColor',

--- a/packages/styled-system/src/utils/transforms.js
+++ b/packages/styled-system/src/utils/transforms.js
@@ -1,5 +1,19 @@
 import get from './get';
 
+export const outline = (value, scale, props) => {
+  const isNoneOrZero = value === 'none' || value === '0' || value === 0;
+  if (isNoneOrZero) {
+    return {
+      outline: '2px solid transparent',
+      outlineOffset: '2px',
+    };
+  }
+
+  return {
+    outline: get(scale, value, value),
+  };
+};
+
 export const positiveOrNegative = (value, scale, props) => {
   /**
    * Scale object


### PR DESCRIPTION
The new `outline-transform` prop in the `@tonic-ui/styled-system` library allows developers to transform the `outline` property to fit the needs of high-contrast mode users. This feature improves accessibility and usability for users who rely on high-contrast settings.