### PR TITLE
fix: cursor jump to end position when typing in SearchInput

### DIFF
--- a/packages/react/src/search-input/SearchInput.js
+++ b/packages/react/src/search-input/SearchInput.js
@@ -1,3 +1,4 @@
+
 import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { ensureString } from 'ensure-type';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -31,13 +32,13 @@ const SearchInput = React.forwardRef((
   const combinedRef = useMergeRefs(nodeRef, ref);
   const [value, setValue] = useState(ensureString(valueProp ?? defaultValueProp));
   const isClearable = !disabled && !readOnly && !!value;
+  const isControlled = (valueProp !== undefined);
 
   useEffect(() => {
-    const isControlled = (valueProp !== undefined);
     if (isControlled) {
       setValue(valueProp);
     }
-  }, [valueProp]);
+  }, [isControlled]);
 
   const iconState = (() => {
     if (isLoading) {
@@ -55,7 +56,6 @@ const SearchInput = React.forwardRef((
     }
 
     const nextValue = '';
-    const isControlled = (valueProp !== undefined);
     if (!isControlled) {
       setValue(nextValue);
     }
@@ -68,19 +68,16 @@ const SearchInput = React.forwardRef((
       const el = nodeRef.current;
       el && el.focus(); // Retain focus on the input after clearing
     });
-  }, [iconState, valueProp, onClearInputProp]);
+  }, [iconState, isControlled, onClearInputProp]);
 
   const onChange = useCallback((e) => {
     const nextValue = ensureString(e.target.value ?? '');
-    const isControlled = (valueProp !== undefined);
-    if (!isControlled) {
-      setValue(nextValue);
-    }
+    setValue(nextValue);
 
     if (typeof onChangeProp === 'function') {
       onChangeProp(e);
     }
-  }, [valueProp, onChangeProp]);
+  }, [onChangeProp]);
 
   const startAdornment = (
     <SearchInputAdornment>


### PR DESCRIPTION
## Type
- [x] fix (SearchInput cursor jumping issue)

## Description
[Issue 797](https://github.com/trendmicro-frontend/tonic-ui/issues/797)
In controlled component usage, when typing in the SearchInput, the cursor would jump to end after inputting.

https://github.com/trendmicro-frontend/tonic-ui/blob/a80d4ccbbe6de41bf19f2da43bfc552630355d47/packages/react/src/search-input/SearchInput.js#L72-L84
Inside SearchInput `onChange`, controlled mode would cause it to change valueProp through onChangeProp and cause component re-render which cause this issue.

## Changes
- move `isControlled` definition to higher and update relative dependencies for avoiding needless re-render when valueProp changes
- remove the isControlled check to update state in `onChange`, no matter controlled or not controlled, the state should be updated inside