### PR TITLE
fix: disable Popper's scroll event listener for preventing `Submenu` from scrolling with `MenuList`

### DIFF
--- a/packages/react-docs/pages/components/menu.mdx
+++ b/packages/react-docs/pages/components/menu.mdx
@@ -1357,6 +1357,7 @@ render(() => {
 | children | ReactNode | | |
 | defaultIsOpen | boolean | false | Whether the submenu is open by default. |
 | isOpen | boolean | | Whether the submenu is open. |
+| offset | [skidding, distance] | [0, 0] | The skidding and distance of the menu. |
 | onClose | function | | Callback when the submenu is closed. |
 | onOpen | function | | Callback when the submenu is opened. |
 | placement | string | 'right-start' | The placement of the submenu. One of: 'right-start', 'right-end', 'left-start', 'left-end' |

--- a/packages/react/src/menu/MenuContent.js
+++ b/packages/react/src/menu/MenuContent.js
@@ -98,7 +98,7 @@ const MenuContent = forwardRef((
     const modifiers = [
       { // https://popper.js.org/docs/v2/modifiers/flip/
         name: 'flip',
-        enabled: false,
+        enabled: false, // Disable flip functionality
       },
       { // https://popper.js.org/docs/v2/modifiers/offset/
         name: 'offset',

--- a/packages/react/src/menu/SubmenuContent.js
+++ b/packages/react/src/menu/SubmenuContent.js
@@ -73,12 +73,20 @@ const SubmenuContent = forwardRef((
     const modifiers = [
       { // https://popper.js.org/docs/v2/modifiers/flip/
         name: 'flip',
-        enabled: false,
+        enabled: false, // Disable flip functionality
       },
       { // https://popper.js.org/docs/v2/modifiers/offset/
         name: 'offset',
         options: {
           offset: [skidding, distance],
+        },
+      },
+      {
+        // https://popper.js.org/docs/v2/modifiers/event-listeners/
+        name: 'eventListeners',
+        options: {
+          scroll: false, // Disable scroll event listener to prevent scrolling the popper element with the reference element
+          resize: true, // Keep resize event listener enabled (default behavior)
         },
       },
     ];


### PR DESCRIPTION
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-770/components/menu#scrolling