### PR TITLE
feat: improve focus control by adding `returnFocusOnClose` prop to the `Menu` component

### DIFF
--- a/packages/react-docs/pages/components/menu.mdx
+++ b/packages/react-docs/pages/components/menu.mdx
@@ -194,92 +194,128 @@ The following example shows a menu with cascading submenus.
 </Flex>
 ```
 
-### Controlled menu
+### Controlled and uncontrolled menu
 
-The menu opens over the anchor element by default, and closes when the user clicks outside of the menu.
+Pass `isOpen` to the `Menu` component to control the state of the menu.
 
-```jsx noInline
-render(() => {
-  const [anchorEl, setAnchorEl] = React.useState(null);
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [colorMode] = useColorMode();
-  const [colorStyle] = useColorStyle({ colorMode });
+```jsx
+function Example() {
+  const [isOpen, toggleIsOpen] = useToggle(false);
+  const onClose = () => toggleIsOpen(false);
   const [selectedValue, setSelectedValue] = React.useState(null);
-  const handleOpenMenu = (event) => {
-    setAnchorEl(event.currentTarget);
-    setIsOpen(!isOpen);
-  };
-  const handleCloseMenu = () => {
-    setAnchorEl(null);
-    setIsOpen(false);
-  };
   const handleClickMenuItem = (event) => {
     const value = event.target.getAttribute('value');
-    setSelectedValue(value);
-  };
-  const handleMenuItemClick = (event) => {
-    const value = event.target.getAttribute('value');
-    console.log(`List item ${value} clicked`);
+    if (!isNullOrUndefined(value)) {
+      setSelectedValue(value);
+    }
   };
 
   return (
     <Flex columnGap="4x" alignItems="center">
-      <Button
-        aria-controls="basic-menu"
-        aria-haspopup="true"
-        aria-expanded={isOpen ? 'true' : undefined}
-        onClick={handleOpenMenu}
-      >
-        Options
-      </Button>
-      <Text>Selected: {selectedValue}</Text>
-      {isOpen && (
-        <Menu
-          id="basic-menu"
-          anchorEl={anchorEl}
-          isOpen={isOpen}
-          onClose={handleCloseMenu}
+      <Menu isOpen={isOpen} onClose={onClose}>
+        <MenuButton onClick={toggleIsOpen}>
+          Options
+        </MenuButton>
+        <MenuList
+          onClick={handleClickMenuItem}
+          width="max-content"
         >
-          <MenuList
-            onClick={handleClickMenuItem}
-            width="max-content"
-          >
-            <MenuItem value={1}>
-              List item 1
-            </MenuItem>
-            <MenuItem value={2}>
-              List item 2
-            </MenuItem>
-            <MenuDivider />
-            <Submenu>
-              <SubmenuToggle>
-                <MenuItem>
-                  <Flex
-                    alignItems="center"
-                    columnGap="2x"
-                    justifyContent="space-between"
-                    width="100%"
-                  >
-                    Submenu
-                    <Icon icon="angle-right" />
-                  </Flex>
-                </MenuItem>
-              </SubmenuToggle>
-              <SubmenuList width="max-content">
-                <MenuItem value={3}>
-                  List item 3
-                </MenuItem>
-                <MenuItem value={4}>
-                  List item 4
-                </MenuItem>
-              </SubmenuList>
-            </Submenu>
-          </MenuList>
-        </Menu>
-      )}
+          <MenuItem value={1}>
+            List item 1
+          </MenuItem>
+          <MenuItem value={2}>
+            List item 2
+          </MenuItem>
+          <MenuDivider />
+          <Submenu>
+            <SubmenuToggle>
+              <MenuItem>
+                <Flex
+                  alignItems="center"
+                  columnGap="2x"
+                  justifyContent="space-between"
+                  width="100%"
+                >
+                  Submenu
+                  <Icon icon="angle-right" />
+                </Flex>
+              </MenuItem>
+            </SubmenuToggle>
+            <SubmenuList width="max-content">
+              <MenuItem value={3}>
+                List item 3
+              </MenuItem>
+              <MenuItem value={4}>
+                List item 4
+              </MenuItem>
+            </SubmenuList>
+          </Submenu>
+        </MenuList>
+      </Menu>
+      <Text>Selected: {selectedValue}</Text>
     </Flex>
   );
-});
+}
+```
+
+Menu is uncontrolled by default. You can set `defaultIsOpen` to `true` to have the menu open for the first render.
+
+```jsx
+function Example() {
+  const [selectedValue, setSelectedValue] = React.useState(null);
+  const handleClickMenuItem = (event) => {
+    const value = event.target.getAttribute('value');
+    if (!isNullOrUndefined(value)) {
+      setSelectedValue(value);
+    }
+  };
+
+  return (
+    <Flex columnGap="4x" alignItems="center">
+      <Menu>
+        <MenuButton>
+          Options
+        </MenuButton>
+        <MenuList
+          onClick={handleClickMenuItem}
+          width="max-content"
+        >
+          <MenuItem value={1}>
+            List item 1
+          </MenuItem>
+          <MenuItem value={2}>
+            List item 2
+          </MenuItem>
+          <MenuDivider />
+          <Submenu>
+            <SubmenuToggle>
+              <MenuItem>
+                <Flex
+                  alignItems="center"
+                  columnGap="2x"
+                  justifyContent="space-between"
+                  width="100%"
+                >
+                  Submenu
+                  <Icon icon="angle-right" />
+                </Flex>
+              </MenuItem>
+            </SubmenuToggle>
+            <SubmenuList width="max-content">
+              <MenuItem value={3}>
+                List item 3
+              </MenuItem>
+              <MenuItem value={4}>
+                List item 4
+              </MenuItem>
+            </SubmenuList>
+          </Submenu>
+        </MenuList>
+      </Menu>
+      <Text>Selected: {selectedValue}</Text>
+    </Flex>
+  );
+}
 ```
 
 ### MenuToggle

--- a/packages/react-docs/pages/components/menu.mdx
+++ b/packages/react-docs/pages/components/menu.mdx
@@ -1178,6 +1178,7 @@ render(() => {
 | onKeyDown | function | | Callback when the user presses a key. |
 | onOpen | function | | Callback when the menu is opened. |
 | placement | string | 'bottom-start' | The placement of the menu. One of: 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end' |
+| returnFocusOnClose | boolean | true | If `true`, the menu will return the focus to the trigger element when closing. Otherwise, it will leave focus unchanged. |
 
 ### MenuButton
 

--- a/packages/react-docs/pages/components/popover.mdx
+++ b/packages/react-docs/pages/components/popover.mdx
@@ -34,7 +34,7 @@ To create an accessible popover, it should allow users to access it using the ta
 ```jsx disabled
 <Popover>
   <PopoverTrigger>
-    <Button>Trigger</Button>
+    <Button variant="secondary">Trigger</Button>
   </PopoverTrigger>
   <PopoverContent>
     <PopoverHeader>Popover Header</PopoverHeader>
@@ -48,7 +48,7 @@ By default, you have to pass a single React element child to the `PopoverTrigger
 
 ```jsx disabled
 <PopoverTrigger>
-  <Button>Trigger</Button>
+  <Button variant="secondary">Trigger</Button>
 </PopoverTrigger>
 ```
 
@@ -111,7 +111,7 @@ Popover is uncontrolled by default. You can set `defaultIsOpen` to `true` to hav
 ```jsx
 <Popover defaultIsOpen={false}>
   <PopoverTrigger>
-    <Button>Trigger</Button>
+    <Button variant="secondary">Trigger</Button>
   </PopoverTrigger>
   <PopoverContent>
     <Text>This is an uncontrolled popover</Text>
@@ -134,7 +134,7 @@ function Example() {
       initialFocusRef={initialFocusRef}
     >
       <PopoverTrigger>
-        <Button>Trigger</Button>
+        <Button variant="secondary">Trigger</Button>
       </PopoverTrigger>
       <PopoverContent>
         <PopoverHeader>
@@ -166,9 +166,7 @@ function Example() {
 
 #### Focus an element when popover closes
 
-The focus status will send to `PopoverTrigger` when `Popover` closes. You can send the focus status to a specific element when it closes by passing the `finalFocusRef` prop.
-
-If required, you can set `returnFocusOnClose` to `false` to prevent `Popover` from returning the focus status to `PopoverTrigger`.
+When the `Popover` is closed, the focus status is sent to the `PopoverTrigger`. If you need to prevent the `Popover` from returning the focus status to `PopoverTrigger`, you can set the `returnFocusOnClose` prop to `false`.
 
 ```jsx
 function Example() {
@@ -185,7 +183,7 @@ function Example() {
         returnFocusOnClose={false}
       >
         <PopoverTrigger>
-          <Button onClick={toggle}>
+          <Button variant="secondary" onClick={toggle}>
             Trigger
           </Button>
         </PopoverTrigger>
@@ -205,7 +203,7 @@ function Example() {
   hideArrow
 >
   <PopoverTrigger>
-    <Button>Trigger</Button>
+    <Button variant="secondary">Trigger</Button>
   </PopoverTrigger>
   <PopoverContent>
     Popover
@@ -228,7 +226,7 @@ The second number, `distance`, controls the distance between the `PopoverContent
 ```jsx
 <Popover offset={[24, 12]}>
   <PopoverTrigger>
-    <Button>Trigger</Button>
+    <Button variant="secondary">Trigger</Button>
   </PopoverTrigger>
   <PopoverContent>
     Popover
@@ -245,7 +243,7 @@ To access the internal state of the popover, you can use the Function as Child C
   {({ isOpen, onClose }) => (
     <>
       <PopoverTrigger>
-        <Button>Trigger</Button>
+        <Button variant="secondary">Trigger</Button>
       </PopoverTrigger>
       <PopoverContent>
         <PopoverHeader>
@@ -306,7 +304,7 @@ The `nextToCursor` prop will set the popover position next to the cursor.
 ```jsx
 <Popover trigger="hover" nextToCursor>
   <PopoverTrigger>
-    <Button>Trigger</Button>
+    <Button variant="secondary">Trigger</Button>
   </PopoverTrigger>
   <PopoverContent>
     Popover
@@ -321,7 +319,7 @@ The `followCursor` prop will set the popover position to follow the cursor when 
 ```jsx
 <Popover trigger="hover" followCursor>
   <PopoverTrigger>
-    <Button>Trigger</Button>
+    <Button variant="secondary">Trigger</Button>
   </PopoverTrigger>
   <PopoverContent>
     Popover
@@ -386,7 +384,7 @@ To mitigate this issue, you can pass `PopperProps={{ usePortal: true }}` to `Pop
 ```jsx
 <Popover>
   <PopoverTrigger>
-    <Button>Trigger</Button>
+    <Button variant="secondary">Trigger</Button>
   </PopoverTrigger>
   <PopoverContent PopperProps={{ usePortal: true }}>
     Popover
@@ -398,21 +396,19 @@ To mitigate this issue, you can pass `PopperProps={{ usePortal: true }}` to `Pop
 
 ### Keyboard and focus
 
-* When `Popover` is opened, the focus status is moved to `PopoverContent`. If `initialFocusRef` is set, then the focus status is moved to the element with the related reference (`ref`).
+The `Popover` component includes several accessibility features to ensure that it is usable with a keyboard and assistive technologies:
 
-* When `Popover` is closed, the focus status returns to the trigger. If you set `returnFocusOnClose` to `false`, the focus status will not return.
+* When the `Popover` is opened, the focus is automatically moved to the `PopoverContent` element. If the `initialFocusRef` prop is set, then the focus is moved to the element with the specified reference.
 
-* If `trigger` is set to `hover`:
-  - Focusing on or mousing over the trigger will open `Popover`.
-  - Blurring or mousing out of the trigger will close `Popover`. If you move your mouse into `PopoverContent`, `Popover` remains visible.
+* When the `Popover` is closed, the focus returns to the trigger element by default. If the `returnFocusOnClose` prop is set to `false`, the focus will not return to the trigger element.
 
-* If `trigger` is set to `click`:
-  - Clicking the trigger or using the `Space` or `Enter` key when the focus status is on the trigger will open `Popover`.
-  - Clicking the trigger again will close `Popover`.
+* If the trigger prop is set to `'hover'`, the `Popover` can be opened by focusing on or mousing over the trigger element, and closed by blurring or mousing out of the trigger element. If the mouse is moved into the `PopoverContent` element, the `Popover` remains visible.
 
-* Hitting the `Esc` key while `Popover` is open and the focus status is within `PopoverContent` will close `Popover`. If you set `closeOnEsc` to `false`, `Popover` will not close.
+* If the trigger prop is set to `'click'`, the `Popover` can be opened by clicking on the trigger element or pressing the **Space** or **Enter** key when the trigger element has focus. The `Popover` can be closed by clicking on the trigger element again.
 
-* Clicking outside or blurring out of `PopoverContent` closes `Popover`. If you set `closeOnBlur` to `false`, `Popover` will not close.
+* The `Popover` can also be closed by hitting the **Esc** key when the `PopoverContent` element has focus, unless the `closeOnEsc` prop is set to `false`.
+
+* Clicking outside or blurring out of the `PopoverContent` element also closes the `Popover`, unless the `closeOnBlur` prop is set to `false`.
 
 ### ARIA attributes
 
@@ -455,7 +451,7 @@ To mitigate this issue, you can pass `PopperProps={{ usePortal: true }}` to `Pop
 | onClose | () => void | | Callback when the popover is closed. |
 | onOpen | () => void | | Callback when the popover is opened. |
 | placement | string | 'bottom' | The placement of the popover. One of: 'top', 'bottom', 'right', 'left', 'top-start', 'top-end', 'bottom-start', 'bottom-end', 'right-start', 'right-end', 'left-start', 'left-end' |
-| returnFocusOnClose | boolean | true | If `true`, the popover will return the focus status to the trigger when closing. |
+| returnFocusOnClose | boolean | true | If `true`, the popover will return the focus to the trigger element when closing. Otherwise, it will leave focus unchanged. |
 | trigger | string | 'click' | The type of trigger. One of: 'click', 'hover' |
 
 ### PopoverTrigger

--- a/packages/react-docs/pages/components/popover.mdx
+++ b/packages/react-docs/pages/components/popover.mdx
@@ -73,7 +73,7 @@ If you need to pass more than one child element or non-element children, wrap th
 </Popover>
 ```
 
-### Controlled usage
+### Controlled and uncontrolled popover
 
 Pass `isOpen` to the `Popover` component to control the state of the popover.
 
@@ -103,8 +103,6 @@ function Example() {
   );
 }
 ```
-
-### Uncontrolled usage
 
 Popover is uncontrolled by default. You can set `defaultIsOpen` to `true` to have the popover open for the first render.
 

--- a/packages/react-docs/pages/components/tooltip.mdx
+++ b/packages/react-docs/pages/components/tooltip.mdx
@@ -37,7 +37,7 @@ If you need to pass more than one child element or non-element children, wrap th
 </Tooltip>
 ```
 
-### Controlled usage
+### Controlled and uncontrolled tooltip
 
 Pass `isOpen` to the `Tooltip` component to control the state of the tooltip.
 
@@ -60,8 +60,6 @@ function Example() {
   );
 }
 ```
-
-### Uncontrolled usage
 
 Tooltip is uncontrolled by default. You can set `defaultIsOpen` to `true` to have the tooltip open for the first render.
 

--- a/packages/react/src/menu/Menu.js
+++ b/packages/react/src/menu/Menu.js
@@ -37,6 +37,7 @@ const Menu = forwardRef((
     onKeyDown: onKeyDownProp,
     onOpen: onOpenProp,
     placement = 'bottom-start', // One of: 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end'
+    returnFocusOnClose = true,
     ...rest
   },
   ref,
@@ -86,7 +87,7 @@ const Menu = forwardRef((
         });
       });
     }
-    if (activeIndex === -1 && !isOpen && prevIsOpen) {
+    if (activeIndex === -1 && !isOpen && prevIsOpen && returnFocusOnClose) {
       // Use requestAnimationFrame to ensure that the focus is set at the end of the current frame
       requestAnimationFrame(() => {
         const el = menuToggleRef.current;
@@ -100,7 +101,7 @@ const Menu = forwardRef((
         el && el.focus();
       });
     }
-  }, [isOpen, activeIndex, getFocusableElements, menuRef, menuToggleRef, prevIsOpen]);
+  }, [isOpen, activeIndex, getFocusableElements, menuRef, menuToggleRef, prevIsOpen, returnFocusOnClose]);
 
   const onOpen = useCallback(() => {
     const isControlled = (isOpenProp !== undefined);


### PR DESCRIPTION
The current implementation of the `Menu` component sets focus to the element that triggered the menu to open, usually the `MenuTrigger` or `MenuButton` component, when the menu is closed. However, this behavior may not always be desirable, such as when a user clicks a menu item to launch a popover or a modal.

To provide more control over focus management, we recommend adding a `returnFocusOnClose` prop to the `Menu` component. When the `returnFocusOnClose` prop is set to `true`, it would return focus to the element that triggered the menu to open, regardless of which element was used to open the menu. Otherwise, setting this prop to `false` would leave focus unchanged.

By default, the `returnFocusOnClose` prop will be set to `true` to maintain the current behavior of the `Menu` component.