### PR TITLE
fix(styled-system): specify unit for CSS custom property negation

### DIFF
--- a/.changeset/tonic-ui-907.md
+++ b/.changeset/tonic-ui-907.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/styled-system": patch
+---
+
+fix(styled-system): specify `0px` instead of `0` for CSS custom property negation in `calc()`

--- a/.changeset/tonic-ui-907.md
+++ b/.changeset/tonic-ui-907.md
@@ -2,4 +2,4 @@
 "@tonic-ui/styled-system": patch
 ---
 
-fix(styled-system): specify `0px` instead of `0` for CSS custom property negation in `calc()`
+fix(styled-system): specify unit for CSS custom property negation

--- a/packages/react/src/drawer/__tests__/__snapshots__/Drawer.test.js.snap
+++ b/packages/react/src/drawer/__tests__/__snapshots__/Drawer.test.js.snap
@@ -132,7 +132,7 @@ exports[`Drawer should render correctly 1`] = `
 
 .emotion-12:focus-visible {
   outline-color: var(--tonic-colors-blue-60);
-  outline-offset: calc(0 - var(--tonic-space-1h));
+  outline-offset: calc(0px - var(--tonic-space-1h));
   outline-style: solid;
   outline-width: var(--tonic-sizes-1h);
 }

--- a/packages/react/src/menu/__tests__/__snapshots__/Menu.test.js.snap
+++ b/packages/react/src/menu/__tests__/__snapshots__/Menu.test.js.snap
@@ -195,7 +195,7 @@ exports[`Menu should render correctly 1`] = `
 
 .emotion-16:focus-visible {
   outline-color: var(--tonic-colors-blue-60);
-  outline-offset: calc(0 - var(--tonic-space-1h));
+  outline-offset: calc(0px - var(--tonic-space-1h));
   outline-style: solid;
   outline-width: var(--tonic-sizes-1h);
 }

