### PR TITLE
fix(react/OverflowTooltip): show the tooltip only when the string is truncated and the `disabled` prop is not true

### DIFF
--- a/.changeset/tonic-ui-912.md
+++ b/.changeset/tonic-ui-912.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": patch
+---
+
+fix(react/OverflowTooltip): show the tooltip only when the string is truncated and the `disabled` prop is not true

--- a/packages/react-docs/pages/components/overflow-tooltip/index.page.mdx
+++ b/packages/react-docs/pages/components/overflow-tooltip/index.page.mdx
@@ -68,7 +68,7 @@ To resolve this issue, set `PopperProps={{ usePortal: true }}`.
 | closeOnEsc | boolean | true | If `true`, close the tooltip when pressing the escape key. |
 | closeOnMouseDown | boolean | false | If `true`, close the tooltip while the mouse is down. |
 | defaultIsOpen | boolean | false | Whether the tooltip will be open by default. |
-| disabled | boolean | | If `true`, the tooltip will not display. |
+| disabled | boolean | false | If `true`, the tooltip will not display. |
 | enterDelay | number | 100 | The delay in milliseconds before the tooltip appears. |
 | followCursor | boolean | | If `true`, the tooltip will follow the cursor. |
 | isOpen | boolean | | If `true`, show the tooltip. |

--- a/packages/react/src/tooltip/OverflowTooltip.js
+++ b/packages/react/src/tooltip/OverflowTooltip.js
@@ -7,10 +7,10 @@ import Tooltip from './Tooltip';
 const OverflowTooltip = forwardRef((
   {
     children,
-    disabled,
-    nextToCursor = true,
-    offset = [8, 12],
-    placement = 'bottom-end',
+    disabled: disabledProp = false,
+    nextToCursor: nextToCursorProp = true,
+    offset: offsetProp = [8, 12],
+    placement: placementProp = 'bottom-end',
     ...rest
   },
   ref,
@@ -62,10 +62,11 @@ const OverflowTooltip = forwardRef((
   useEventListener(eventTargetFn, 'mouseleave', onMouseLeave);
 
   const tooltipProps = {
-    disabled: disabled || !isOverflow,
-    nextToCursor: isOverflow ? nextToCursor : undefined,
-    offset,
-    placement,
+    // The `disabled` prop is set to `true` if there is no overflow
+    disabled: isOverflow ? disabledProp : true,
+    nextToCursor: nextToCursorProp,
+    offset: offsetProp,
+    placement: placementProp,
   };
 
   return (

--- a/packages/react/src/tooltip/OverflowTooltip.js
+++ b/packages/react/src/tooltip/OverflowTooltip.js
@@ -7,6 +7,7 @@ import Tooltip from './Tooltip';
 const OverflowTooltip = forwardRef((
   {
     children,
+    disabled,
     nextToCursor = true,
     offset = [8, 12],
     placement = 'bottom-end',
@@ -61,7 +62,7 @@ const OverflowTooltip = forwardRef((
   useEventListener(eventTargetFn, 'mouseleave', onMouseLeave);
 
   const tooltipProps = {
-    disabled: !isOverflow,
+    disabled: disabled || !isOverflow,
     nextToCursor: isOverflow ? nextToCursor : undefined,
     offset,
     placement,


### PR DESCRIPTION
The tooltip should be shown only if the string is truncated when the disabled prop is false.

Issue: https://github.com/trendmicro-frontend/tonic-ui/issues/912