### PR TITLE
fix(`SearchInput`): resolve composition event issue with CJK input methods in controlled inputs

### DIFF
--- a/packages/react/src/search-input/SearchInput.js
+++ b/packages/react/src/search-input/SearchInput.js
@@ -81,12 +81,10 @@ const SearchInput = React.forwardRef((
   }, [iconState, valueProp, onClearInputProp]);
 
   const onChange = useCallback((e) => {
+    // When the input value remains unchanged in controlled input, composition events (especially CJK input methods) may not work properly.
+    // To address this issue, update the input value internally before invoking `onChangeProp`.
     const nextValue = ensureString(e.target.value ?? '');
-    const isControlled = (valueProp !== undefined);
-
-    if (!isControlled) {
-      setValue(nextValue);
-    }
+    setValue(nextValue);
 
     inputSelectionRef.current = {
       start: e.target.selectionStart,
@@ -96,7 +94,7 @@ const SearchInput = React.forwardRef((
     if (typeof onChangeProp === 'function') {
       onChangeProp(e);
     }
-  }, [valueProp, onChangeProp]);
+  }, [onChangeProp]);
 
   const startAdornment = (
     <SearchInputAdornment>


### PR DESCRIPTION
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-850/components/search-input

When the input value remains unchanged in controlled input, composition events (especially CJK input methods) may not work properly. To address this issue, update the input value internally before invoking `onChangeProp`.

Check out the screenshot and video below:

![image](https://github.com/trendmicro-frontend/tonic-ui/assets/447801/b1e905b4-cd43-4566-be81-7b3cf3dfb49d)

![May-08-2024 09-54-26](https://github.com/trendmicro-frontend/tonic-ui/assets/447801/66b8295f-e786-4bc4-a163-c04658cbc2fb)