--- a/packages/react/src/modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/packages/react/src/modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -132,7 +132,7 @@ exports[`Modal should render correctly 1`] = `
 
 .emotion-12:focus-visible {
   outline-color: var(--tonic-colors-blue-60);
-  outline-offset: calc(0 - var(--tonic-space-1h));
+  outline-offset: calc(0px - var(--tonic-space-1h));
   outline-style: solid;
   outline-width: var(--tonic-sizes-1h);
 }

--- a/packages/react/src/tabs/__tests__/__snapshots__/Tabs.test.js.snap
+++ b/packages/react/src/tabs/__tests__/__snapshots__/Tabs.test.js.snap
@@ -53,7 +53,7 @@ exports[`Tabs should render correctly 1`] = `
 
 .emotion-4:focus-visible {
   outline-color: var(--tonic-colors-blue-60);
-  outline-offset: calc(0 - var(--tonic-space-1h));
+  outline-offset: calc(0px - var(--tonic-space-1h));
   outline-style: solid;
   outline-width: var(--tonic-sizes-1h);
   color: var(--tonic-colors-white-primary);
@@ -106,7 +106,7 @@ exports[`Tabs should render correctly 1`] = `
 
 .emotion-6:focus-visible {
   outline-color: var(--tonic-colors-blue-60);
-  outline-offset: calc(0 - var(--tonic-space-1h));
+  outline-offset: calc(0px - var(--tonic-space-1h));
   outline-style: solid;
   outline-width: var(--tonic-sizes-1h);
   color: var(--tonic-colors-white-primary);
@@ -160,7 +160,7 @@ exports[`Tabs should render correctly 1`] = `
 
 .emotion-8:focus-visible {
   outline-color: var(--tonic-colors-blue-60);
-  outline-offset: calc(0 - var(--tonic-space-1h));
+  outline-offset: calc(0px - var(--tonic-space-1h));
   outline-style: solid;
   outline-width: var(--tonic-sizes-1h);
   color: var(--tonic-colors-white-disabled);

--- a/packages/react/src/tree/__tests__/__snapshots__/Tree.test.js.snap
+++ b/packages/react/src/tree/__tests__/__snapshots__/Tree.test.js.snap
@@ -32,7 +32,7 @@ exports[`Tree should render correctly 1`] = `
 
 .emotion-4:focus-visible {
   outline-color: var(--tonic-colors-blue-60);
-  outline-offset: calc(0 - var(--tonic-space-1h));
+  outline-offset: calc(0px - var(--tonic-space-1h));
   outline-style: solid;
   outline-width: var(--tonic-sizes-1h);
 }

--- a/packages/styled-system/src/config/__tests__/margin.test.js
+++ b/packages/styled-system/src/config/__tests__/margin.test.js
@@ -132,10 +132,10 @@ test('returns negative theme values using CSS variables', () => {
   });
   expect(style).toEqual({
     margin: 'var(--tonic-space-0)',
-    marginLeft: 'calc(0 - var(--tonic-space-2))',
-    marginRight: 'calc(0 - var(--tonic-space-2))',
-    marginTop: 'calc(0 - var(--tonic-space-1))',
-    marginBottom: 'calc(0 - var(--tonic-space-1))',
+    marginLeft: 'calc(0px - var(--tonic-space-2))',
+    marginRight: 'calc(0px - var(--tonic-space-2))',
+    marginTop: 'calc(0px - var(--tonic-space-1))',
+    marginBottom: 'calc(0px - var(--tonic-space-1))',
   });
 });
 

--- a/packages/styled-system/src/config/__tests__/position.test.js
+++ b/packages/styled-system/src/config/__tests__/position.test.js
@@ -103,10 +103,10 @@ test('returns negative theme values using CSS variables', () => {
     left: -4,
   });
   expect(style).toEqual({
-    top: 'calc(0 - var(--tonic-space-1))',
-    right: 'calc(0 - var(--tonic-space-2))',
-    bottom: 'calc(0 - var(--tonic-space-3))',
-    left: 'calc(0 - var(--tonic-space-4))',
+    top: 'calc(0px - var(--tonic-space-1))',
+    right: 'calc(0px - var(--tonic-space-2))',
+    bottom: 'calc(0px - var(--tonic-space-3))',
+    left: 'calc(0px - var(--tonic-space-4))',
   });
 });
 

--- a/packages/styled-system/src/utils/transforms.js
+++ b/packages/styled-system/src/utils/transforms.js
@@ -17,7 +17,7 @@ const toNegativeValue = (scale, absoluteValue, options) => {
   // Handle CSS variables for negative values
   if (useCSSVariables && isSimpleCSSVariable(n)) {
     // https://stackoverflow.com/questions/49469344/using-negative-css-custom-properties
-    return `calc(0 - ${n})`;
+    return `calc(0px - ${n})`;
   }
 
   // Handle numeric value


### PR DESCRIPTION
#907: To correctly negate CSS custom properties, you need to specify a unit, or the calculation might not function as expected.

This approach does not work:
```
outline-offset: calc(0 - var(--tonic-space-1h));
```

This approach works:
```
outline-offset: calc(0px - var(--tonic-space-1h));
```

### **PR Type**
Bug fix, Tests


___

### **Description**
- Updated CSS custom property negation in `calc()` from `0` to `0px` in margin and position test files.
- Modified `toNegativeValue` function to use `0px` instead of `0` for CSS variable negation.
- Ensured consistency and correctness in handling negative theme values using CSS variables.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>margin.test.js</strong><dd><code>Fix CSS custom property negation in margin tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/styled-system/src/config/__tests__/margin.test.js

<li>Updated CSS custom property negation in <code>calc()</code> from <code>0</code> to <code>0px</code> for <br>margin properties.<br> <li> Ensured consistency in negative theme values using CSS variables.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/908/files#diff-f5fba974b124a20433fe10b850e50e32f8361666d86e1f39bbace33e1f73b6ac">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>position.test.js</strong><dd><code>Fix CSS custom property negation in position tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/styled-system/src/config/__tests__/position.test.js

<li>Updated CSS custom property negation in <code>calc()</code> from <code>0</code> to <code>0px</code> for <br>position properties.<br> <li> Ensured consistency in negative theme values using CSS variables.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/908/files#diff-e158b12cbdd85615393932a36d5fff0143253a5e5c8360e7ccbcd9bb0567fac7">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transforms.js</strong><dd><code>Fix CSS variable negation in `toNegativeValue` function</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/styled-system/src/utils/transforms.js

<li>Modified <code>toNegativeValue</code> function to use <code>0px</code> instead of <code>0</code> for CSS <br>variable negation in <code>calc()</code>.<br> <li> Improved handling of CSS variables for negative values.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/908/files#diff-70491b03a4f29b274eb5541c768ccec565ae1536742aec6e143587f089a77c0c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

