### PR TITLE
refactor: Preserve modules structure in cjs build

### DIFF
--- a/packages/react-base/rollup.config.mjs
+++ b/packages/react-base/rollup.config.mjs
@@ -17,10 +17,10 @@ export default [
     output: {
       dir: cjsOutputDirectory,
       format: 'cjs',
-
       // https://rollupjs.org/guide/en/#changed-defaults
       // https://rollupjs.org/guide/en/#outputinterop
       interop: 'auto',
+      preserveModules: true,
     },
     external: isExternal,
     plugins: [

--- a/packages/react-hooks/rollup.config.mjs
+++ b/packages/react-hooks/rollup.config.mjs
@@ -21,6 +21,7 @@ export default [
       // https://rollupjs.org/guide/en/#changed-defaults
       // https://rollupjs.org/guide/en/#outputinterop
       interop: 'auto',
+      preserveModules: true,
     },
     external: isExternal,
     plugins: [

--- a/packages/react-icons/rollup.config.mjs
+++ b/packages/react-icons/rollup.config.mjs
@@ -17,10 +17,10 @@ export default [
     output: {
       dir: cjsOutputDirectory,
       format: 'cjs',
-
       // https://rollupjs.org/guide/en/#changed-defaults
       // https://rollupjs.org/guide/en/#outputinterop
       interop: 'auto',
+      preserveModules: true
     },
     external: isExternal,
     plugins: [

--- a/packages/react-lab/rollup.config.mjs
+++ b/packages/react-lab/rollup.config.mjs
@@ -21,6 +21,7 @@ export default [
       // https://rollupjs.org/guide/en/#changed-defaults
       // https://rollupjs.org/guide/en/#outputinterop
       interop: 'auto',
+      preserveModules: true,
     },
     external: isExternal,
     plugins: [

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -17,10 +17,10 @@ export default [
     output: {
       dir: cjsOutputDirectory,
       format: 'cjs',
-
       // https://rollupjs.org/guide/en/#changed-defaults
       // https://rollupjs.org/guide/en/#outputinterop
       interop: 'auto',
+      preserveModules: true,
     },
     external: isExternal,
     plugins: [

--- a/packages/styled-system/rollup.config.mjs
+++ b/packages/styled-system/rollup.config.mjs
@@ -21,6 +21,7 @@ export default [
       // https://rollupjs.org/guide/en/#changed-defaults
       // https://rollupjs.org/guide/en/#outputinterop
       interop: 'auto',
+      preserveModules: true,
     },
     external: isExternal,
     plugins: [

--- a/packages/theme/rollup.config.mjs
+++ b/packages/theme/rollup.config.mjs
@@ -21,6 +21,7 @@ export default [
       // https://rollupjs.org/guide/en/#changed-defaults
       // https://rollupjs.org/guide/en/#outputinterop
       interop: 'auto',
+      preserveModules: true,
 
       // The `@tonic-ui/theme` package mixed default and named exports. See `output.exports` for more info.
       //

--- a/packages/utils/rollup.config.mjs
+++ b/packages/utils/rollup.config.mjs
@@ -21,6 +21,7 @@ export default [
       // https://rollupjs.org/guide/en/#changed-defaults
       // https://rollupjs.org/guide/en/#outputinterop
       interop: 'auto',
+      preserveModules: true,
     },
     external: isExternal,
     plugins: [


### PR DESCRIPTION
Preserve modules structure in cjs build to avoid bundling into a single module.