### PR TITLE
fix: apply `display: block` to ensure Text-based components behave as block-level elements

### DIFF
--- a/packages/react-docs/pages/components/text-label/basic.js
+++ b/packages/react-docs/pages/components/text-label/basic.js
@@ -1,8 +1,11 @@
-import { TextLabel } from '@tonic-ui/react';
+import { Input, TextLabel } from '@tonic-ui/react';
 import React from 'react';
 
 const App = () => (
-  <TextLabel>Label text:</TextLabel>
+  <>
+    <TextLabel mb="1x">Label:</TextLabel>
+    <Input placeholder="Basic example" />
+  </>
 );
 
 export default App;

--- a/packages/react/src/text/__tests__/__snapshots__/Text.test.js.snap
+++ b/packages/react/src/text/__tests__/__snapshots__/Text.test.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextLabel should render correctly 1`] = `
+.emotion-0 {
+  display: block;
+}
+
 <div>
   <div
     class="emotion-0 emotion-1"

--- a/packages/react/src/text/__tests__/__snapshots__/TextLabel.test.js.snap
+++ b/packages/react/src/text/__tests__/__snapshots__/TextLabel.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`TextLabel should render correctly 1`] = `
 .emotion-0 {
+  display: block;
   color: var(--tonic-colors-white-secondary);
 }
 

--- a/packages/react/src/text/styles.js
+++ b/packages/react/src/text/styles.js
@@ -5,6 +5,7 @@ const useTextStyle = ({ size }) => {
   const { fontSizes, lineHeights } = useTheme();
 
   return {
+    display: 'block', // Apply 'display: block' to ensure Text-based components behave as block-level elements
     fontSize: fontSizes?.[size],
     lineHeight: lineHeights?.[size],
   };

--- a/packages/react/src/truncate/__tests__/__snapshots__/Truncate.test.js.snap
+++ b/packages/react/src/truncate/__tests__/__snapshots__/Truncate.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Truncate should render correctly 1`] = `
 .emotion-0 {
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-859/components/text-label