### PR TITLE
feat(styled-system): add complete support for `grid` CSS properties

### DIFF
--- a/packages/styled-system/src/config/__tests__/gap.test.js
+++ b/packages/styled-system/src/config/__tests__/gap.test.js
@@ -2,13 +2,21 @@ import gap from '../gap';
 
 test('returns gap styles', () => {
   const style = gap({
-    gap: 32,
-    columnGap: 16,
-    rowGap: 16,
+    theme: {
+      sizes: {
+        '1x': '.25rem',
+        '2x': '.5rem',
+        '3x': '.75rem',
+        '4x': '1rem',
+      },
+    },
+    gap: '1x',
+    columnGap: '2x',
+    rowGap: '4x',
   });
   expect(style).toEqual({
-    gap: 32,
-    columnGap: 16,
-    rowGap: 16,
+    gap: '.25rem',
+    columnGap: '.5rem',
+    rowGap: '1rem',
   });
 });

--- a/packages/styled-system/src/config/__tests__/grid.test.js
+++ b/packages/styled-system/src/config/__tests__/grid.test.js
@@ -2,13 +2,60 @@ import grid from '../grid';
 
 test('returns grid styles', () => {
   const style = grid({
-    gridGap: 32,
-    gridColumnGap: 16,
-    gridRowGap: 16,
+    theme: {
+      sizes: {
+        '1x': '.25rem',
+        '2x': '.5rem',
+        '3x': '.75rem',
+        '4x': '1rem',
+      },
+    },
+
+    gridArea: 'auto',
+    gridAutoColumns: 'minmax(100px, auto)',
+    gridAutoFlow: 'row',
+    gridAutoRows: 'minmax(max-content, 2fr)',
+    gridColumn: 'auto / auto',
+    gridColumnEnd: 'auto',
+    gridColumnStart: 'auto',
+    gridRow: 'auto / auto',
+    gridRowEnd: 'auto',
+    gridRowStart: 'auto',
+    gridTemplate: `
+      "a a a" 20%
+      "b b b" auto
+    `.trim(),
+    gridTemplateAreas: '"a b b" "a c d"',
+    gridTemplateColumns: 'minmax(100px, 1fr)',
+    gridTemplateRows: 'minmax(100px, 1fr)',
+
+    // deprecated properties
+    gridGap: '1x', // `gridGap` is an alias for `gap`
+    gridColumnGap: '2x', // `gridColumnGap` is an alias for `columnGap`
+    gridRowGap: '4x', // `gridRowGap` is an alias for `rowGap`
   });
   expect(style).toEqual({
-    gridGap: 32,
-    gridColumnGap: 16,
-    gridRowGap: 16,
+    gridArea: 'auto',
+    gridAutoColumns: 'minmax(100px, auto)',
+    gridAutoFlow: 'row',
+    gridAutoRows: 'minmax(max-content, 2fr)',
+    gridColumn: 'auto / auto',
+    gridColumnEnd: 'auto',
+    gridColumnStart: 'auto',
+    gridRow: 'auto / auto',
+    gridRowEnd: 'auto',
+    gridRowStart: 'auto',
+    gridTemplate: `
+      "a a a" 20%
+      "b b b" auto
+    `.trim(),
+    gridTemplateAreas: '"a b b" "a c d"',
+    gridTemplateColumns: 'minmax(100px, 1fr)',
+    gridTemplateRows: 'minmax(100px, 1fr)',
+
+    // deprecated properties
+    gridGap: '.25rem',
+    gridColumnGap: '.5rem',
+    gridRowGap: '1rem',
   });
 });

--- a/packages/styled-system/src/config/grid.js
+++ b/packages/styled-system/src/config/grid.js
@@ -2,27 +2,34 @@ import system from '../core/system';
 
 const group = 'grid';
 const config = {
-  gridGap: {
+  gridArea: true,
+  gridAutoColumns: true,
+  gridAutoFlow: true,
+  gridAutoRows: true,
+  gridColumn: true,
+  gridColumnEnd: true,
+  gridColumnStart: true,
+  gridRow: true,
+  gridRowEnd: true,
+  gridRowStart: true,
+  gridTemplate: true,
+  gridTemplateAreas: true,
+  gridTemplateColumns: true,
+  gridTemplateRows: true,
+
+  // The following properties are renamed in CSS3 and will be deprecated or removed in the next major release
+  gridGap: { // `gridGap` is an alias for `gap`
     property: 'gridGap',
     scale: 'sizes',
   },
-  gridColumnGap: {
+  gridColumnGap: { // `gridColumnGap` is an alias for `columnGap`
     property: 'gridColumnGap',
     scale: 'sizes',
   },
-  gridRowGap: {
+  gridRowGap: { // `gridRowGap` is an alias for `rowGap`
     property: 'gridRowGap',
     scale: 'sizes',
   },
-  gridColumn: true,
-  gridRow: true,
-  gridAutoFlow: true,
-  gridAutoColumns: true,
-  gridAutoRows: true,
-  gridTemplateColumns: true,
-  gridTemplateRows: true,
-  gridTemplateAreas: true,
-  gridArea: true,
 };
 
 const grid = system(config, { group });


### PR DESCRIPTION
The new configuration might look loke below:
```js
const config = {
  gridArea: true,
  gridAutoColumns: true,
  gridAutoFlow: true,
  gridAutoRows: true,
  gridColumn: true,
  gridColumnEnd: true,
  gridColumnStart: true,
  gridRow: true,
  gridRowEnd: true,
  gridRowStart: true,
  gridTemplate: true,
  gridTemplateAreas: true,
  gridTemplateColumns: true,
  gridTemplateRows: true,

  // The following properties are renamed in CSS3 and will be deprecated or removed in the next major release
  gridGap: { // `gridGap` is an alias for `gap`
    property: 'gridGap',
    scale: 'sizes',
  },
  gridColumnGap: { // `gridColumnGap` is an alias for `columnGap`
    property: 'gridColumnGap',
    scale: 'sizes',
  },
  gridRowGap: { // `gridRowGap` is an alias for `rowGap`
    property: 'gridRowGap',
    scale: 'sizes',
  },
};
```

Note that the change will be applied to `v1` and `v2` releases.