### PR TITLE
fix: correct arrow position when enabling popper's flip modifier

### DIFF
--- a/packages/react-docs/pages/components/popover.mdx
+++ b/packages/react-docs/pages/components/popover.mdx
@@ -459,21 +459,97 @@ Use the `placement` prop to control the placement of the popover.
 
 ## Commonly Asked Questions
 
-### Preventing popover content cut-off with `PopperProps`
+### Resolving popover content cut-off with `PopperProps`
 
 By default, the `Popover` component positions the popover relative to its parent container. In some cases, the popover content might be cut off when it extends outside the container that holds it.
 
-To mitigate this issue, you can pass `PopperProps={{ usePortal: true }}` to `PopoverContent` to make it positioned on the document root.
+To address this issue, you can pass `PopperProps={{ usePortal: true }}` to `PopoverContent` to make it positioned on the document root.
 
 ```jsx
 <Popover>
   <PopoverTrigger>
     <Button variant="secondary">Trigger</Button>
   </PopoverTrigger>
-  <PopoverContent PopperProps={{ usePortal: true }}>
+  <PopoverContent
+    PopperProps={{
+      usePortal: true,
+    }}
+  >
     Popover
   </PopoverContent>
 </Popover>
+```
+
+### Automatically adjusting popover placement with the `flip` modifier
+
+The `flip` modifier is a useful feature that allows for automatic adjustment of popover placement when it is at risk of overflowing the specified boundary. To learn more about utilizing the `flip` modifier, please refer to [Popper.js documentation](https://popper.js.org/docs/v2/modifiers/flip/).
+
+In the following example, the popover's placement is initially set to `top`. However, if the placement is not suitable due to space constraints, the opposite `bottom` placement will be used instead.
+
+```jsx noInline
+const FormGroup = (props) => (
+  <Box mb="4x" {...props} />
+);
+
+render(() => {
+  const [colorMode] = useColorMode();
+  const [colorStyle] = useColorStyle({ colorMode });
+  const [isFlipModifierEnabled, toggleIsFlipModifierEnabled] = useToggle(true);
+
+  return (
+    <>
+      <Box mb="4x">
+        <Text fontSize="lg" lineHeight="lg">
+          Modifiers
+        </Text>
+      </Box>
+      <FormGroup>
+        <TextLabel display="inline-flex" alignItems="center">
+          <Checkbox
+            checked={isFlipModifierEnabled}
+            onChange={() => toggleIsFlipModifierEnabled()}
+          />
+          <Space width="2x" />
+          <Text fontFamily="mono" whiteSpace="nowrap">Enable flip modifier</Text>
+        </TextLabel>
+      </FormGroup>
+      <Divider my="4x" />
+      <Scrollbar
+        height={180}
+        width={180}
+        overflowY="visible"
+        border={1}
+        borderColor={colorStyle.divider}
+      >
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          height={300}
+        >
+          <Popover isOpen placement="top">
+            <PopoverTrigger>
+              <Text display="inline-block">
+                Reference
+              </Text>
+            </PopoverTrigger>
+            <PopoverContent
+              PopperProps={{
+                modifiers: [
+                  { // https://popper.js.org/docs/v2/modifiers/flip/
+                    name: 'flip',
+                    enabled: isFlipModifierEnabled,
+                  },
+                ],
+              }}
+            >
+              Popover
+            </PopoverContent>
+          </Popover>
+        </Flex>
+      </Scrollbar>
+    </>
+  );
+});
 ```
 
 ## Accessibility
@@ -554,7 +630,7 @@ The `Popover` component includes several accessibility features to ensure that i
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| PopperComponent | ElementType | Popper | The component used for the popover. |
+| PopperComponent | ElementType | Popper | The component used for the popper. |
 | PopperProps | object | | Props applied to the Popper component. |
 | PopoverArrowComponent | ElementType | PopoverArrow | The component used for the popover arrow. |
 | PopoverArrowProps | object | | Props applied to the `PopoverArrow` component. |

--- a/packages/react-docs/pages/components/tooltip.mdx
+++ b/packages/react-docs/pages/components/tooltip.mdx
@@ -374,11 +374,11 @@ function Example() {
 
 ## Commonly Asked Questions
 
-### Preventing tooltip cut-off with `PopperProps`
+### Resolving tooltip content cut-off with `PopperProps`
 
 By default, the `Tooltip` component positions the tooltip relative to its parent container. In some cases, the tooltip content might be cut off when it extends outside the container that holds it.
 
-To mitigate this issue, you can pass `PopperProps={{ usePortal: true }}` to `Tooltip` to make it positioned on the document root.
+To address this issue, you can pass `PopperProps={{ usePortal: true }}` to `Tooltip` to make it positioned on the document root.
 
 ```jsx
 <Tooltip
@@ -389,13 +389,83 @@ To mitigate this issue, you can pass `PopperProps={{ usePortal: true }}` to `Too
 </Tooltip>
 ```
 
+### Automatically adjusting tooltip placement with the `flip` modifier
+
+The `flip` modifier is a useful feature that allows for automatic adjustment of tooltip placement when it is at risk of overflowing the specified boundary. To learn more about utilizing the `flip` modifier, please refer to [Popper.js documentation](https://popper.js.org/docs/v2/modifiers/flip/).
+
+In the following example, the tooltip's placement is initially set to `top`. However, if the placement is not suitable due to space constraints, the opposite `bottom` placement will be used instead.
+
+```jsx noInline
+const FormGroup = (props) => (
+  <Box mb="4x" {...props} />
+);
+
+render(() => {
+  const [colorMode] = useColorMode();
+  const [colorStyle] = useColorStyle({ colorMode });
+  const [isFlipModifierEnabled, toggleIsFlipModifierEnabled] = useToggle(true);
+
+  return (
+    <>
+      <Box mb="4x">
+        <Text fontSize="lg" lineHeight="lg">
+          Modifiers
+        </Text>
+      </Box>
+      <FormGroup>
+        <TextLabel display="inline-flex" alignItems="center">
+          <Checkbox
+            checked={isFlipModifierEnabled}
+            onChange={() => toggleIsFlipModifierEnabled()}
+          />
+          <Space width="2x" />
+          <Text fontFamily="mono" whiteSpace="nowrap">Enable flip modifier</Text>
+        </TextLabel>
+      </FormGroup>
+      <Divider my="4x" />
+      <Scrollbar
+        height={180}
+        width={180}
+        overflowY="visible"
+        border={1}
+        borderColor={colorStyle.divider}
+      >
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          height={300}
+        >
+          <Tooltip
+            isOpen
+            placement="top"
+            label="This is a tooltip"
+            PopperProps={{
+              modifiers: [
+                { // https://popper.js.org/docs/v2/modifiers/flip/
+                  name: 'flip',
+                  enabled: isFlipModifierEnabled,
+                },
+              ],
+            }}
+          >
+            <Text display="inline-block">
+              Reference
+            </Text>
+          </Tooltip>
+        </Flex>
+      </Scrollbar>
+    </>
+  );
+});
+```
+
 ## Props
 
 ### Tooltip
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
-| PopperComponent | ElementType | Popper | The component used for the popover. |
+| PopperComponent | ElementType | Popper | The component used for the popper. |
 | PopperProps | object | | Props applied to the Popper component. |
 | TooltipArrowComponent | ElementType | TooltipArrow | The component used for the tooltip arrow. |
 | TooltipArrowProps | object | | Props applied to the `TooltipArrow` component. |

--- a/packages/react/src/popover/PopoverArrow.js
+++ b/packages/react/src/popover/PopoverArrow.js
@@ -8,6 +8,7 @@ const PopoverArrow = forwardRef((
   {
     arrowHeight = 8,
     arrowWidth = 12,
+    sx,
     ...rest
   },
   ref,
@@ -16,26 +17,27 @@ const PopoverArrow = forwardRef((
     placement,
     popoverContentRef,
   } = usePopover();
-  const styleProps = usePopoverArrowStyle({ arrowHeight, arrowWidth, placement });
-  const colorStyleProps = (() => {
-    const popoverContentEl = popoverContentRef?.current;
-    if (isHTMLElement(popoverContentEl)) {
-      // Compute the background color of the first direct child of the popover content and apply it to the popover arrow
-      const computedStyle = getComputedStyle(popoverContentEl.firstChild);
-      return {
-        color: computedStyle?.backgroundColor,
-      };
-    }
-    return {};
-  })();
+  const popoverContentEl = popoverContentRef?.current;
+  const styleProps = usePopoverArrowStyle({ arrowHeight, arrowWidth });
+
+  if (isHTMLElement(popoverContentEl)) {
+    // Compute the background color of the first direct child of the popover content and apply it to the popover arrow
+    const computedStyle = getComputedStyle(popoverContentEl.firstChild);
+    styleProps.color = computedStyle?.backgroundColor;
+  }
 
   return (
     <Box
       ref={ref}
       role="presentation"
-      data-popper-arrow // This data attribute is used by the Popper.js library to identify the element to use as the arrow (refer to "popper/Popper.js")
-      {...styleProps}
-      {...colorStyleProps}
+      // The `data-popper-arrow` attribute is utilized by `popper/Popper.js` to designate the element used as the arrow
+      data-popper-arrow
+      // The `data-popper-placement` attribute is automatically updated by `popper/Popper.js` to reflect the popper's actual placement
+      data-popper-placement={placement}
+      sx={[
+        styleProps,
+        ...Array.isArray(sx) ? sx : [sx],
+      ]}
       {...rest}
     />
   );

--- a/packages/react/src/popover/PopoverContent.js
+++ b/packages/react/src/popover/PopoverContent.js
@@ -209,7 +209,6 @@ const PopoverContent = forwardRef((
       anchorEl={popoverTriggerRef.current}
       id={popoverId}
       isOpen={isOpen}
-      modifiers={popperModifiers}
       placement={placement}
       ref={popoverContentRef}
       role={role}
@@ -218,6 +217,12 @@ const PopoverContent = forwardRef((
       willUseTransition={true}
       zIndex="popover"
       {...PopperProps}
+      modifiers={[
+        // Default modifiers
+        ...popperModifiers,
+        // User-defined modifiers
+        ...ensureArray(PopperProps?.modifiers),
+      ]}
     >
       {({ placement, transition }) => {
         const { in: inProp, onEnter, onExited } = { ...transition };

--- a/packages/react/src/popover/__tests__/__snapshots__/Popover.test.js.snap
+++ b/packages/react/src/popover/__tests__/__snapshots__/Popover.test.js.snap
@@ -117,12 +117,35 @@ exports[`Popover should render correctly 1`] = `
 }
 
 .emotion-6 {
-  position: absolute;
-  top: 0;
   color: white;
 }
 
-.emotion-6::before {
+.emotion-6[data-popper-placement^="top"] {
+  position: absolute;
+  bottom: 0;
+}
+
+.emotion-6[data-popper-placement^="top"]::before {
+  content: "";
+  border-top: 8px solid;
+  border-left: calc(12px/2) solid transparent;
+  border-right: calc(12px/2) solid transparent;
+  -webkit-filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.08));
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.08));
+  position: absolute;
+  bottom: calc(8px * -1);
+  -webkit-transform: translateX(-50%);
+  -moz-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  transform: translateX(-50%);
+}
+
+.emotion-6[data-popper-placement^="bottom"] {
+  position: absolute;
+  top: 0;
+}
+
+.emotion-6[data-popper-placement^="bottom"]::before {
   content: "";
   border-bottom: 8px solid;
   border-left: calc(12px/2) solid transparent;
@@ -135,6 +158,46 @@ exports[`Popover should render correctly 1`] = `
   -moz-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
   transform: translateX(-50%);
+}
+
+.emotion-6[data-popper-placement^="left"] {
+  position: absolute;
+  right: 0;
+}
+
+.emotion-6[data-popper-placement^="left"]::before {
+  content: "";
+  border-left: 8px solid;
+  border-top: calc(12px/2) solid transparent;
+  border-bottom: calc(12px/2) solid transparent;
+  -webkit-filter: drop-shadow(1px 0px 1px rgba(0, 0, 0, 0.08));
+  filter: drop-shadow(1px 0px 1px rgba(0, 0, 0, 0.08));
+  position: absolute;
+  right: calc(8px * -1);
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.emotion-6[data-popper-placement^="right"] {
+  position: absolute;
+  left: 0;
+}
+
+.emotion-6[data-popper-placement^="right"]::before {
+  content: "";
+  border-right: 8px solid;
+  border-top: calc(12px/2) solid transparent;
+  border-bottom: calc(12px/2) solid transparent;
+  -webkit-filter: drop-shadow(-1px 0px 1px rgba(0, 0, 0, 0.08));
+  filter: drop-shadow(-1px 0px 1px rgba(0, 0, 0, 0.08));
+  position: absolute;
+  left: calc(8px * -1);
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
 }
 
 <div>
@@ -168,6 +231,7 @@ exports[`Popover should render correctly 1`] = `
       <div
         class="emotion-6 emotion-1"
         data-popper-arrow="true"
+        data-popper-placement="bottom"
         role="presentation"
         style="position: absolute; left: 0px; transform: translate(12px, 0px);"
       />

--- a/packages/react/src/popover/styles.js
+++ b/packages/react/src/popover/styles.js
@@ -1,4 +1,4 @@
-import { ensureNumber, ensureString } from 'ensure-type';
+import { ensureNumber } from 'ensure-type';
 import { useColorMode } from '../color-mode';
 import { useColorStyle } from '../color-style';
 import { useTheme } from '../theme';
@@ -14,23 +14,22 @@ const pixelize = (value) => {
 const usePopoverArrowStyle = ({
   arrowHeight: arrowHeightProp,
   arrowWidth: arrowWidthProp,
-  placement: placementProp,
 }) => {
   const [colorMode] = useColorMode();
   const { sizes } = useTheme();
   const arrowHeight = sizes[arrowHeightProp] ?? pixelize(arrowHeightProp);
   const arrowWidth = sizes[arrowWidthProp] ?? pixelize(arrowWidthProp);
-  const placement = ensureString(placementProp);
   const dropShadowColor = {
     dark: 'rgba(0, 0, 0, 0.16)',
     light: 'rgba(0, 0, 0, 0.08)',
   }[colorMode];
 
-  if (placement.startsWith('top')) {
-    return {
+  return {
+    // https://popper.js.org/docs/v2/tutorial/#arrow
+    '&[data-popper-placement^="top"]': {
       position: 'absolute',
       bottom: 0,
-      __before: {
+      '::before': {
         content: '""',
         borderTop: `${arrowHeight} solid`,
         borderLeft: `calc(${arrowWidth}/2) solid transparent`,
@@ -40,14 +39,11 @@ const usePopoverArrowStyle = ({
         bottom: `-${arrowHeight}`,
         transform: 'translateX(-50%)',
       },
-    };
-  }
-
-  if (placement.startsWith('bottom')) {
-    return {
+    },
+    '&[data-popper-placement^="bottom"]': {
       position: 'absolute',
       top: 0,
-      __before: {
+      '::before': {
         content: '""',
         borderBottom: `${arrowHeight} solid`,
         borderLeft: `calc(${arrowWidth}/2) solid transparent`,
@@ -57,14 +53,11 @@ const usePopoverArrowStyle = ({
         top: `-${arrowHeight}`,
         transform: 'translateX(-50%)',
       },
-    };
-  }
-
-  if (placement.startsWith('left')) {
-    return {
+    },
+    '&[data-popper-placement^="left"]': {
       position: 'absolute',
       right: 0,
-      __before: {
+      '::before': {
         content: '""',
         borderLeft: `${arrowHeight} solid`,
         borderTop: `calc(${arrowWidth}/2) solid transparent`,
@@ -74,14 +67,11 @@ const usePopoverArrowStyle = ({
         right: `-${arrowHeight}`,
         transform: 'translateY(-50%)',
       },
-    };
-  }
-
-  if (placement.startsWith('right')) {
-    return {
+    },
+    '&[data-popper-placement^="right"]': {
       position: 'absolute',
       left: 0,
-      __before: {
+      '::before': {
         content: '""',
         borderRight: `${arrowHeight} solid`,
         borderTop: `calc(${arrowWidth}/2) solid transparent`,
@@ -91,10 +81,8 @@ const usePopoverArrowStyle = ({
         left: `-${arrowHeight}`,
         transform: 'translateY(-50%)',
       },
-    };
-  }
-
-  return {};
+    },
+  };
 };
 
 const usePopoverTriggerStyle = () => {

--- a/packages/react/src/popper/Popper.js
+++ b/packages/react/src/popper/Popper.js
@@ -81,12 +81,20 @@ const Popper = forwardRef((
           enabled: true,
           phase: 'afterWrite',
           fn: ({ state }) => {
+            const arrowEl = state?.elements?.arrow;
+            const nextPlacement = state?.placement;
+
+            // Update the arrow element's `data-popper-placement` attribute based on the desired placement
+            // @see https://popper.js.org/docs/v2/tutorial/
+            if (arrowEl && arrowEl.getAttribute('data-popper-placement') !== nextPlacement) {
+              arrowEl.setAttribute('data-popper-placement', nextPlacement);
+            }
+
             const isControlled = (placementProp !== undefined);
             if (isControlled) {
               return;
             }
 
-            const nextPlacement = state?.placement;
             if (nextPlacement && (nextPlacement !== placement)) {
               setPlacement(nextPlacement);
             }

--- a/packages/react/src/popper/Popper.js
+++ b/packages/react/src/popper/Popper.js
@@ -72,10 +72,6 @@ const Popper = forwardRef((
             padding: 12, // 12px from the edges of the popper
           },
         },
-        { // https://popper.js.org/docs/v2/modifiers/flip/
-          name: 'flip',
-          enabled: false, // No flip
-        },
         {
           name: 'handlePopperUpdate',
           enabled: true,

--- a/packages/react/src/tooltip/TooltipArrow.js
+++ b/packages/react/src/tooltip/TooltipArrow.js
@@ -8,6 +8,7 @@ const TooltipArrow = forwardRef((
   {
     arrowHeight = 4,
     arrowWidth = 8,
+    sx,
     ...rest
   },
   ref,
@@ -16,26 +17,27 @@ const TooltipArrow = forwardRef((
     placement,
     tooltipContentRef,
   } = useTooltip();
-  const styleProps = useTooltipArrowStyle({ arrowHeight, arrowWidth, placement });
-  const colorStyleProps = (() => {
-    const tooltipContentEl = tooltipContentRef?.current;
-    if (isHTMLElement(tooltipContentEl)) {
-      // Compute the background color of the first direct child of the tooltip content and apply it to the tooltip arrow
-      const computedStyle = getComputedStyle(tooltipContentEl.firstChild);
-      return {
-        color: computedStyle?.backgroundColor,
-      };
-    }
-    return {};
-  })();
+  const tooltipContentEl = tooltipContentRef?.current;
+  const styleProps = useTooltipArrowStyle({ arrowHeight, arrowWidth });
+
+  if (isHTMLElement(tooltipContentEl)) {
+    // Compute the background color of the first direct child of the tooltip content and apply it to the tooltip arrow
+    const computedStyle = getComputedStyle(tooltipContentEl.firstChild);
+    styleProps.color = computedStyle?.backgroundColor;
+  }
 
   return (
     <Box
       ref={ref}
       role="presentation"
-      data-popper-arrow // This data attribute is used by the Popper.js library to identify the element to use as the arrow (refer to "popper/Popper.js")
-      {...styleProps}
-      {...colorStyleProps}
+      // The `data-popper-arrow` attribute is utilized by `popper/Popper.js` to designate the element used as the arrow
+      data-popper-arrow
+      // The `data-popper-placement` attribute is automatically updated by `popper/Popper.js` to reflect the popper's actual placement
+      data-popper-placement={placement}
+      sx={[
+        styleProps,
+        ...Array.isArray(sx) ? sx : [sx],
+      ]}
       {...rest}
     />
   );

--- a/packages/react/src/tooltip/TooltipContent.js
+++ b/packages/react/src/tooltip/TooltipContent.js
@@ -146,7 +146,6 @@ const TooltipContent = forwardRef((
       anchorEl={tooltipTriggerRef.current}
       id={tooltipId}
       isOpen={isOpen}
-      modifiers={popperModifiers}
       placement={placement}
       pointerEvents="none"
       ref={tooltipContentRef}
@@ -156,6 +155,12 @@ const TooltipContent = forwardRef((
       willUseTransition={true}
       zIndex="tooltip"
       {...PopperProps}
+      modifiers={[
+        // Default modifiers
+        ...popperModifiers,
+        // User-defined modifiers
+        ...ensureArray(PopperProps?.modifiers),
+      ]}
     >
       {({ placement, transition }) => {
         const { in: inProp, onEnter, onExited } = { ...transition };

--- a/packages/react/src/tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/packages/react/src/tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -110,12 +110,32 @@ exports[`Tooltip should render correctly 1`] = `
   transform-origin: top center;
 }
 
-.emotion-6 {
+.emotion-6[data-popper-placement^="top"] {
+  position: absolute;
+  bottom: 0;
+}
+
+.emotion-6[data-popper-placement^="top"]::before {
+  content: "";
+  border-top: 4px solid;
+  border-left: calc(8px/2) solid transparent;
+  border-right: calc(8px/2) solid transparent;
+  -webkit-filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.08));
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.08));
+  position: absolute;
+  bottom: calc(4px * -1);
+  -webkit-transform: translateX(-50%);
+  -moz-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  transform: translateX(-50%);
+}
+
+.emotion-6[data-popper-placement^="bottom"] {
   position: absolute;
   top: 0;
 }
 
-.emotion-6::before {
+.emotion-6[data-popper-placement^="bottom"]::before {
   content: "";
   border-bottom: 4px solid;
   border-left: calc(8px/2) solid transparent;
@@ -128,6 +148,46 @@ exports[`Tooltip should render correctly 1`] = `
   -moz-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
   transform: translateX(-50%);
+}
+
+.emotion-6[data-popper-placement^="left"] {
+  position: absolute;
+  right: 0;
+}
+
+.emotion-6[data-popper-placement^="left"]::before {
+  content: "";
+  border-left: 4px solid;
+  border-top: calc(8px/2) solid transparent;
+  border-bottom: calc(8px/2) solid transparent;
+  -webkit-filter: drop-shadow(1px 0px 1px rgba(0, 0, 0, 0.08));
+  filter: drop-shadow(1px 0px 1px rgba(0, 0, 0, 0.08));
+  position: absolute;
+  right: calc(4px * -1);
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.emotion-6[data-popper-placement^="right"] {
+  position: absolute;
+  left: 0;
+}
+
+.emotion-6[data-popper-placement^="right"]::before {
+  content: "";
+  border-right: 4px solid;
+  border-top: calc(8px/2) solid transparent;
+  border-bottom: calc(8px/2) solid transparent;
+  -webkit-filter: drop-shadow(-1px 0px 1px rgba(0, 0, 0, 0.08));
+  filter: drop-shadow(-1px 0px 1px rgba(0, 0, 0, 0.08));
+  position: absolute;
+  left: calc(4px * -1);
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
 }
 
 <div>
@@ -156,6 +216,7 @@ exports[`Tooltip should render correctly 1`] = `
       <div
         class="emotion-6 emotion-1"
         data-popper-arrow="true"
+        data-popper-placement="bottom"
         role="presentation"
         style="position: absolute; left: 0px; transform: translate(12px, 0px);"
       />

--- a/packages/react/src/tooltip/styles.js
+++ b/packages/react/src/tooltip/styles.js
@@ -1,4 +1,4 @@
-import { ensureNumber, ensureString } from 'ensure-type';
+import { ensureNumber } from 'ensure-type';
 import { useColorMode } from '../color-mode';
 import { useColorStyle } from '../color-style';
 import { useTheme } from '../theme';
@@ -14,23 +14,22 @@ const pixelize = (value) => {
 const useTooltipArrowStyle = ({
   arrowHeight: arrowHeightProp,
   arrowWidth: arrowWidthProp,
-  placement: placementProp,
 }) => {
   const [colorMode] = useColorMode();
   const { sizes } = useTheme();
   const arrowHeight = sizes[arrowHeightProp] ?? pixelize(arrowHeightProp);
   const arrowWidth = sizes[arrowWidthProp] ?? pixelize(arrowWidthProp);
-  const placement = ensureString(placementProp);
   const dropShadowColor = {
     dark: 'rgba(0, 0, 0, 0.16)',
     light: 'rgba(0, 0, 0, 0.08)',
   }[colorMode];
 
-  if (placement.startsWith('top')) {
-    return {
+  return {
+    // https://popper.js.org/docs/v2/tutorial/#arrow
+    '&[data-popper-placement^="top"]': {
       position: 'absolute',
       bottom: 0,
-      __before: {
+      '::before': {
         content: '""',
         borderTop: `${arrowHeight} solid`,
         borderLeft: `calc(${arrowWidth}/2) solid transparent`,
@@ -40,14 +39,11 @@ const useTooltipArrowStyle = ({
         bottom: `-${arrowHeight}`,
         transform: 'translateX(-50%)',
       },
-    };
-  }
-
-  if (placement.startsWith('bottom')) {
-    return {
+    },
+    '&[data-popper-placement^="bottom"]': {
       position: 'absolute',
       top: 0,
-      __before: {
+      '::before': {
         content: '""',
         borderBottom: `${arrowHeight} solid`,
         borderLeft: `calc(${arrowWidth}/2) solid transparent`,
@@ -57,14 +53,11 @@ const useTooltipArrowStyle = ({
         top: `-${arrowHeight}`,
         transform: 'translateX(-50%)',
       },
-    };
-  }
-
-  if (placement.startsWith('left')) {
-    return {
+    },
+    '&[data-popper-placement^="left"]': {
       position: 'absolute',
       right: 0,
-      __before: {
+      '::before': {
         content: '""',
         borderLeft: `${arrowHeight} solid`,
         borderTop: `calc(${arrowWidth}/2) solid transparent`,
@@ -74,14 +67,11 @@ const useTooltipArrowStyle = ({
         right: `-${arrowHeight}`,
         transform: 'translateY(-50%)',
       },
-    };
-  }
-
-  if (placement.startsWith('right')) {
-    return {
+    },
+    '&[data-popper-placement^="right"]': {
       position: 'absolute',
       left: 0,
-      __before: {
+      '::before': {
         content: '""',
         borderRight: `${arrowHeight} solid`,
         borderTop: `calc(${arrowWidth}/2) solid transparent`,
@@ -91,10 +81,8 @@ const useTooltipArrowStyle = ({
         left: `-${arrowHeight}`,
         transform: 'translateY(-50%)',
       },
-    };
-  }
-
-  return {};
+    },
+  };
 };
 
 const useTooltipTriggerStyle = () => {


### PR DESCRIPTION
## Overview
This PR resolves a regression issue introduced in #729, where the arrow position becomes incorrect when the flip modifier option of the popper is enabled.

Based on the provided screenshot, the desired popper placement should be determined by the `data-popper-placement` attribute instead of being retrieved from the context provider.

![image](https://github.com/trendmicro-frontend/tonic-ui/assets/447801/97c2b131-a0ea-48fc-84bb-9f2346d80243)

## Demo
* https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-761/components/popover#automatically-flipping-popover-placement-with-the-flip-modifier
* https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-761/components/tooltip#automatically-flipping-tooltip-placement-with-the-flip-modifier