### PR TITLE
feat(tree-shaking): Enabled side effects optimization for esm build

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,16 +2,17 @@
   "name": "@tonic-ui/react",
   "version": "1.29.0",
   "description": "React Tonic UI component library.",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "build": "cross-env PACKAGE_NAME=index INPUT=src OUTPUT_DIRECTORY=dist rollup --config rollup.config.mjs",
+    "build": "cross-env PACKAGE_NAME=index INPUT=src CJS_OUTPUT_DIRECTORY=dist/cjs ESM_OUTPUT_DIRECTORY=dist/esm rollup --config rollup.config.mjs",
     "clean": "del build coverage dist",
     "lint": "eslint --ext .js,.jsx,.mjs .",
     "pre-push": "bash -c 'echo -e \"=> \\e[1;33m$npm_package_name\\e[0m\"' && yarn run build && yarn run lint && yarn run test",

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -6,7 +6,8 @@ const packageName = process.env.PACKAGE_NAME;
 
 const input = process.env.INPUT || path.resolve(__dirname, 'src', 'index.js');
 
-const outputDirectory = process.env.OUTPUT_DIRECTORY || path.resolve(__dirname, 'dist');
+const cjsOutputDirectory = process.env.CJS_OUTPUT_DIRECTORY || path.resolve(__dirname, 'dist', 'cjs');
+const esmOutputDirectory = process.env.ESM_OUTPUT_DIRECTORY || path.resolve(__dirname, 'dist', 'esm');
 
 const isExternal = id => !id.startsWith('.') && !id.startsWith('/');
 
@@ -14,7 +15,7 @@ export default [
   {
     input,
     output: {
-      file: path.join(outputDirectory, `${packageName}.cjs.js`),
+      file: path.join(cjsOutputDirectory, `${packageName}.js`),
       format: 'cjs',
 
       // https://rollupjs.org/guide/en/#changed-defaults
@@ -30,13 +31,14 @@ export default [
   {
     input,
     output: {
-      file: path.join(outputDirectory, `${packageName}.esm.js`),
+      dir: esmOutputDirectory,
       format: 'esm',
+      preserveModules: true,
     },
     external: isExternal,
     plugins: [
       nodeResolve(),
-      babel({ babelHelpers: 'bundled' }),
+      babel({ babelHelpers: 'bundled' })
     ],
-  }
+  },
 ];


### PR DESCRIPTION
# Enable Side Effects Optimization for ESM Build #832 

In this PR, I enable side effects optimization for the ESM build. Paired with #831, we can dramatically reduce bundle sizes when importing simple components like `Box` which previously imported >500KB of code. Please refer to the issue #832 and this article explaining how to make tree shakeable libraries: https://blog.theodo.com/2021/04/library-tree-shaking/.

### Here is what the ESM build looks like before the side effects optimization (it's only one module):
<img width="1871" alt="Screenshot 2024-02-28 at 11 29 54 AM" src="https://github.com/trendmicro-frontend/tonic-ui/assets/55165268/45c1765e-8182-4186-8a48-530f17d740ef">

### Here is what the ESM build looks like after the side effects optimization:
<img width="1883" alt="Screenshot 2024-02-28 at 11 23 28 AM" src="https://github.com/trendmicro-frontend/tonic-ui/assets/55165268/b47cf856-f8de-40e9-9547-3369597aedb1">

## With these changes coupled with the optimizations from #831, we get significantly smaller imports:
_**Screenshots are from an example project using Rollup.**_

### Here is a simple import before optimization:
<img width="807" alt="Screenshot 2024-02-28 at 11 31 07 AM" src="https://github.com/trendmicro-frontend/tonic-ui/assets/55165268/7ccecee2-fe78-4557-8fdd-a66e53665489">

### Here is a simple import after side effect optimizations and modularized icons #831 
<img width="760" alt="Screenshot 2024-02-28 at 11 34 14 AM" src="https://github.com/trendmicro-frontend/tonic-ui/assets/55165268/ca9569bf-3cba-453b-8652-fadb14779f19">

