### PR TITLE
docs: update usage for using as="li" for Text component

### DIFF
--- a/packages/react-docs/pages/components/text/index.page.mdx
+++ b/packages/react-docs/pages/components/text/index.page.mdx
@@ -40,6 +40,14 @@ You can format the `Text` component by passing `fontSize`, `lineHeight`, or othe
 
 {render('./the-as-prop')}
 
+## Commonly Asked Questions
+
+### Show bullet when using as `li` props
+
+The default value for `display` props is `block` which causes the bullet points of list items to disappear. Setting `display="list-item"` will restore their visibility.
+
+{render('./text-as-li')}
+
 ## Props
 
 ### Text

--- a/packages/react-docs/pages/components/text/text-as-li.js
+++ b/packages/react-docs/pages/components/text/text-as-li.js
@@ -1,0 +1,18 @@
+import { Text } from '@tonic-ui/react';
+import React from 'react';
+
+const App = () => (
+  <>
+    <Text as="li" display="list-item">
+      This is an example with bullet points.
+    </Text>
+    <Text as="li" display="list-item">
+      This is an example with bullet points.
+    </Text>
+    <Text as="li" display="list-item">
+      This is an example with bullet points.
+    </Text>
+  </>
+);
+
+export default App;


### PR DESCRIPTION
### **User description**

https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-899/components/text

The bullet is missing when setting `as="li"` for the `Text` component.

Issue: [#898](https://github.com/trendmicro-frontend/tonic-ui/issues/898)


___

### **PR Type**
Documentation


___

### **Description**
- Added a new example file `text-as-li.js` to demonstrate the use of the `Text` component with `as="li"` and `display="list-item"` to show bullet points.
- Updated the `index.page.mdx` documentation to include a new FAQ section explaining how to display bullet points for list items using the `Text` component.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>text-as-li.js</strong><dd><code>Add example for `Text` component with `as="li"`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react-docs/pages/components/text/text-as-li.js

<li>Added a new example file demonstrating the use of the <code>Text</code> component <br>with <code>as="li"</code> and <code>display="list-item"</code>.<br> <li> Showcased how to make list items display bullet points.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/899/files#diff-14012cf1ffde7a329aae16caca8aeead9634135fc9125002f8cc4208b6830fde">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.page.mdx</strong><dd><code>Update Text component docs with FAQ and example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react-docs/pages/components/text/index.page.mdx

<li>Updated documentation to include a new section for commonly asked <br>questions.<br> <li> Added an explanation and example for showing bullet points when using <br><code>as="li"</code> with the <code>Text</code> component.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/899/files#diff-b82167987fb04f4cbf7d406a245464ccac0a05b53fa914d14be8009436f38e77">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

