### PR TITLE
fix(styled-system): set `outlineOffset="unset"` to fallback to the initial value if the `outline` is not zero

### DIFF
--- a/packages/styled-system/src/utils/transforms.js
+++ b/packages/styled-system/src/utils/transforms.js
@@ -11,6 +11,7 @@ export const outline = (value, scale, props) => {
 
   return {
     outline: get(scale, value, value),
+    outlineOffset: 'unset',
   };
 };
 


### PR DESCRIPTION
The transformation of `outline: 0` to `outline: 2px solid transparent; outlineOffset: 2px;` was implemented in PR #693.

Before
```css
outline: 0;
```

After
```css
outline: 2px solid transparent;
outlineOffset: 2px;
```

However, it was observed that `outlineOffset` was not removed in focus mode when the `outline` was not zero.

![image](https://user-images.githubusercontent.com/447801/219865729-c4cd5a52-4a40-42dd-b9a3-890b7b49a5bd.png)
