### PR TITLE
feat: enhance focus control for `Drawer`, `Modal`, and `Tooltip` components

### DIFF
--- a/packages/react-docs/components/InputTag/InputTag.js
+++ b/packages/react-docs/components/InputTag/InputTag.js
@@ -136,7 +136,7 @@ const InputTag = forwardRef((props, ref) => {
                 key={id}
                 mr="2x"
                 title={value}
-                isInvalid={!!error}
+                error={!!error}
                 onChange={handleTagChange(id)}
                 onClose={handleTagClose(id)}
               >

--- a/packages/react-docs/pages/components/drawer.mdx
+++ b/packages/react-docs/pages/components/drawer.mdx
@@ -88,6 +88,7 @@ function Example() {
   const [closeOnOutsideClick, toggleCloseOnOutsideClick] = useToggle(true);
   const [ensureFocus, toggleEnsureFocus] = useToggle(true);
   const [isClosable, toggleIsClosable] = useToggle(true);
+  const [returnFocusOnClose, toggleReturnFocusOnClose] = useToggle(true);
   const [isOverlayVisible, toggleIsOverlayVisible] = useToggle(true);
   const [isHeaderVisible, toggleIsHeaderVisible] = useToggle(true);
   const [isBodyVisible, toggleIsBodyVisible] = useToggle(true);
@@ -234,6 +235,16 @@ function Example() {
           <Text fontFamily="mono" whiteSpace="nowrap">isClosable</Text>
         </TextLabel>
       </FormGroup>
+      <FormGroup>
+        <TextLabel display="flex" alignItems="center">
+          <Checkbox
+            checked={returnFocusOnClose}
+            onChange={() => toggleReturnFocusOnClose()}
+          />
+          <Space width="2x" />
+          <Text fontFamily="mono" whiteSpace="nowrap">returnFocusOnClose</Text>
+        </TextLabel>
+      </FormGroup>
       <Divider my="4x" />
       <Box mb="4x">
         <Text fontSize="lg" lineHeight="lg">
@@ -314,6 +325,7 @@ function Example() {
         isOpen={isOpen}
         onClose={() => toggleDrawer(false)}
         placement={placement}
+        returnFocusOnClose={returnFocusOnClose}
         size={size}
       >
         {enableBodyScrollLock && (

--- a/packages/react-docs/pages/components/drawer.mdx
+++ b/packages/react-docs/pages/components/drawer.mdx
@@ -239,6 +239,7 @@ function Example() {
         <TextLabel display="flex" alignItems="center">
           <Checkbox
             checked={returnFocusOnClose}
+            disabled={!ensureFocus}
             onChange={() => toggleReturnFocusOnClose()}
           />
           <Space width="2x" />
@@ -459,18 +460,18 @@ Besides the default functionality of the `DrawerCloseButton`, you can also pass 
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| autoFocus | boolean | false | If `true` and `ensureFocus` is `true` and `initialFocusRef` is not set, it will automatically set focus on the first focusable element. |
+| autoFocus | boolean | false | If `true`, the drawer will automatically set focus on the first focusable element inside the drawer when it is opened.<br />⚠️ This only works if `initialFocusRef` is not defined and `ensureFocus` is set to `true`. |
 | backdrop | boolean | false | If `true`, it will wrap components with a backdrop to provide a click area for dismissing when clicking outside the drawer. |
 | children | ReactNode \| `(context) => ReactNode` | | A function child can be used intead of a React element. This function is called with the context object. |
 | closeOnEsc | boolean | false | If `true`, close the drawer when the `esc` key is pressed. |
 | closeOnOutsideClick | boolean | false | If `true`, close the drawer when click outside of the drawer. Note that this value will not have any effect when `backdrop` is set to `true`. |
-| ensureFocus | boolean | false | If `true`, it will always bring the focus back to the `Drawer` descendants, which does not allow the focus to escape while open. |
-| finalFocusRef | RefObject | | The `ref` of element to receive focus when the drawer closes. |
-| initialFocusRef | RefObject | | The `ref` of the element to receive focus when the drawer opens. |
+| ensureFocus | boolean | false | If `true`, it ensures that the user's focus remains within the drawer when it is open, preventing them from interacting with elements outside the drawer. |
+| finalFocusRef | RefObject | | The `ref` of the element that should receive focus when the drawer closes.<br />⚠️ This only works if `ensureFocus` is set to `true`. |
+| initialFocusRef | RefObject | | The `ref` of the element that should receive focus when the drawer opens.<br />⚠️ This only works if `ensureFocus` is set to `true`. |
 | isClosable | boolean | false | If `true`, a close button will appear on the right side. |
 | isOpen | boolean | false | If `true`, the drawer is shown. |
 | onClose | function | | Callback fired when the drawer closes. |
-| returnFocusOnClose | boolean | true | If `true`, the focus will be restored to the element that was focused on when the drawer was initially opened. |
+| returnFocusOnClose | boolean | true | If `true`, the focus will be restored to the element that was focused on when the drawer was initially opened.<br />⚠️ This only works if `ensureFocus` is set to `true`. |
 | placement | string | 'right' | Change the placement of the drawer. One of: 'left', 'right', 'top', 'bottom' |
 | size | string | 'auto' | Change the size of the drawer. One of: 'auto', 'sm', 'md', 'lg', 'full' |
 

--- a/packages/react-docs/pages/components/drawer.mdx
+++ b/packages/react-docs/pages/components/drawer.mdx
@@ -98,9 +98,11 @@ function Example() {
   return (
     <>
       <Box>
-        <Button onClick={() => toggleDrawer(true)}>
-          Launch drawer
-        </Button>
+        <Tooltip label="Click to launch drawer" openOnFocus={false}>
+          <Button onClick={() => toggleDrawer(true)}>
+            Launch drawer
+          </Button>
+        </Tooltip>
       </Box>
       <Divider my="4x" />
       <Box mb="4x">
@@ -456,6 +458,7 @@ Besides the default functionality of the `DrawerCloseButton`, you can also pass 
 | isClosable | boolean | false | If `true`, a close button will appear on the right side. |
 | isOpen | boolean | false | If `true`, the drawer is shown. |
 | onClose | function | | Callback fired when the drawer closes. |
+| returnFocusOnClose | boolean | true | If `true`, the focus will be restored to the element that was focused on when the drawer was initially opened. |
 | placement | string | 'right' | Change the placement of the drawer. One of: 'left', 'right', 'top', 'bottom' |
 | size | string | 'auto' | Change the size of the drawer. One of: 'auto', 'sm', 'md', 'lg', 'full' |
 

--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -313,6 +313,7 @@ function Example() {
         <TextLabel display="flex" alignItems="center">
           <Checkbox
             checked={returnFocusOnClose}
+            disabled={!ensureFocus}
             onChange={() => toggleReturnFocusOnClose()}
           />
           <Space width="2x" />
@@ -683,17 +684,17 @@ function Example() {
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| autoFocus | boolean | false | If `true` and `ensureFocus` is `true` and `initialFocusRef` is not set, it will automatically set focus on the first focusable element. |
+| autoFocus | boolean | false | If `true`, the modal will automatically set focus on the first focusable element inside the modal when it is opened.<br />⚠️ This only works if `initialFocusRef` is not defined and `ensureFocus` is set to `true`. |
 | children | ReactNode \| `(context) => ReactNode` | | A function child can be used intead of a React element. This function is called with the context object. |
 | closeOnEsc | boolean | false | If `true`, close the modal when the `esc` key is pressed. |
 | closeOnOutsideClick | boolean | false | If `true`, close the modal when click outside of the modal. |
-| ensureFocus | boolean | false | If `true`, it will always bring the focus back to the `Modal` descendants, which does not allow the focus to escape while open. |
-| finalFocusRef | RefObject | | The `ref` of element to receive focus when the modal closes. |
-| initialFocusRef | RefObject | | The `ref` of the element to receive focus when the modal opens. |
+| ensureFocus | boolean | false | If `true`, it ensures that the user's focus remains within the modal when it is open, preventing them from interacting with elements outside the modal. |
+| finalFocusRef | RefObject | | The `ref` of the element that should receive focus when the modal closes.<br />⚠️ This only works if `ensureFocus` is set to `true`. |
+| initialFocusRef | RefObject | | The `ref` of the element that should receive focus when the modal opens.<br />⚠️ This only works if `ensureFocus` is set to `true`. |
 | isClosable | boolean | false | If `true`, a close button will appear on the right side. |
 | isOpen | boolean | false | If `true`, the modal is shown. |
 | onClose | function | | Callback fired when the modal closes. |
-| returnFocusOnClose | boolean | true | If `true`, the focus will be restored to the element that was focused on when the modal was initially opened. |
+| returnFocusOnClose | boolean | true | If `true`, the focus will be restored to the element that was focused on when the modal was initially opened.<br />⚠️ This only works if `ensureFocus` is set to `true`. |
 | size | string | 'auto' | Change the size of the modal. One of: 'auto', 'xs', 'sm', 'md', 'lg', 'xl', 'full' |
 | scrollBehavior | string | 'inside' | Control the scroll behavior of the modal if the content overflows. One of: 'inside', 'outside' |
 

--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -172,9 +172,11 @@ function Example() {
   return (
     <>
       <Box>
-        <Button onClick={() => toggleModal(true)}>
-          Launch modal
-        </Button>
+        <Tooltip label="Click to launch modal" openOnFocus={false}>
+          <Button onClick={() => toggleModal(true)}>
+            Launch modal
+          </Button>
+        </Tooltip>
       </Box>
       <Divider my="4x" />
       <Box mb="4x">
@@ -679,6 +681,7 @@ function Example() {
 | isClosable | boolean | false | If `true`, a close button will appear on the right side. |
 | isOpen | boolean | false | If `true`, the modal is shown. |
 | onClose | function | | Callback fired when the modal closes. |
+| returnFocusOnClose | boolean | true | If `true`, the focus will be restored to the element that was focused on when the modal was initially opened. |
 | size | string | 'auto' | Change the size of the modal. One of: 'auto', 'xs', 'sm', 'md', 'lg', 'xl', 'full' |
 | scrollBehavior | string | 'inside' | Control the scroll behavior of the modal if the content overflows. One of: 'inside', 'outside' |
 

--- a/packages/react-docs/pages/components/modal.mdx
+++ b/packages/react-docs/pages/components/modal.mdx
@@ -149,6 +149,7 @@ function Example() {
   const [closeOnOutsideClick, toggleCloseOnOutsideClick] = useToggle(true);
   const [ensureFocus, toggleEnsureFocus] = useToggle(true);
   const [isClosable, toggleIsCloseButtonVisible] = useToggle(true);
+  const [returnFocusOnClose, toggleReturnFocusOnClose] = useToggle(true);
   const [isOverlayVisible, toggleIsOverlayVisible] = useToggle(true);
   const [isHeaderVisible, toggleIsHeaderVisible] = useToggle(true);
   const [isBodyVisible, toggleIsBodyVisible] = useToggle(true);
@@ -308,6 +309,16 @@ function Example() {
           <Text fontFamily="mono" whiteSpace="nowrap">isClosable</Text>
         </TextLabel>
       </FormGroup>
+      <FormGroup>
+        <TextLabel display="flex" alignItems="center">
+          <Checkbox
+            checked={returnFocusOnClose}
+            onChange={() => toggleReturnFocusOnClose()}
+          />
+          <Space width="2x" />
+          <Text fontFamily="mono" whiteSpace="nowrap">returnFocusOnClose</Text>
+        </TextLabel>
+      </FormGroup>
       <Divider my="4x" />
       <Box mb="4x">
         <Text fontSize="lg" lineHeight="lg">
@@ -446,13 +457,14 @@ function Example() {
       <Modal
         TransitionComponent={null}
         autoFocus={autoFocus}
-        ensureFocus={ensureFocus}
         closeOnEsc={closeOnEsc}
         closeOnOutsideClick={closeOnOutsideClick}
+        ensureFocus={ensureFocus}
         initialFocusRef={initialFocusRef}
         isClosable={isClosable}
         isOpen={isOpen}
         onClose={() => toggleModal(false)}
+        returnFocusOnClose={returnFocusOnClose}
         scrollBehavior={scrollBehavior}
         size={size}
         {...modalStyleProps}

--- a/packages/react-docs/pages/components/tooltip.mdx
+++ b/packages/react-docs/pages/components/tooltip.mdx
@@ -404,9 +404,9 @@ To mitigate this issue, you can pass `PopperProps={{ usePortal: true }}` to `Too
 | TransitionProps.appear | boolean | true | |
 | arrow | boolean | true | If `true`, adds an arrow to the tooltip. |
 | children | ReactNode \| `(context) => ReactNode` | | |
-| closeOnClick | boolean | true | If `true`, close the tooltip on click. |
-| closeOnEsc | boolean | true | If `true`, close the tooltip when pressing the escape key. |
-| closeOnMouseDown | boolean | false | If `true`, close the tooltip while the mouse is down. |
+| closeOnClick | boolean | true | If `true`, the tooltip will close upon clicking. |
+| closeOnEsc | boolean | true | If `true`, the tooltip will close upon pressing the escape key. |
+| closeOnPointerDown | boolean | true | If `true`, the tooltip will close while the pointer is pressed down. |
 | defaultIsOpen | boolean | false | Whether the tooltip will be open by default. |
 | disabled | boolean | | If `true`, the tooltip will not display. |
 | enterDelay | number | 100 | The delay in milliseconds before the tooltip appears. |
@@ -418,5 +418,6 @@ To mitigate this issue, you can pass `PopperProps={{ usePortal: true }}` to `Too
 | offset | [skidding, distance] | [0, 8] | The skidding and distance of the tooltip. |
 | onClose| function | | Callback fired when the tooltip is closed. |
 | onOpen | function | | Callback fired when the tooltip is opened. |
+| openOnFocus | boolean | true | If `true`, the tooltip will open upon receiving focus. |
 | placement | PopperJS.Placement | 'bottom' | Position the tooltip relative to the trigger element as well as surrounding elements. One of: 'top', 'bottom', 'right', 'left', 'top-start', 'top-end', 'bottom-start', 'bottom-end', 'right-start', 'right-end', 'left-start', 'left-end' |
 | shouldWrapChildren | boolean | false | If `true`, the tooltip will be wrapped in a `Box` component. Otherwise, you have to ensure tooltip has only one child node. |

--- a/packages/react/src/alert/AlertCloseButton.js
+++ b/packages/react/src/alert/AlertCloseButton.js
@@ -26,6 +26,7 @@ const AlertCloseButton = forwardRef((
 
   return (
     <ButtonBase
+      aria-label="Close"
       ref={ref}
       onClick={callEventHandlers(onClickProp, onClose)}
       {...styleProps}

--- a/packages/react/src/drawer/Drawer.js
+++ b/packages/react/src/drawer/Drawer.js
@@ -29,6 +29,7 @@ const Drawer = forwardRef((
     onClose,
     placement = defaultPlacement,
     portalProps,
+    returnFocusOnClose = true,
     size = defaultSize,
     ...rest
   },
@@ -69,7 +70,7 @@ const Drawer = forwardRef((
     scrollBehavior: 'inside', // internal use only (only 'inside' is supported by Drawer)
   });
 
-  const returnFocus = !finalFocusRef;
+  const returnFocus = returnFocusOnClose && !finalFocusRef;
   const onFocusLockActivation = useCallback(() => {
     if (initialFocusRef && initialFocusRef.current) {
       const el = initialFocusRef.current;

--- a/packages/react/src/drawer/DrawerCloseButton.js
+++ b/packages/react/src/drawer/DrawerCloseButton.js
@@ -23,6 +23,7 @@ const DrawerCloseButton = forwardRef((
 
   return (
     <ButtonBase
+      aria-label="Close"
       ref={ref}
       onClick={callEventHandlers(onClickProp, onClose)}
       {...styleProps}

--- a/packages/react/src/drawer/DrawerContent.js
+++ b/packages/react/src/drawer/DrawerContent.js
@@ -1,5 +1,5 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
-import { callAll } from '@tonic-ui/utils';
+import { ariaAttr, callAll } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { Slide } from '../transitions';
 import { useAnimatePresence } from '../utils/animate-presence';
@@ -33,6 +33,7 @@ const DrawerContent = forwardRef((
   const tabIndex = -1;
   const styleProps = useDrawerContentStyle({ placement, size, tabIndex });
   const contentProps = {
+    'aria-modal': ariaAttr(true),
     ref: combinedRef,
     role: 'dialog',
     tabIndex,

--- a/packages/react/src/drawer/__tests__/Drawer.test.js
+++ b/packages/react/src/drawer/__tests__/Drawer.test.js
@@ -1,0 +1,209 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@tonic-ui/react/test-utils/render';
+import { testA11y } from '@tonic-ui/react/test-utils/accessibility';
+import {
+  Button,
+  Input,
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerHeader,
+  DrawerBody,
+  DrawerFooter,
+  DrawerCloseButton,
+  Text,
+} from '@tonic-ui/react/src';
+import React, { useCallback, useRef, useState } from 'react';
+
+describe('Drawer', () => {
+  it('should render correctly', async () => {
+    const renderOptions = {
+      useCSSVariables: true,
+    };
+    const { baseElement } = render((
+      <Drawer
+        isOpen
+        onClose={jest.fn()}
+        placement="right"
+      >
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerHeader>Drawer header</DrawerHeader>
+          <DrawerBody>Drawer body</DrawerBody>
+          <DrawerFooter>Drawer footer</DrawerFooter>
+          <DrawerCloseButton />
+        </DrawerContent>
+      </Drawer>
+    ), renderOptions);
+
+    expect(baseElement).toMatchSnapshot();
+
+    // Test baseElement because the drawer is rendered in a portal
+    await testA11y(baseElement, {
+      axeOptions: {
+        rules: {
+          // ARIA dialog and alertdialog nodes should have an accessible name (aria-dialog-name)
+          'aria-dialog-name': { enabled: false },
+        },
+      },
+    });
+  });
+
+  it('should have the proper ARIA attributes', () => {
+    render(
+      <Drawer
+        isOpen
+        onClose={jest.fn()}
+        placement="right"
+      >
+        <DrawerOverlay />
+        <DrawerContent data-testid="drawer-content">
+          <DrawerHeader>Drawer header</DrawerHeader>
+          <DrawerBody>Drawer body</DrawerBody>
+          <DrawerFooter>Drawer footer</DrawerFooter>
+          <DrawerCloseButton data-testid="drawer-close-button" />
+        </DrawerContent>
+      </Drawer>
+    );
+
+    const drawerContent = screen.getByTestId('drawer-content');
+    const drawerCloseButton = screen.getByTestId('drawer-close-button');
+    expect(drawerContent).toHaveAttribute('aria-modal', 'true');
+    expect(drawerContent).toHaveAttribute('role', 'dialog');
+    expect(drawerCloseButton).toHaveAttribute('aria-label', 'Close');
+  });
+
+  it('should fire `onClose` when the close button is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+
+    render(
+      <Drawer
+        isOpen
+        onClose={onClose}
+        placement="right"
+      >
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerHeader>Drawer header</DrawerHeader>
+          <DrawerCloseButton data-testid="drawer-close-button" />
+        </DrawerContent>
+      </Drawer>
+    );
+
+    await user.click(screen.getByTestId('drawer-close-button'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should close when pressing the escape key', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+
+    render(
+      <Drawer
+        closeOnEsc
+        ensureFocus
+        isOpen
+        onClose={onClose}
+        placement="right"
+      >
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerHeader>Drawer header</DrawerHeader>
+          <DrawerBody>Drawer body</DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    );
+
+    await user.keyboard('[Escape]');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should close when clicking outside the drawer', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+
+    render(
+      <Drawer
+        closeOnOutsideClick
+        isOpen
+        onClose={onClose}
+        placement="right"
+      >
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerHeader>Drawer header</DrawerHeader>
+          <DrawerBody>Drawer body</DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    );
+
+    const dialog = await screen.findByRole('dialog');
+    await user.click(dialog.parentElement);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should ensure proper focus management when opening and closing the drawer', async () => {
+    const user = userEvent.setup();
+
+    const TestComponent = () => {
+      const [isOpen, setIsOpen] = useState(false);
+      const openDrawer = useCallback(() => setIsOpen(true), []);
+      const closeDrawer = useCallback(() => setIsOpen(false), []);
+      const buttonRef = useRef(null);
+      const inputRef = useRef(null);
+
+      return (
+        <>
+          <Button
+            data-testid="button"
+            onClick={openDrawer}
+            ref={buttonRef}
+          >
+            Open
+          </Button>
+          <Drawer
+            ensureFocus
+            finalFocusRef={buttonRef}
+            initialFocusRef={inputRef}
+            isOpen={isOpen}
+            onClose={closeDrawer}
+            placement="right"
+          >
+            <DrawerOverlay />
+            <DrawerContent>
+              <DrawerHeader>Drawer header</DrawerHeader>
+              <DrawerBody>
+                <Text>Drawer body</Text>
+                <Input data-testid="input" ref={inputRef} />
+              </DrawerBody>
+              <DrawerCloseButton data-testid="drawer-close-button" />
+            </DrawerContent>
+          </Drawer>
+        </>
+      );
+    };
+
+    render(<TestComponent />);
+
+    const button = screen.getByTestId('button');
+
+    // The button should not have focus at start
+    expect(button).not.toHaveFocus();
+
+    // Open the drawer
+    await user.click(button);
+
+    // The input should have focus
+    expect(screen.getByTestId('input')).toHaveFocus();
+
+    // Close the drawer
+    await user.click(screen.getByTestId('drawer-close-button'));
+
+    // Wait for the button to be focused
+    await waitFor(() => {
+      expect(button).toHaveFocus();
+    });
+  });
+});

--- a/packages/react/src/drawer/__tests__/__snapshots__/Drawer.test.js.snap
+++ b/packages/react/src/drawer/__tests__/__snapshots__/Drawer.test.js.snap
@@ -1,0 +1,250 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Drawer should render correctly 1`] = `
+.emotion-0 {
+  position: fixed;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: var(--tonic-zIndices-drawer);
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.emotion-2 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, .7);
+  opacity: 1;
+  -webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  outline: 0;
+  overflow: clip;
+  position: relative;
+  color: var(--tonic-colors-black-primary);
+  background: white;
+  border-width: var(--tonic-sizes-1q);
+  border-style: solid;
+  border-color: var(--tonic-colors-gray-30);
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.16),0 4px 8px 0 rgba(0, 0, 0, 0.08);
+  margin: auto;
+  margin-right: 0;
+  width: auto;
+  height: 100%;
+  max-width: 100vw;
+  max-height: 100vh;
+  -webkit-transform: none;
+  -moz-transform: none;
+  -ms-transform: none;
+  transform: none;
+  -webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1);
+  transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1);
+}
+
+.emotion-6 {
+  padding-top: var(--tonic-space-4x);
+  padding-bottom: var(--tonic-space-6x);
+  padding-left: var(--tonic-space-4x);
+  padding-right: var(--tonic-space-4x);
+  position: relative;
+  font-size: var(--tonic-fontSizes-xl);
+  line-height: var(--tonic-lineHeights-xl);
+}
+
+.emotion-8 {
+  padding-left: var(--tonic-space-4x);
+  padding-right: var(--tonic-space-4x);
+  padding-bottom: var(--tonic-space-6x);
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  height: auto;
+  overflow-y: auto;
+}
+
+.emotion-8:first-of-type {
+  margin-top: calc(1rem + 1.75rem + .75rem);
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  padding-left: var(--tonic-space-4x);
+  padding-right: var(--tonic-space-4x);
+  padding-top: var(--tonic-space-4x);
+  padding-bottom: var(--tonic-space-4x);
+}
+
+.emotion-10:first-of-type {
+  margin-top: calc(1rem + 1.75rem + .75rem);
+}
+
+.emotion-12 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: inherit;
+  border: var(--tonic-borders-1);
+  color: rgba(0, 0, 0, .54);
+  cursor: pointer;
+  outline: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  border-color: var(--tonic-colors-transparent);
+  width: var(--tonic-sizes-8x);
+  height: var(--tonic-sizes-8x);
+  -webkit-transition: border-color 200ms cubic-bezier(0.4, 0, 0.2, 1),box-shadow 200ms cubic-bezier(0.4, 0, 0.2, 1),color 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: border-color 200ms cubic-bezier(0.4, 0, 0.2, 1),box-shadow 200ms cubic-bezier(0.4, 0, 0.2, 1),color 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  position: absolute;
+  top: calc(.5rem - .0625rem);
+  right: calc(.5rem - .0625rem);
+}
+
+.emotion-12:focus,
+.emotion-12[data-focus] {
+  border-color: #1e5ede;
+  box-shadow: inset 0 0 0 1px #1e5ede;
+  color: rgba(0, 0, 0, .54);
+}
+
+.emotion-12:hover,
+.emotion-12[data-hover] {
+  color: rgba(0, 0, 0, .92);
+}
+
+.emotion-12:focus:hover {
+  color: rgba(0, 0, 0, .92);
+}
+
+.emotion-12:active,
+.emotion-12[data-active] {
+  color: rgba(0, 0, 0, .54);
+}
+
+.emotion-12:focus:active {
+  border-color: #1e5ede;
+  box-shadow: inset 0 0 0 1px #1e5ede;
+  color: rgba(0, 0, 0, .54);
+}
+
+.emotion-14 {
+  width: var(--tonic-sizes-4x);
+  height: var(--tonic-sizes-4x);
+  fill: currentColor;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  vertical-align: middle;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-14:not(:root) {
+  overflow: hidden;
+}
+
+<body>
+  <div />
+  <div
+    class="tonic-ui-portal"
+  >
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      data-focus-lock-disabled="disabled"
+    >
+      <div
+        class="emotion-0 emotion-1"
+      >
+        <div
+          class="emotion-2 emotion-1"
+        />
+        <div
+          aria-modal="true"
+          class="emotion-4 emotion-1"
+          role="dialog"
+          tabindex="-1"
+        >
+          <div
+            class="emotion-6 emotion-1"
+          >
+            Drawer header
+          </div>
+          <div
+            class="emotion-8 emotion-1"
+          >
+            Drawer body
+          </div>
+          <div
+            class="emotion-10 emotion-1"
+          >
+            Drawer footer
+          </div>
+          <button
+            aria-label="Close"
+            class="emotion-12 emotion-1"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="emotion-14 emotion-15"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 16 16"
+            >
+              <g>
+                <path
+                  d="M15 2l-1-1-6 6-6-6-0.99 0.99 5.99 6.010-6 6 1 1 6-6 6 6 1-1-6-6 6-6z"
+                />
+              </g>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+  </div>
+</body>
+`;

--- a/packages/react/src/menu/__tests__/Menu.test.js
+++ b/packages/react/src/menu/__tests__/Menu.test.js
@@ -1,4 +1,4 @@
-import { act, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@tonic-ui/react/test-utils/render';
 import { testA11y } from '@tonic-ui/react/test-utils/accessibility';
@@ -6,61 +6,24 @@ import { Menu, MenuButton, MenuList, MenuItem } from '@tonic-ui/react/src';
 import React from 'react';
 
 describe('Menu', () => {
-  it('should render correctly', async () => {
-    const user = userEvent.setup();
+  const TestComponent = (props) => {
     const items = [
       { id: 1, label: 'Menu item 1', disabled: false },
       { id: 2, label: 'Menu item 2', disabled: false },
       { id: 3, label: 'Menu item 3', disabled: true },
     ];
-    const renderOptions = {
-      useCSSVariables: true,
-    };
-    const { container } = render((
-      <Menu>
-        <MenuButton variant="secondary" data-testid="menu-button">
+
+    return (
+      <Menu {...props}>
+        <MenuButton
+          data-testid="button"
+          variant="secondary"
+        >
           Open
         </MenuButton>
-        <MenuList>
-          {items.map((item) => (
-            <MenuItem
-              data-id={item.id}
-              key={item.id}
-              disabled={item.disabled}
-            >
-              {item.label}
-            </MenuItem>
-          ))}
-        </MenuList>
-      </Menu>
-    ), renderOptions);
-
-    const menuButton = screen.getByTestId('menu-button');
-    expect(menuButton).toBeInTheDocument();
-
-    await act(() => user.click(menuButton));
-
-    expect(await screen.findByRole('menu')).toBeInTheDocument();
-    expect(container).toMatchSnapshot();
-
-    await testA11y(container);
-  });
-
-  it('should set initial focus to `MenuList` on open and return focus to `MenuButton` on close', async () => {
-    const user = userEvent.setup();
-    const items = [
-      { id: 1, label: 'Menu item 1', disabled: false },
-      { id: 2, label: 'Menu item 2', disabled: false },
-      { id: 3, label: 'Menu item 3', disabled: true },
-    ];
-    render(
-      <Menu
-        returnFocusOnClose={true}
-      >
-        <MenuButton variant="secondary" data-testid="menu-button">
-          Open
-        </MenuButton>
-        <MenuList data-testid="menu-list">
+        <MenuList
+          data-testid="menu-list"
+        >
           {items.map((item) => (
             <MenuItem
               data-id={item.id}
@@ -73,15 +36,57 @@ describe('Menu', () => {
         </MenuList>
       </Menu>
     );
+  };
 
-    await act(() => user.click(screen.getByTestId('menu-button')));
-    await waitFor(() => {
-      expect(document.activeElement).toBe(screen.getByTestId('menu-list'));
-    });
+  it('should render correctly', async () => {
+    const user = userEvent.setup();
+    const renderOptions = {
+      useCSSVariables: true,
+    };
+    const { container } = render((
+      <TestComponent />
+    ), renderOptions);
 
-    await act(() => user.click(document.body));
+    const button = screen.getByTestId('button');
+
+    // The button should be in the document
+    expect(button).toBeInTheDocument();
+
+    // Open the menu
+    await user.click(button);
+
+    // The menu should be in the document
+    expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+    expect(container).toMatchSnapshot();
+
+    await testA11y(container);
+  });
+
+  it('should ensure proper focus management when opening and closing the menu', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TestComponent returnFocusOnClose />
+    );
+
+    const button = screen.getByTestId('button');
+
+    // The button should not have focus at start
+    expect(button).not.toHaveFocus();
+
+    // Open the menu
+    await user.click(button);
+
+    // The menu list should have focus
+    expect(screen.getByTestId('menu-list')).toHaveFocus();
+
+    // Close the menu
+    await user.click(document.body);
+
+    // Wait for the button to be focused
     await waitFor(() => {
-      expect(document.activeElement).toBe(screen.getByTestId('menu-button'));
+      expect(button).toHaveFocus();
     });
   });
 });

--- a/packages/react/src/menu/__tests__/__snapshots__/Menu.test.js.snap
+++ b/packages/react/src/menu/__tests__/__snapshots__/Menu.test.js.snap
@@ -303,7 +303,7 @@ exports[`Menu should render correctly 1`] = `
       aria-expanded="true"
       aria-haspopup="menu"
       class="emotion-2 emotion-1"
-      data-testid="menu-button"
+      data-testid="button"
       id="@tonic-ui/react:MenuToggle-1"
       role="button"
       tabindex="0"
@@ -339,6 +339,7 @@ exports[`Menu should render correctly 1`] = `
       data-popper-escaped=""
       data-popper-placement="bottom-start"
       data-popper-reference-hidden=""
+      data-testid="menu-list"
       id="@tonic-ui/react:Menu-1"
       role="menu"
       style="position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(0px, 0px);"
@@ -354,7 +355,7 @@ exports[`Menu should render correctly 1`] = `
             class="emotion-16 emotion-1"
             data-id="1"
             role="menuitem"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             Menu item 1

--- a/packages/react/src/modal/Modal.js
+++ b/packages/react/src/modal/Modal.js
@@ -27,6 +27,7 @@ const Modal = forwardRef((
     isOpen = false,
     onClose,
     portalProps,
+    returnFocusOnClose = true,
     scrollBehavior = defaultScrollBehavior,
     size = defaultSize,
     ...rest
@@ -67,7 +68,7 @@ const Modal = forwardRef((
     placement: 'center', // internal use only (only 'center' is supported by Modal)
   });
 
-  const returnFocus = !finalFocusRef;
+  const returnFocus = returnFocusOnClose && !finalFocusRef;
   const onFocusLockActivation = useCallback(() => {
     if (initialFocusRef && initialFocusRef.current) {
       const el = initialFocusRef.current;

--- a/packages/react/src/modal/ModalCloseButton.js
+++ b/packages/react/src/modal/ModalCloseButton.js
@@ -23,6 +23,7 @@ const ModalCloseButton = forwardRef((
 
   return (
     <ButtonBase
+      aria-label="Close"
       ref={ref}
       onClick={callEventHandlers(onClickProp, onClose)}
       {...styleProps}

--- a/packages/react/src/modal/ModalContent.js
+++ b/packages/react/src/modal/ModalContent.js
@@ -1,5 +1,5 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
-import { callAll } from '@tonic-ui/utils';
+import { ariaAttr, callAll } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { Fade } from '../transitions';
 import { useAnimatePresence } from '../utils/animate-presence';
@@ -34,6 +34,7 @@ const ModalContent = forwardRef((
   const tabIndex = -1;
   const styleProps = useModalContentStyle({ placement, scrollBehavior, size, tabIndex });
   const contentProps = {
+    'aria-modal': ariaAttr(true),
     ref: combinedRef,
     role: 'dialog',
     tabIndex,

--- a/packages/react/src/modal/__tests__/Modal.test.js
+++ b/packages/react/src/modal/__tests__/Modal.test.js
@@ -1,0 +1,194 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@tonic-ui/react/test-utils/render';
+import { testA11y } from '@tonic-ui/react/test-utils/accessibility';
+import {
+  Button,
+  Input,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Text,
+} from '@tonic-ui/react/src';
+import React, { useCallback, useRef, useState } from 'react';
+
+describe('Modal', () => {
+  it('should render correctly', async () => {
+    const renderOptions = {
+      useCSSVariables: true,
+    };
+    const { baseElement } = render((
+      <Modal isOpen onClose={jest.fn()}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Modal header</ModalHeader>
+          <ModalBody>Modal body</ModalBody>
+          <ModalFooter>Modal footer</ModalFooter>
+          <ModalCloseButton />
+        </ModalContent>
+      </Modal>
+    ), renderOptions);
+
+    expect(baseElement).toMatchSnapshot();
+
+    // Test baseElement because the modal is rendered in a portal
+    await testA11y(baseElement, {
+      axeOptions: {
+        rules: {
+          // ARIA dialog and alertdialog nodes should have an accessible name (aria-dialog-name)
+          'aria-dialog-name': { enabled: false },
+        },
+      },
+    });
+  });
+
+  it('should have the proper ARIA attributes', () => {
+    render(
+      <Modal isOpen onClose={jest.fn()}>
+        <ModalOverlay />
+        <ModalContent data-testid="modal-content">
+          <ModalHeader>Modal header</ModalHeader>
+          <ModalBody>Modal body</ModalBody>
+          <ModalFooter>Modal footer</ModalFooter>
+          <ModalCloseButton data-testid="modal-close-button" />
+        </ModalContent>
+      </Modal>
+    );
+
+    const modalContent = screen.getByTestId('modal-content');
+    const modalCloseButton = screen.getByTestId('modal-close-button');
+    expect(modalContent).toHaveAttribute('aria-modal', 'true');
+    expect(modalContent).toHaveAttribute('role', 'dialog');
+    expect(modalCloseButton).toHaveAttribute('aria-label', 'Close');
+  });
+
+  it('should fire `onClose` when the close button is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+
+    render(
+      <Modal isOpen onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Modal header</ModalHeader>
+          <ModalCloseButton data-testid="modal-close-button" />
+        </ModalContent>
+      </Modal>
+    );
+
+    await user.click(screen.getByTestId('modal-close-button'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should close when pressing the escape key', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+
+    render(
+      <Modal
+        closeOnEsc
+        ensureFocus
+        isOpen
+        onClose={onClose}
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Modal header</ModalHeader>
+          <ModalBody>Modal body</ModalBody>
+        </ModalContent>
+      </Modal>
+    );
+
+    await user.keyboard('[Escape]');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should close when clicking outside the modal', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+
+    render(
+      <Modal
+        closeOnOutsideClick
+        isOpen
+        onClose={onClose}
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Modal header</ModalHeader>
+          <ModalBody>Modal body</ModalBody>
+        </ModalContent>
+      </Modal>
+    );
+
+    const dialog = await screen.findByRole('dialog');
+    await user.click(dialog.parentElement);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should ensure proper focus management when opening and closing the modal', async () => {
+    const user = userEvent.setup();
+
+    const TestComponent = () => {
+      const [isOpen, setIsOpen] = useState(false);
+      const openModal = useCallback(() => setIsOpen(true), []);
+      const closeModal = useCallback(() => setIsOpen(false), []);
+      const buttonRef = useRef(null);
+      const inputRef = useRef(null);
+
+      return (
+        <>
+          <Button
+            data-testid="button"
+            onClick={openModal}
+            ref={buttonRef}
+          >
+            Open
+          </Button>
+          <Modal
+            ensureFocus
+            finalFocusRef={buttonRef}
+            initialFocusRef={inputRef}
+            isOpen={isOpen}
+            onClose={closeModal}
+          >
+            <ModalOverlay />
+            <ModalContent>
+              <ModalHeader>Modal header</ModalHeader>
+              <ModalBody>
+                <Text>Modal body</Text>
+                <Input data-testid="input" ref={inputRef} />
+              </ModalBody>
+              <ModalCloseButton data-testid="modal-close-button" />
+            </ModalContent>
+          </Modal>
+        </>
+      );
+    };
+
+    render(<TestComponent />);
+
+    const button = screen.getByTestId('button');
+
+    // The button should not have focus at start
+    expect(button).not.toHaveFocus();
+
+    // Open the modal
+    await user.click(button);
+
+    // The input should have focus
+    expect(screen.getByTestId('input')).toHaveFocus();
+
+    // Close the modal
+    await user.click(screen.getByTestId('modal-close-button'));
+
+    // Wait for the button to be focused
+    await waitFor(() => {
+      expect(button).toHaveFocus();
+    });
+  });
+});

--- a/packages/react/src/modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/packages/react/src/modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -1,0 +1,250 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Modal should render correctly 1`] = `
+.emotion-0 {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  overflow: auto;
+  z-index: var(--tonic-zIndices-modal);
+}
+
+.emotion-2 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, .7);
+  opacity: 1;
+  -webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  outline: 0;
+  overflow: clip;
+  position: relative;
+  color: var(--tonic-colors-black-primary);
+  background: white;
+  border-width: var(--tonic-sizes-1q);
+  border-style: solid;
+  border-color: var(--tonic-colors-gray-30);
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.16),0 4px 8px 0 rgba(0, 0, 0, 0.08);
+  margin: auto;
+  width: auto;
+  height: auto;
+  max-width: 100vw;
+  max-height: 100vh;
+  opacity: 1;
+  -webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.emotion-6 {
+  padding-top: var(--tonic-space-4x);
+  padding-bottom: var(--tonic-space-6x);
+  padding-left: var(--tonic-space-6x);
+  padding-right: var(--tonic-space-6x);
+  position: relative;
+  font-size: var(--tonic-fontSizes-xl);
+  line-height: var(--tonic-lineHeights-xl);
+}
+
+.emotion-8 {
+  padding-left: var(--tonic-space-6x);
+  padding-right: var(--tonic-space-6x);
+  padding-bottom: var(--tonic-space-6x);
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  height: auto;
+  overflow-y: auto;
+}
+
+.emotion-8:first-of-type {
+  margin-top: calc(1rem + 1.75rem + .75rem);
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  padding-left: var(--tonic-space-6x);
+  padding-right: var(--tonic-space-6x);
+  padding-top: var(--tonic-space-4x);
+  padding-bottom: var(--tonic-space-4x);
+  border-top: var(--tonic-borders-1);
+  border-top-color: rgba(0, 0, 0, 0.12);
+}
+
+.emotion-10:first-of-type {
+  margin-top: calc(1rem + 1.75rem + .75rem);
+}
+
+.emotion-12 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: inherit;
+  border: var(--tonic-borders-1);
+  color: rgba(0, 0, 0, .54);
+  cursor: pointer;
+  outline: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  border-color: var(--tonic-colors-transparent);
+  width: var(--tonic-sizes-8x);
+  height: var(--tonic-sizes-8x);
+  -webkit-transition: border-color 200ms cubic-bezier(0.4, 0, 0.2, 1),box-shadow 200ms cubic-bezier(0.4, 0, 0.2, 1),color 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: border-color 200ms cubic-bezier(0.4, 0, 0.2, 1),box-shadow 200ms cubic-bezier(0.4, 0, 0.2, 1),color 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  position: absolute;
+  top: calc(.5rem - .0625rem);
+  right: calc(.5rem - .0625rem);
+}
+
+.emotion-12:focus,
+.emotion-12[data-focus] {
+  border-color: #1e5ede;
+  box-shadow: inset 0 0 0 1px #1e5ede;
+  color: rgba(0, 0, 0, .54);
+}
+
+.emotion-12:hover,
+.emotion-12[data-hover] {
+  color: rgba(0, 0, 0, .92);
+}
+
+.emotion-12:focus:hover {
+  color: rgba(0, 0, 0, .92);
+}
+
+.emotion-12:active,
+.emotion-12[data-active] {
+  color: rgba(0, 0, 0, .54);
+}
+
+.emotion-12:focus:active {
+  border-color: #1e5ede;
+  box-shadow: inset 0 0 0 1px #1e5ede;
+  color: rgba(0, 0, 0, .54);
+}
+
+.emotion-14 {
+  width: var(--tonic-sizes-4x);
+  height: var(--tonic-sizes-4x);
+  fill: currentColor;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  vertical-align: middle;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-14:not(:root) {
+  overflow: hidden;
+}
+
+<body>
+  <div />
+  <div
+    class="tonic-ui-portal"
+  >
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      data-focus-lock-disabled="disabled"
+    >
+      <div
+        class="emotion-0 emotion-1"
+      >
+        <div
+          class="emotion-2 emotion-1"
+        />
+        <div
+          aria-modal="true"
+          class="emotion-4 emotion-1"
+          role="dialog"
+          tabindex="-1"
+        >
+          <div
+            class="emotion-6 emotion-1"
+          >
+            Modal header
+          </div>
+          <div
+            class="emotion-8 emotion-1"
+          >
+            Modal body
+          </div>
+          <div
+            class="emotion-10 emotion-1"
+          >
+            Modal footer
+          </div>
+          <button
+            aria-label="Close"
+            class="emotion-12 emotion-1"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="emotion-14 emotion-15"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 16 16"
+            >
+              <g>
+                <path
+                  d="M15 2l-1-1-6 6-6-6-0.99 0.99 5.99 6.010-6 6 1 1 6-6 6 6 1-1-6-6 6-6z"
+                />
+              </g>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+  </div>
+</body>
+`;

--- a/packages/react/src/tag/TagCloseButton.js
+++ b/packages/react/src/tag/TagCloseButton.js
@@ -24,6 +24,7 @@ const TagCloseButton = forwardRef((
 
   return (
     <ButtonBase
+      aria-label="Close"
       ref={ref}
       disabled={disabled}
       onClick={callEventHandlers(onClickProp, onClose)}

--- a/packages/react/src/toast/ToastCloseButton.js
+++ b/packages/react/src/toast/ToastCloseButton.js
@@ -26,6 +26,7 @@ const ToastCloseButton = forwardRef((
 
   return (
     <ButtonBase
+      aria-label="Close"
       ref={ref}
       onClick={callEventHandlers(onClickProp, onClose)}
       {...styleProps}

--- a/packages/react/src/tooltip/Tooltip.js
+++ b/packages/react/src/tooltip/Tooltip.js
@@ -35,11 +35,12 @@ const Tooltip = forwardRef((
     hideArrow, // deprecated
     hideDelay, // deprecated
     showDelay, // deprecated
+    closeOnMouseDown, // deprecated
     arrow = true,
     children,
     closeOnClick = true,
     closeOnEsc = true,
-    closeOnMouseDown = false,
+    closeOnPointerDown = true,
     defaultIsOpen = false,
     disabled,
     enterDelay = 100,
@@ -51,6 +52,7 @@ const Tooltip = forwardRef((
     offset,
     onClose: onCloseProp,
     onOpen: onOpenProp,
+    openOnFocus = true,
     placement = defaultPlacement,
     ...rest
   },
@@ -89,6 +91,14 @@ const Tooltip = forwardRef((
         willRemove: true,
       });
     }, (showDelay !== undefined));
+
+    useOnceWhen(() => {
+      warnDeprecatedProps('closeOnMouseDown', {
+        prefix,
+        alternative: 'closeOnPointerDown',
+        willRemove: true,
+      });
+    }, (closeOnMouseDown !== undefined));
 
     if (hideArrow !== undefined) {
       arrow = !hideArrow;
@@ -189,7 +199,7 @@ const Tooltip = forwardRef((
     arrow: (followCursor || nextToCursor) ? false : arrow,
     closeOnClick,
     closeOnEsc,
-    closeOnMouseDown,
+    closeOnPointerDown,
     disabled,
     followCursor,
     isOpen,
@@ -199,6 +209,7 @@ const Tooltip = forwardRef((
     offset,
     onClose,
     onOpen,
+    openOnFocus,
     placement: (followCursor || nextToCursor) ? 'bottom-start' : placement,
     setMousePageX,
     setMousePageY,

--- a/packages/react/src/tooltip/TooltipTrigger.js
+++ b/packages/react/src/tooltip/TooltipTrigger.js
@@ -13,10 +13,10 @@ const TooltipTrigger = forwardRef((
     onBlur: onBlurProp,
     onClick: onClickProp,
     onFocus: onFocusProp,
-    onMouseDown: onMouseDownProp,
     onMouseEnter: onMouseEnterProp,
     onMouseLeave: onMouseLeaveProp,
     onMouseMove: onMouseMoveProp,
+    onPointerDown: onPointerDownProp,
     ...rest
   },
   ref,
@@ -24,11 +24,12 @@ const TooltipTrigger = forwardRef((
   const {
     closeOnClick,
     closeOnEsc,
-    closeOnMouseDown,
+    closeOnPointerDown,
     followCursor,
     isOpen,
     onClose,
     onOpen,
+    openOnFocus,
     setMousePageX,
     setMousePageY,
     tooltipId,
@@ -41,23 +42,22 @@ const TooltipTrigger = forwardRef((
   const eventHandler = {};
 
   eventHandler.onBlur = function (event) {
-    onClose();
+    if (isOpen) {
+      onClose();
+    }
   };
   eventHandler.onClick = function (event) {
-    if (closeOnClick) {
+    if (isOpen && closeOnClick) {
       onClose();
     }
   };
   eventHandler.onFocus = function (event) {
-    onOpen();
+    if (!isOpen && openOnFocus) {
+      onOpen();
+    }
   };
   eventHandler.onKeyDown = function (event) {
     if (isOpen && closeOnEsc && event.key === 'Escape') {
-      onClose();
-    }
-  };
-  eventHandler.onMouseDown = function (event) {
-    if (closeOnMouseDown) {
       onClose();
     }
   };
@@ -76,6 +76,11 @@ const TooltipTrigger = forwardRef((
     if (enableMouseMove || followCursor) {
       setMousePageX(event.pageX);
       setMousePageY(event.pageY);
+    }
+  };
+  eventHandler.onPointerDown = function (event) {
+    if (isOpen && closeOnPointerDown) {
+      onClose();
     }
   };
 
@@ -105,10 +110,10 @@ const TooltipTrigger = forwardRef((
       onBlur: callEventHandlers(ownProps?.onBlur, onBlurProp, eventHandler.onBlur),
       onClick: callEventHandlers(ownProps?.onClick, onClickProp, eventHandler.onClick),
       onFocus: callEventHandlers(ownProps?.onFocus, onFocusProp, eventHandler.onFocus),
-      onMouseDown: callEventHandlers(ownProps?.onMouseDown, onMouseDownProp, eventHandler.onMouseDown),
       onMouseEnter: callEventHandlers(ownProps?.onMouseEnter, onMouseEnterProp, eventHandler.onMouseEnter),
       onMouseLeave: callEventHandlers(ownProps?.onMouseLeave, onMouseLeaveProp, eventHandler.onMouseLeave),
       onMouseMove: callEventHandlers(ownProps?.onMouseMove, onMouseMoveProp, eventHandler.onMouseMove),
+      onPointerDown: callEventHandlers(ownProps?.onPointerDown, onPointerDownProp, eventHandler.onPointerDown),
       ...styleProps,
       ...rest,
     };

--- a/packages/react/src/tooltip/__tests__/Tooltip.test.js
+++ b/packages/react/src/tooltip/__tests__/Tooltip.test.js
@@ -1,36 +1,110 @@
-import { act, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@tonic-ui/react/test-utils/render';
 import { testA11y } from '@tonic-ui/react/test-utils/accessibility';
-import { Text, Tooltip } from '@tonic-ui/react/src';
+import { Button, Tooltip } from '@tonic-ui/react/src';
 import React from 'react';
 
 describe('Tooltip', () => {
+  const tooltipLabel = 'tooltip label';
+  const buttonLabel = 'button label';
+  const TestComponent = (props) => (
+    <Tooltip label={tooltipLabel} {...props}>
+      <Button>{buttonLabel}</Button>
+    </Tooltip>
+  );
+
   it('should render correctly', async () => {
     const user = userEvent.setup();
     const renderOptions = {
       useCSSVariables: true,
     };
     const { container } = render((
-      <Tooltip label={<Text data-testid="tooltip-label">This is a tooltip</Text>}>
-        <Text data-testid="tooltip-content">Hover me</Text>
-      </Tooltip>
+      <TestComponent />
     ), renderOptions);
 
-    const tooltipContent = screen.getByTestId('tooltip-content');
-    expect(tooltipContent).toBeInTheDocument();
+    const button = screen.getByText(buttonLabel);
+    expect(button).toBeInTheDocument();
 
-    await act(() => user.hover(tooltipContent));
-
-    await waitFor(() => {
-      const tooltipLabel = screen.getByTestId('tooltip-label');
-      expect(tooltipLabel).toHaveTextContent('This is a tooltip');
-    });
+    await user.hover(button);
 
     expect(await screen.findByRole('tooltip')).toBeInTheDocument();
 
     expect(container).toMatchSnapshot();
 
     await testA11y(container);
+  });
+
+  it('should not show on mouseover if `disabled` is set to `false`', async () => {
+    const user = userEvent.setup();
+
+    render(<TestComponent disabled={false} />);
+
+    await user.hover(screen.getByText(buttonLabel));
+
+    expect(await screen.findByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('should not show on mouseover if `disabled` is set to `true`', async () => {
+    const user = userEvent.setup();
+
+    render(<TestComponent disabled={true} />);
+
+    await user.hover(screen.getByText(buttonLabel));
+
+    await waitFor(() => {
+      expect(screen.queryByText(tooltipLabel)).not.toBeInTheDocument();
+    });
+  });
+
+  it('should display on mouseover and close when clicked if `closeOnClick` is set to `true`', async () => {
+    const user = userEvent.setup();
+
+    render(<TestComponent closeOnClick={true} />);
+
+    await user.hover(screen.getByText(buttonLabel));
+
+    expect(await screen.findByRole('tooltip')).toBeInTheDocument();
+
+    // Click
+    await user.click(screen.getByText(buttonLabel));
+
+    await waitFor(() => {
+      expect(screen.queryByText(tooltipLabel)).not.toBeInTheDocument();
+    });
+  });
+
+  it('should display on mouseover and close when `Escape` key is pressed if `closeOnEsc` is set to `true`', async () => {
+    const user = userEvent.setup();
+
+    render(<TestComponent closeOnEsc={true} />);
+
+    await user.hover(screen.getByText(buttonLabel));
+
+    expect(await screen.findByRole('tooltip')).toBeInTheDocument();
+
+    // Press [Escape]
+    await user.keyboard('[Escape]');
+
+    await waitFor(() => {
+      expect(screen.queryByText(tooltipLabel)).not.toBeInTheDocument();
+    });
+  });
+
+  it('should display on mouseover and close when pointer down if `closeOnPointerDown` is set to `true`', async () => {
+    const user = userEvent.setup();
+
+    render(<TestComponent closeOnPointerDown={true} />);
+
+    await user.hover(screen.getByText(buttonLabel));
+
+    expect(await screen.findByRole('tooltip')).toBeInTheDocument();
+
+    // Pointer down
+    await fireEvent.pointerDown(screen.getByText(buttonLabel));
+
+    await waitFor(() => {
+      expect(screen.queryByText(tooltipLabel)).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/react/src/tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/packages/react/src/tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -1,6 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip should render correctly 1`] = `
+.emotion-0 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: var(--tonic-colors-gray-20);
+  border: var(--tonic-borders-1);
+  color: var(--tonic-colors-black-emphasis);
+  cursor: pointer;
+  outline: 0;
+  padding: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  white-space: nowrap;
+  border-radius: var(--tonic-radii-sm);
+  padding-left: var(--tonic-space-3x);
+  padding-right: var(--tonic-space-3x);
+  -webkit-transition: background-color 200ms cubic-bezier(0.4, 0, 0.2, 1),border-color 200ms cubic-bezier(0.4, 0, 0.2, 1),box-shadow 200ms cubic-bezier(0.4, 0, 0.2, 1),color 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: background-color 200ms cubic-bezier(0.4, 0, 0.2, 1),border-color 200ms cubic-bezier(0.4, 0, 0.2, 1),box-shadow 200ms cubic-bezier(0.4, 0, 0.2, 1),color 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  min-height: var(--tonic-sizes-8x);
+  font-size: var(--tonic-fontSizes-sm);
+  line-height: var(--tonic-lineHeights-sm);
+  border-color: var(--tonic-colors-transparent);
+}
+
+.emotion-0[aria-selected=true],
+.emotion-0[data-selected] {
+  background-color: var(--tonic-colors-gray-30);
+  color: var(--tonic-colors-black-emphasis);
+  pointer-events: none;
+}
+
+.emotion-0:focus,
+.emotion-0[data-focus] {
+  z-index: 1;
+}
+
+.emotion-0:focus:not(:active),
+.emotion-0[data-focus]:not(:active) {
+  border-color: var(--tonic-colors-blue-60);
+  box-shadow: inset 0 0 0 .0625rem #1e5ede,inset 0 0 0 .125rem rgba(255, 255, 255, 1.0);
+}
+
+.emotion-0:hover,
+.emotion-0[data-hover] {
+  background-color: var(--tonic-colors-gray-10);
+  z-index: 2;
+}
+
+.emotion-0:active,
+.emotion-0[data-active] {
+  background-color: var(--tonic-colors-gray-30);
+}
+
+.emotion-0:disabled,
+.emotion-0:disabled:focus,
+.emotion-0:disabled:hover,
+.emotion-0[aria-disabled=true],
+.emotion-0[aria-disabled=true]:focus,
+.emotion-0[aria-disabled=true]:hover,
+.emotion-0[data-disabled] {
+  background-color: var(--tonic-colors-gray-20);
+  color: var(--tonic-colors-black-emphasis);
+  cursor: not-allowed;
+  opacity: 0.3;
+}
+
 .emotion-2 {
   position: absolute;
   pointer-events: none;
@@ -29,12 +110,12 @@ exports[`Tooltip should render correctly 1`] = `
   transform-origin: top center;
 }
 
-.emotion-8 {
+.emotion-6 {
   position: absolute;
   top: 0;
 }
 
-.emotion-8::before {
+.emotion-6::before {
   content: "";
   border-bottom: 4px solid;
   border-left: calc(8px/2) solid transparent;
@@ -50,14 +131,14 @@ exports[`Tooltip should render correctly 1`] = `
 }
 
 <div>
-  <div
+  <button
     aria-describedby="@tonic-ui/react:Tooltip-1"
     class="emotion-0 emotion-1"
-    data-testid="tooltip-content"
     id="@tonic-ui/react:TooltipTrigger-1"
+    type="button"
   >
-    Hover me
-  </div>
+    button label
+  </button>
   <div
     aria-labelledby="@tonic-ui/react:TooltipTrigger-1"
     class="emotion-2 emotion-1"
@@ -71,14 +152,9 @@ exports[`Tooltip should render correctly 1`] = `
     <div
       class="emotion-4 emotion-1"
     >
+      tooltip label
       <div
-        class="emotion-0 emotion-1"
-        data-testid="tooltip-label"
-      >
-        This is a tooltip
-      </div>
-      <div
-        class="emotion-8 emotion-1"
+        class="emotion-6 emotion-1"
         data-popper-arrow="true"
         role="presentation"
         style="position: absolute; left: 0px; transform: translate(12px, 0px);"


### PR DESCRIPTION
This pull request introduces several new props to control the focus behavior in the `Drawer`, `Modal`, and `Tooltip` components. These changes are designed to address an issue identified in https://github.com/trendmicro-frontend/tonic-ui/issues/345, where the focus is restored to the initially focused element upon closing the drawer or modal, causing an unexpected display of the tooltip.

Here are the revised props:

### Drawer
| Name | Type | Default | Description |
| :--- | :--- | :------ | :---------- |
| returnFocusOnClose | boolean | true | If `true`, the focus will be restored to the element that was focused on when the drawer was initially opened.<br />⚠️ This only works if `ensureFocus` is set to `true`. |

### Modal
| Name | Type | Default | Description |
| :--- | :--- | :------ | :---------- |
| returnFocusOnClose | boolean | true | If `true`, the focus will be restored to the element that was focused on when the modal was initially opened.<br />⚠️ This only works if `ensureFocus` is set to `true`. |

### Tooltip
| Name | Type | Default | Description |
| :--- | :--- | :------ | :---------- |
| closeOnPointerDown | boolean | true | If `true`, the tooltip will close while the pointer is pressed down. |
| openOnFocus | boolean | true | If `true`, the tooltip will open upon receiving focus. |