### PR TITLE
feat: introduce `DefaultPropsProvider` for setting default props in React components

### DIFF
--- a/.changeset/tonic-ui-73.md
+++ b/.changeset/tonic-ui-73.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": minor
+---
+
+feat: introduce `DefaultPropsProvider` for setting default props in React components

--- a/packages/react-docs/pages/_app.page.js
+++ b/packages/react-docs/pages/_app.page.js
@@ -32,8 +32,23 @@ const NONCE = ensureString(process.env.NONCE);
 // Algolia search client
 const searchClient = algoliasearch(process.env.ALGOLIA_APPLICATION_ID, process.env.ALGOLIA_SEARCH_API_KEY);
 
+theme.components = {
+  // Set default props for components here.
+  //
+  // Example:
+  // ```
+  // 'AccordionToggle': {
+  //   defaultProps: {
+  //     disabled: true,
+  //   },
+  // }
+  // ```
+};
+
 // Enable CSS variables replacement
 theme.config.useCSSVariables = true;
+
+
 
 const EmotionCacheProvider = ({
   children,

--- a/packages/react-docs/pages/_app.page.js
+++ b/packages/react-docs/pages/_app.page.js
@@ -11,6 +11,7 @@ import {
   useTheme,
 } from '@tonic-ui/react';
 import {
+  useConst,
   useMediaQuery,
   useToggle,
 } from '@tonic-ui/react-hooks';
@@ -48,8 +49,6 @@ theme.components = {
 // Enable CSS variables replacement
 theme.config.useCSSVariables = true;
 
-
-
 const EmotionCacheProvider = ({
   children,
   nonce,
@@ -67,6 +66,28 @@ const EmotionCacheProvider = ({
 };
 
 const App = (props) => {
+  const customTheme = useConst(() => {
+    return {
+      ...theme,
+      components: {
+        // Set default props for components here.
+        //
+        // Example:
+        // ```
+        // 'AccordionToggle': {
+        //   defaultProps: {
+        //     disabled: true,
+        //   },
+        // }
+        // ```
+      },
+      config: {
+        ...theme?.config,
+        // Enable CSS variables replacement
+        useCSSVariables: true,
+      },
+    };
+  });
   const [initialColorMode, setColorMode] = useState(null);
   const router = useRouter();
 
@@ -109,7 +130,7 @@ const App = (props) => {
           colorStyle={{
             defaultValue: defaultColorStyle,
           }}
-          theme={theme}
+          theme={customTheme}
           useCSSBaseline
         >
           <PortalManager>

--- a/packages/react-docs/pages/getting-started/icons/index.page.mdx
+++ b/packages/react-docs/pages/getting-started/icons/index.page.mdx
@@ -4,4 +4,4 @@
 
 * Explore a variety of pre-defined icons with [React Icons](../icons).
 * Discover how to create custom SVG icons using [SVGIcon](../icons/svg-icon).
-* Learn about migrating icon components when upgrading from v1 to v2 [here](../migration-guide/migrating-from-v1-to-v2#icons).
+* Learn about migrating icon components when upgrading from v1 to v2 [here](../migrations/migrating-from-v1-to-v2#icons).

--- a/packages/react/__tests__/index.test.js
+++ b/packages/react/__tests__/index.test.js
@@ -64,6 +64,10 @@ test('should match expected exports', () => {
     'Calendar',
     'DatePicker',
 
+    // default-props
+    'DefaultPropsProvider',
+    'useDefaultProps',
+
     // divider
     'Divider',
 

--- a/packages/react/__tests__/index.test.js
+++ b/packages/react/__tests__/index.test.js
@@ -64,10 +64,6 @@ test('should match expected exports', () => {
     'Calendar',
     'DatePicker',
 
-    // default-props
-    'DefaultPropsProvider',
-    'useDefaultProps',
-
     // divider
     'Divider',
 

--- a/packages/react/__tests__/use-default-props.test.js
+++ b/packages/react/__tests__/use-default-props.test.js
@@ -1,0 +1,75 @@
+const fs = require('node:fs');
+const { globSync } = require('glob');
+const parser = require('@babel/parser');
+const traverse = require('@babel/traverse').default;
+
+/**
+ * Example 1: with `forwardRef`
+ * ```js
+ * const Accordion = forwardRef((inProps, ref) => {
+ *   const {
+ *     children,
+ *     ...rest
+ *   } = useDefaultProps({ props: inProps, name: 'Accordion' });
+ * ``
+ *
+ * Example 2: without `forwardRef`
+ * ```
+ * const Portal = (inProps) => {
+ *   const {
+ *     appendToParentPortal = false,
+ *     children,
+ *     containerRef,
+ *   } = useDefaultProps({ props: inProps, name: 'Portal' });
+ * ```
+ */
+test('the `name` property in `useDefaultProps` should match the component name', () => {
+  const files = globSync([
+    'src/*/**/*.js',
+  ], {
+    'ignore': [
+      'src/*/**/__tests__/**/*.js',
+    ],
+  }).sort(); // Sort files alphabetically
+
+  for (const file of files) {
+    const code = fs.readFileSync(file, { encoding: 'utf-8' });
+    const ast = parser.parse(code, {
+      sourceType: 'module',
+      plugins: ['jsx'],
+    });
+
+    traverse(ast, {
+      VariableDeclarator(path) {
+        if (!path.node.init) {
+          return;
+        }
+
+        const isForwardRef = (path.node.init.callee && path.node.init.callee.name === 'forwardRef');
+        const isFunctionOrArrowFunctionExpression = (path.node.init.type === 'ArrowFunctionExpression' || path.node.init.type === 'FunctionExpression');
+
+        if (isForwardRef || isFunctionOrArrowFunctionExpression) {
+          const componentName = path.node.id.name;
+          path.traverse({
+            CallExpression(innerPath) {
+              if (innerPath.node.callee.name === 'useDefaultProps') {
+                const nameProperty = innerPath.node.arguments[0].properties.find(prop => prop.key.name === 'name');
+                const namePropertyValue = nameProperty?.value?.value;
+                if (!namePropertyValue) {
+                  console.error(`Error: No 'name' property found in 'useDefaultProps' in file "${file}"`);
+                  return;
+                }
+
+                try {
+                  expect(namePropertyValue).toEqual(componentName);
+                } catch (err) {
+                  throw new Error(`Mismatch in file "${file}": Expected component name '${componentName}' but found '${namePropertyValue}'`);
+                }
+              }
+            }
+          });
+        }
+      }
+    });
+  }
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,6 +62,7 @@
     "eslint-plugin-jsx-a11y": "latest",
     "eslint-plugin-react": "latest",
     "eslint-plugin-react-hooks": "latest",
+    "glob": "^11.0.0",
     "jest": "^29.0.0",
     "jest-axe": "^8.0.0",
     "jest-environment-jsdom": "^29.0.0",

--- a/packages/react/src/accordion/Accordion.js
+++ b/packages/react/src/accordion/Accordion.js
@@ -2,18 +2,17 @@ import { runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { AccordionContext } from './context';
 import { useAccordionStyle } from './styles';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const Accordion = forwardRef((
-  {
+const Accordion = forwardRef((inProps, ref) => {
+  const {
     children,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Accordion' });
   const context = getMemoizedState({
     // TODO
   });

--- a/packages/react/src/accordion/AccordionBody.js
+++ b/packages/react/src/accordion/AccordionBody.js
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import AccordionContent from './AccordionContent';
 import { useAccordionBodyStyle } from './styles';
 
-const AccordionBody = forwardRef((props, ref) => {
+const AccordionBody = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'AccordionBody' });
   const styleProps = useAccordionBodyStyle();
 
   return (

--- a/packages/react/src/accordion/AccordionContent.js
+++ b/packages/react/src/accordion/AccordionContent.js
@@ -1,17 +1,16 @@
 import { ariaAttr } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { Collapse } from '../transitions';
 import useAccordionItem from './useAccordionItem';
 
-const AccordionContent = forwardRef((
-  {
+const AccordionContent = forwardRef((inProps, ref) => {
+  const {
     TransitionComponent = Collapse,
     TransitionProps,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'AccordionContent' });
   const context = useAccordionItem(); // context might be an undefined value
 
   if (!context) {

--- a/packages/react/src/accordion/AccordionHeader.js
+++ b/packages/react/src/accordion/AccordionHeader.js
@@ -1,19 +1,18 @@
 import { ensureBoolean } from 'ensure-type';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import AccordionToggle from './AccordionToggle';
 import AccordionToggleIcon from './AccordionToggleIcon';
 import useAccordionItem from './useAccordionItem';
 import { useAccordionHeaderStyle } from './styles';
 
-const AccordionHeader = forwardRef((
-  {
+const AccordionHeader = forwardRef((inProps, ref) => {
+  const {
     children,
     disabled: disabledProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'AccordionHeader' });
   const context = useAccordionItem(); // context might be an undefined value
   const disabled = ensureBoolean(disabledProp ?? context?.disabled);
   const styleProps = useAccordionHeaderStyle();

--- a/packages/react/src/accordion/AccordionItem.js
+++ b/packages/react/src/accordion/AccordionItem.js
@@ -3,6 +3,7 @@ import { ensureFunction } from 'ensure-type';
 import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useState } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
 import { AccordionItemContext } from './context';
@@ -10,17 +11,15 @@ import useAccordion from './useAccordion';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const AccordionItem = forwardRef((
-  {
+const AccordionItem = forwardRef((inProps, ref) => {
+  const {
     children,
     disabled,
     isExpanded: isExpandedProp,
     defaultIsExpanded: defaultIsExpandedProp,
     onToggle: onToggleProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'AccordionItem' });
   const accordionContext = useAccordion();
   const defaultId = useAutoId();
   const accordionToggleId = `${config.name}:AccordionToggle-${defaultId}`;

--- a/packages/react/src/accordion/AccordionToggle.js
+++ b/packages/react/src/accordion/AccordionToggle.js
@@ -2,18 +2,17 @@ import { ariaAttr, callEventHandlers } from '@tonic-ui/utils';
 import { ensureBoolean } from 'ensure-type';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
+import { useDefaultProps } from '../default-props';
 import useAccordionItem from './useAccordionItem';
 import { useAccordionToggleStyle } from './styles';
 
-const AccordionToggle = forwardRef((
-  {
+const AccordionToggle = forwardRef((inProps, ref) => {
+  const {
     children,
     disabled: disabledProp,
     onClick: onClickProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'AccordionToggle' });
   const context = useAccordionItem(); // context might be an undefined value
   const disabled = ensureBoolean(disabledProp ?? context?.disabled);
   const styleProps = useAccordionToggleStyle();

--- a/packages/react/src/accordion/AccordionToggleIcon.js
+++ b/packages/react/src/accordion/AccordionToggleIcon.js
@@ -5,6 +5,7 @@ import { ensureBoolean } from 'ensure-type';
 import React, { forwardRef, useEffect, useRef } from 'react';
 import { Transition } from 'react-transition-group';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useAccordionToggleIconStyle,
 } from './styles';
@@ -39,8 +40,8 @@ const defaultTimeout = {
   exit: Math.floor(133 * 0.7),
 };
 
-const AccordionToggleIcon = forwardRef((
-  {
+const AccordionToggleIcon = forwardRef((inProps, ref) => {
+  const {
     appear = false, // do not perform the enter transition when it first mounts
     children,
     disabled: disabledProp,
@@ -48,9 +49,7 @@ const AccordionToggleIcon = forwardRef((
     style,
     timeout = defaultTimeout,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'AccordionToggleIcon' });
   const context = useAccordionItem(); // context might be an undefined value
   const toggleIconStyleProps = useAccordionToggleIconStyle();
   const nodeRef = useRef(null);

--- a/packages/react/src/alert/Alert.js
+++ b/packages/react/src/alert/Alert.js
@@ -2,6 +2,7 @@ import { runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import AlertCloseButton from './AlertCloseButton';
 import AlertIcon from './AlertIcon';
 import AlertMessage from './AlertMessage';
@@ -16,8 +17,8 @@ import {
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const Alert = forwardRef((
-  {
+const Alert = forwardRef((inProps, ref) => {
+  const {
     isClosable = false,
     onClose,
     severity = defaultSeverity,
@@ -25,9 +26,7 @@ const Alert = forwardRef((
     icon,
     children,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Alert' });
   const context = getMemoizedState({
     icon,
     isClosable,

--- a/packages/react/src/alert/AlertCloseButton.js
+++ b/packages/react/src/alert/AlertCloseButton.js
@@ -2,19 +2,18 @@ import { CloseSIcon } from '@tonic-ui/react-icons';
 import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
+import { useDefaultProps } from '../default-props';
 import {
   useAlertCloseButtonStyle,
 } from './styles';
 import useAlert from './useAlert';
 
-const AlertCloseButton = forwardRef((
-  {
+const AlertCloseButton = forwardRef((inProps, ref) => {
+  const {
     children,
     onClick: onClickProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'AlertCloseButton' });
   const alertContext = useAlert(); // context might be an undefined value
   const {
     // The `isClosable` prop determines whether the close button should be displayed and allows for control over its positioning

--- a/packages/react/src/alert/AlertIcon.js
+++ b/packages/react/src/alert/AlertIcon.js
@@ -6,13 +6,15 @@ import {
 } from '@tonic-ui/react-icons';
 import React, { forwardRef, useMemo } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { Icon } from '../icon';
 import {
   useAlertIconStyle,
 } from './styles';
 import useAlert from './useAlert';
 
-const AlertIcon = forwardRef((props, ref) => {
+const AlertIcon = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'AlertIcon' });
   const alertContext = useAlert(); // context might be an undefined value
   const {
     icon: iconProp,

--- a/packages/react/src/alert/AlertMessage.js
+++ b/packages/react/src/alert/AlertMessage.js
@@ -1,11 +1,13 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useAlertMessageStyle,
 } from './styles';
 import useAlert from './useAlert';
 
-const AlertMessage = forwardRef((props, ref) => {
+const AlertMessage = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'AlertMessage' });
   const alertContext = useAlert(); // context might be an undefined value
   const {
     isClosable,

--- a/packages/react/src/badge/Badge.js
+++ b/packages/react/src/badge/Badge.js
@@ -1,22 +1,21 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useBadgeStyle,
   useBadgeContentStyle,
   useBadgeContentPlacementStyle,
 } from './styles';
 
-const Badge = forwardRef((
-  {
+const Badge = forwardRef((inProps, ref) => {
+  const {
     badgeContent: badgeContentProp,
     children,
     isInvisible: isInvisibleProp,
     placement = 'top-right', // One of: 'top-left', 'top-right', 'bottom-left', 'bottom-right'
     variant = 'solid',
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Badge' });
   const badgeContent = (variant === 'dot') ? null : badgeContentProp;
   const isInvisible = isInvisibleProp ?? (() => {
     if ((badgeContent === null || badgeContent === undefined) && (variant !== 'dot')) {

--- a/packages/react/src/button/Button.js
+++ b/packages/react/src/button/Button.js
@@ -1,5 +1,6 @@
 import { ariaAttr, dataAttr } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import ButtonBase from './ButtonBase';
 import { useButtonStyle } from './styles';
 import useButtonGroup from './useButtonGroup';
@@ -8,17 +9,18 @@ const defaultSize = 'md';
 const defaultVariant = 'default';
 const defaultOrientation = 'horizontal';
 
-const Button = forwardRef((
-  {
+const Button = forwardRef((inProps, ref) => {
+  const {
     disabled,
     selected,
-    size,
-    variant,
+    size: sizeProp,
+    variant: variantProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Button' });
+
   let orientation; // orientation for ButtonGroup
+  let size = sizeProp;
+  let variant = variantProp;
 
   const buttonGroupContext = useButtonGroup();
   if (buttonGroupContext) {
@@ -30,7 +32,7 @@ const Button = forwardRef((
     // Use fallback values if values are null or undefined
     size = (size ?? buttonGroupSize) ?? defaultSize;
     variant = (variant ?? buttonGroupVariant) ?? defaultVariant;
-    orientation = (orientation ?? buttonGroupOrientation) ?? defaultOrientation;
+    orientation = buttonGroupOrientation ?? defaultOrientation;
   } else {
     // Use the default value if the value is null or undefined
     size = size ?? defaultSize;

--- a/packages/react/src/button/ButtonBase.js
+++ b/packages/react/src/button/ButtonBase.js
@@ -1,19 +1,18 @@
 import { ariaAttr } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useButtonBaseStyle } from './styles';
 
 /**
  * `ButtonBase` does not have appearance settings including default color, padding, outline, and border
  */
-const ButtonBase = forwardRef((
-  {
+const ButtonBase = forwardRef((inProps, ref) => {
+  const {
     children,
     disabled,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'ButtonBase' });
   const styleProps = useButtonBaseStyle({ disabled });
 
   return (

--- a/packages/react/src/button/ButtonGroup.js
+++ b/packages/react/src/button/ButtonGroup.js
@@ -2,6 +2,7 @@ import { runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { ButtonGroupContext } from './context';
 import { useButtonGroupStyle } from './styles';
 
@@ -11,16 +12,14 @@ const defaultOrientation = 'horizontal';
 const defaultSize = 'md';
 const defaultVariant = 'default';
 
-const ButtonGroup = forwardRef((
-  {
+const ButtonGroup = forwardRef((inProps, ref) => {
+  const {
     children,
     orientation = defaultOrientation,
     size = defaultSize,
     variant = defaultVariant,
     ...rest
-  },
-  ref
-) => {
+  } = useDefaultProps({ props: inProps, name: 'ButtonGroup' });
   const styleProps = useButtonGroupStyle({ orientation });
   const context = getMemoizedState({ orientation, size, variant });
 

--- a/packages/react/src/button/ButtonLink.js
+++ b/packages/react/src/button/ButtonLink.js
@@ -1,7 +1,10 @@
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import Button from './Button';
 
-const ButtonLink = forwardRef((props, ref) => {
+const ButtonLink = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'ButtonLink' });
+
   return (
     <Button
       as="a"

--- a/packages/react/src/checkbox/Checkbox.js
+++ b/packages/react/src/checkbox/Checkbox.js
@@ -3,37 +3,43 @@ import { callAll, dataAttr, isNullish } from '@tonic-ui/utils';
 import { ensureArray } from 'ensure-type';
 import React, { forwardRef, useRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { VisuallyHidden } from '../visually-hidden';
 import CheckboxControlBox from './CheckboxControlBox';
 import { defaultSize, defaultVariantColor } from './constants';
 import useCheckboxGroup from './useCheckboxGroup';
 import { useCheckboxStyle } from './styles';
 
-const Checkbox = forwardRef((
-  {
-    checked,
+const Checkbox = forwardRef((inProps, ref) => {
+  const {
+    checked: checkedProp,
     children,
     defaultChecked,
-    disabled,
+    disabled: disabledProp,
     id,
     indeterminate,
     inputProps,
     inputRef: inputRefProp,
-    name,
+    name: nameProp,
     onBlur,
-    onChange,
+    onChange: onChangeProp,
     onClick,
     onFocus,
-    size,
+    size: sizeProp,
     value,
-    variantColor,
+    variantColor: variantColorProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Checkbox' });
+
+  let checked = checkedProp;
+  let disabled = disabledProp;
+  let name = nameProp;
+  let onChange = onChangeProp;
+  let size = sizeProp;
+  let variantColor = variantColorProp;
+
   const inputRef = useRef();
   const combinedInputRef = useMergeRefs(inputRefProp, inputRef);
-  const styleProps = useCheckboxStyle({ disabled });
   const checkboxGroupContext = useCheckboxGroup();
 
   if (checkboxGroupContext) {
@@ -62,6 +68,7 @@ const Checkbox = forwardRef((
     size = size ?? defaultSize;
     variantColor = variantColor ?? defaultVariantColor;
   }
+  const styleProps = useCheckboxStyle({ disabled });
 
   return (
     <Box

--- a/packages/react/src/checkbox/Checkbox.js
+++ b/packages/react/src/checkbox/Checkbox.js
@@ -68,6 +68,7 @@ const Checkbox = forwardRef((inProps, ref) => {
     size = size ?? defaultSize;
     variantColor = variantColor ?? defaultVariantColor;
   }
+
   const styleProps = useCheckboxStyle({ disabled });
 
   return (

--- a/packages/react/src/checkbox/CheckboxControlBox.js
+++ b/packages/react/src/checkbox/CheckboxControlBox.js
@@ -11,16 +11,14 @@ import {
   useCheckboxControlBoxStyle,
 } from './styles';
 
-const CheckboxControlBox = forwardRef((
-  {
+const CheckboxControlBox = forwardRef((inProps, ref) => {
+  const {
     indeterminate,
     size = defaultSize,
     variantColor = defaultVariantColor,
     sx: sxProp,
     ...rest
-  },
-  ref,
-) => {
+  } = inProps;
   const { sizes } = useTheme();
   const [colorMode] = useColorMode();
   const iconSize = {

--- a/packages/react/src/checkbox/CheckboxGroup.js
+++ b/packages/react/src/checkbox/CheckboxGroup.js
@@ -2,24 +2,26 @@ import { runIfFn } from '@tonic-ui/utils';
 import { ensureArray } from 'ensure-type';
 import memoize from 'micro-memoize';
 import React, { useEffect, useState } from 'react';
+import { useDefaultProps } from '../default-props';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
 import { CheckboxGroupContext } from './context';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const CheckboxGroup = ({
-  children,
-  defaultValue,
-  disabled,
-  name,
-  size,
-  value: valueProp,
-  variantColor,
-  onChange,
-}) => {
+const CheckboxGroup = (inProps) => {
+  const {
+    children,
+    defaultValue,
+    disabled,
+    name: nameProp,
+    size,
+    value: valueProp,
+    variantColor,
+    onChange,
+  } = useDefaultProps({ props: inProps, name: 'CheckboxGroup' });
   const defaultId = useAutoId();
-  name = name ?? `${config.name}:CheckboxGroup-${defaultId}`;
+  const name = nameProp ?? `${config.name}:CheckboxGroup-${defaultId}`;
 
   const [state, setState] = useState({
     value: ensureArray(valueProp ?? defaultValue),

--- a/packages/react/src/code/Code.js
+++ b/packages/react/src/code/Code.js
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useCodeStyle } from './styles';
 
-const Code = forwardRef((props, ref) => {
+const Code = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'Code' });
   const styleProps = useCodeStyle();
 
   return (

--- a/packages/react/src/color-mode/ColorModeProvider.js
+++ b/packages/react/src/color-mode/ColorModeProvider.js
@@ -1,6 +1,7 @@
 import { canUseDOM, noop } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { useCallback, useEffect, useReducer } from 'react';
+import { useDefaultProps } from '../default-props';
 import { ColorModeContext } from './context';
 import { getColorScheme, colorSchemeQuery } from './utils';
 
@@ -18,13 +19,14 @@ const colorModeReducer = (state, nextValue) => {
   return ensureColorMode(nextValue);
 };
 
-const ColorModeProvider = ({
-  children,
-  defaultValue: defaultValueProp,
-  value: valueProp,
-  onChange: onChangeProp,
-  useSystemColorMode,
-}) => {
+const ColorModeProvider = (inProps) => {
+  const {
+    children,
+    defaultValue: defaultValueProp,
+    value: valueProp,
+    onChange: onChangeProp,
+    useSystemColorMode,
+  } = useDefaultProps({ props: inProps, name: 'ColorModeProvider' });
   const defaultColorMode = (defaultValueProp === 'dark') ? 'dark' : 'light';
   const [colorMode, setColorMode] = useReducer(colorModeReducer, ensureColorMode(valueProp ?? defaultColorMode));
 

--- a/packages/react/src/color-mode/DarkMode.js
+++ b/packages/react/src/color-mode/DarkMode.js
@@ -1,16 +1,21 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import ColorModeProvider from './ColorModeProvider';
 
-const DarkMode = forwardRef((props, ref) => (
-  <ColorModeProvider value="dark">
-    <Box
-      ref={ref}
-      colorScheme="dark"
-      {...props}
-    />
-  </ColorModeProvider>
-));
+const DarkMode = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'DarkMode' });
+
+  return (
+    <ColorModeProvider value="dark">
+      <Box
+        ref={ref}
+        colorScheme="dark"
+        {...props}
+      />
+    </ColorModeProvider>
+  );
+});
 
 DarkMode.displayName = 'DarkMode';
 

--- a/packages/react/src/color-mode/InvertedMode.js
+++ b/packages/react/src/color-mode/InvertedMode.js
@@ -1,9 +1,11 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import ColorModeProvider from './ColorModeProvider';
 import useColorMode from './useColorMode';
 
-const InvertedMode = forwardRef((props, ref) => {
+const InvertedMode = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'InvertedMode' });
   const [colorMode] = useColorMode();
   const invertedColorMode = colorMode === 'light' ? 'dark' : 'light';
 

--- a/packages/react/src/color-mode/LightMode.js
+++ b/packages/react/src/color-mode/LightMode.js
@@ -1,16 +1,21 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import ColorModeProvider from './ColorModeProvider';
 
-const LightMode = forwardRef((props, ref) => (
-  <ColorModeProvider value="light">
-    <Box
-      ref={ref}
-      colorScheme="light"
-      {...props}
-    />
-  </ColorModeProvider>
-));
+const LightMode = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'LightMode' });
+
+  return (
+    <ColorModeProvider value="light">
+      <Box
+        ref={ref}
+        colorScheme="light"
+        {...props}
+      />
+    </ColorModeProvider>
+  );
+});
 
 LightMode.displayName = 'LightMode';
 

--- a/packages/react/src/color-style/ColorStyleProvider.js
+++ b/packages/react/src/color-style/ColorStyleProvider.js
@@ -1,6 +1,7 @@
 import { ensurePlainObject } from 'ensure-type';
 import memoize from 'micro-memoize';
 import React, { useCallback, useEffect, useState } from 'react';
+import { useDefaultProps } from '../default-props';
 import defaultColorStyle from './color-style';
 import { ColorStyleContext } from './context';
 
@@ -10,12 +11,13 @@ const ensureColorStyle = (colorStyle) => {
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const ColorStyleProvider = ({
-  children,
-  defaultValue: defaultValueProp,
-  value: valueProp,
-  onChange: onChangeProp,
-}) => {
+const ColorStyleProvider = (inProps) => {
+  const {
+    children,
+    defaultValue: defaultValueProp,
+    value: valueProp,
+    onChange: onChangeProp,
+  } = useDefaultProps({ props: inProps, name: 'ColorStyleProvider' });
   const [colorStyle, setColorStyle] = useState(ensureColorStyle(valueProp ?? (defaultValueProp ?? defaultColorStyle)));
 
   useEffect(() => {

--- a/packages/react/src/date-pickers/Calendar/Calendar.js
+++ b/packages/react/src/date-pickers/Calendar/Calendar.js
@@ -19,6 +19,7 @@ import subMonths from 'date-fns/subMonths';
 import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../../box';
+import { useDefaultProps } from '../../default-props';
 import { validateDate } from '../validation';
 import { CalendarProvider } from './context';
 import MonthDate from './MonthDate';
@@ -45,9 +46,9 @@ const mapValueToEndOfDay = (value) => {
   return (isDate(date) && isValid(date)) ? endOfDay(date) : null;
 };
 
-const Calendar = forwardRef((
-  {
-    children, // not used
+const Calendar = forwardRef((inProps, ref) => {
+  const {
+    children, // eslint-disable-line no-unused-vars
     date: dateProp,
     defaultDate: defaultDateProp,
     firstDayOfWeek = 0, // 0 = Sunday, 1 = Monday, ...
@@ -58,9 +59,7 @@ const Calendar = forwardRef((
     onError: onErrorProp,
     shouldDisableDate,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Calendar' });
   const initialDate = useConst(() => {
     const value = dateProp ?? defaultDateProp;
     return mapValueToDate(value);

--- a/packages/react/src/date-pickers/DatePicker/DatePicker.js
+++ b/packages/react/src/date-pickers/DatePicker/DatePicker.js
@@ -9,6 +9,7 @@ import startOfDay from 'date-fns/startOfDay';
 import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../../box';
+import { useDefaultProps } from '../../default-props';
 import config from '../../shared/config';
 import useAutoId from '../../utils/useAutoId';
 import Calendar from '../Calendar';
@@ -61,9 +62,9 @@ const mapValueToEndOfDay = (value) => {
   return (isDate(date) && isValid(date)) ? endOfDay(date) : null;
 };
 
-const DatePicker = forwardRef((
-  {
-    children, // not used
+const DatePicker = forwardRef((inProps, ref) => {
+  const {
+    children, // eslint-disable-line no-unused-vars
     closeOnSelect = false, // Note: The default value will be changed to true in the next major release
     defaultValue: defaultValueProp,
     firstDayOfWeek,
@@ -79,9 +80,7 @@ const DatePicker = forwardRef((
     shouldDisableDate,
     value: valueProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'DatePicker' });
   const datePickerContentRef = useRef(null);
   const datePickerToggleRef = useRef(null);
   const initialValue = useConst(() => {

--- a/packages/react/src/default-props/DefaultPropsProvider.js
+++ b/packages/react/src/default-props/DefaultPropsProvider.js
@@ -1,0 +1,14 @@
+import { DefaultPropsContext } from './context';
+
+const DefaultPropsProvider = ({
+  value,
+  children,
+}) => {
+  return (
+    <DefaultPropsContext.Provider value={value}>
+      {children}
+    </DefaultPropsContext.Provider>
+  );
+};
+
+export default DefaultPropsProvider;

--- a/packages/react/src/default-props/DefaultPropsProvider.js
+++ b/packages/react/src/default-props/DefaultPropsProvider.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { DefaultPropsContext } from './context';
 
 const DefaultPropsProvider = ({

--- a/packages/react/src/default-props/__tests__/resolveProps.test.js
+++ b/packages/react/src/default-props/__tests__/resolveProps.test.js
@@ -1,0 +1,105 @@
+import resolveProps from '../resolveProps';
+
+describe('resolveProps', () => {
+  it('use default props if no props', () => {
+    expect(resolveProps({ foo: 'foo' }, {})).toEqual({
+      foo: 'foo',
+    });
+  });
+
+  it('use props if defined', () => {
+    expect(resolveProps({ foo: 'foo' }, { foo: 'bar' })).toEqual({
+      foo: 'bar',
+    });
+  });
+
+  it('merge extra props', () => {
+    expect(resolveProps({ foo: 'foo' }, { foo: 'bar', bar: 'bar' })).toEqual({
+      foo: 'bar',
+      bar: 'bar',
+    });
+  });
+
+  it('use default props if prop value is undefined', () => {
+    expect(resolveProps({ foo: 'foo' }, { foo: undefined })).toEqual({
+      foo: 'foo',
+    });
+  });
+
+  it('use props if default value is undefined', () => {
+    expect(resolveProps({ foo: undefined }, { foo: 'bar' })).toEqual({
+      foo: 'bar',
+    });
+  });
+
+  it('null is a considered a valid value', () => {
+    expect(resolveProps({ foo: 'foo' }, { foo: null })).toEqual({
+      foo: null,
+    });
+  });
+
+  it('"" is a considered a valid value', () => {
+    expect(resolveProps({ foo: 'foo' }, { foo: '' })).toEqual({
+      foo: '',
+    });
+  });
+
+  it('merge `slots` and `slotProps` props', () => {
+    expect(
+      resolveProps(
+        {
+          slots: {
+            input: 'input',
+          },
+          slotProps: {
+            input: {
+              className: 'input',
+            },
+          },
+        },
+        {
+          slots: {
+            root: 'root',
+          },
+          slotProps: {
+            root: {
+              className: 'root',
+            },
+            input: {
+              style: {
+                color: 'red',
+              },
+            },
+          },
+        },
+      ),
+    ).toEqual({
+      slots: {
+        root: 'root',
+        input: 'input',
+      },
+      slotProps: {
+        root: {
+          className: 'root',
+        },
+        input: {
+          className: 'input',
+          style: {
+            color: 'red',
+          },
+        },
+      },
+    });
+  });
+
+  it('should not merge props that are not intended', () => {
+    expect(
+      resolveProps(
+        { notTheSlotProps: { style: { color: 'red' } } },
+        { notTheSlotProps: { className: 'input' } },
+      ),
+    ).toEqual({
+      notTheSlotProps: { className: 'input' },
+    });
+  });
+});

--- a/packages/react/src/default-props/__tests__/resolveProps.test.js
+++ b/packages/react/src/default-props/__tests__/resolveProps.test.js
@@ -2,78 +2,93 @@ import resolveProps from '../resolveProps';
 
 describe('resolveProps', () => {
   it('use default props if no props', () => {
-    expect(resolveProps({ foo: 'foo' }, {})).toEqual({
+    const defaultProps = { foo: 'foo' };
+    const props = {};
+    expect(resolveProps(defaultProps, props)).toEqual({
       foo: 'foo',
     });
   });
 
   it('use props if defined', () => {
-    expect(resolveProps({ foo: 'foo' }, { foo: 'bar' })).toEqual({
+    const defaultProps = { foo: 'foo' };
+    const props = { foo: 'bar' };
+    expect(resolveProps(defaultProps, props)).toEqual({
       foo: 'bar',
     });
   });
 
   it('merge extra props', () => {
-    expect(resolveProps({ foo: 'foo' }, { foo: 'bar', bar: 'bar' })).toEqual({
+    const defaultProps = { foo: 'foo' };
+    const props = { foo: 'bar', bar: 'bar' };
+    expect(resolveProps(defaultProps, props)).toEqual({
       foo: 'bar',
       bar: 'bar',
     });
   });
 
   it('use default props if prop value is undefined', () => {
-    expect(resolveProps({ foo: 'foo' }, { foo: undefined })).toEqual({
+    const defaultProps = { foo: 'foo' };
+    const props = { foo: undefined };
+    expect(resolveProps(defaultProps, props)).toEqual({
       foo: 'foo',
     });
   });
 
   it('use props if default value is undefined', () => {
-    expect(resolveProps({ foo: undefined }, { foo: 'bar' })).toEqual({
+    const defaultProps = { foo: undefined };
+    const props = { foo: 'bar' };
+    expect(resolveProps(defaultProps, props)).toEqual({
       foo: 'bar',
     });
   });
 
   it('null is a considered a valid value', () => {
-    expect(resolveProps({ foo: 'foo' }, { foo: null })).toEqual({
+    const defaultProps = { foo: 'foo' };
+    const props = { foo: null };
+    expect(resolveProps(defaultProps, props)).toEqual({
       foo: null,
     });
   });
 
   it('"" is a considered a valid value', () => {
-    expect(resolveProps({ foo: 'foo' }, { foo: '' })).toEqual({
+    const defaultProps = { foo: 'foo' };
+    const props = { foo: '' };
+    expect(resolveProps(defaultProps, props)).toEqual({
       foo: '',
     });
   });
 
   it('merge `slots` and `slotProps` props', () => {
-    expect(
-      resolveProps(
-        {
-          slots: {
-            input: 'input',
-          },
-          slotProps: {
-            input: {
-              className: 'input',
-            },
-          },
-        },
-        {
-          slots: {
-            root: 'root',
-          },
-          slotProps: {
-            root: {
-              className: 'root',
-            },
-            input: {
-              style: {
-                color: 'red',
-              },
-            },
+    const defaultProps = {
+      slots: {
+        input: 'input',
+      },
+      slotProps: {
+        input: {
+          className: 'input',
+          style: {
+            fontSize: 'sm',
           },
         },
-      ),
-    ).toEqual({
+      },
+    };
+    const props = {
+      slots: {
+        root: 'root',
+      },
+      slotProps: {
+        root: {
+          className: 'root',
+        },
+        input: {
+          style: {
+            color: 'red',
+          },
+        },
+      },
+    };
+
+    expect(resolveProps(defaultProps, props)).toEqual({
       slots: {
         root: 'root',
         input: 'input',

--- a/packages/react/src/default-props/context.js
+++ b/packages/react/src/default-props/context.js
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+const DefaultPropsContext = createContext();
+
+export {
+  DefaultPropsContext,
+};

--- a/packages/react/src/default-props/context.js
+++ b/packages/react/src/default-props/context.js
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
-const DefaultPropsContext = createContext();
+const DefaultPropsContext = createContext({});
 
 export {
   DefaultPropsContext,

--- a/packages/react/src/default-props/index.js
+++ b/packages/react/src/default-props/index.js
@@ -1,0 +1,7 @@
+import DefaultPropsProvider from './DefaultPropsProvider';
+import useDefaultProps from './useDefaultProps';
+
+export {
+  DefaultPropsProvider,
+  useDefaultProps,
+};

--- a/packages/react/src/default-props/resolveProps.js
+++ b/packages/react/src/default-props/resolveProps.js
@@ -1,0 +1,48 @@
+/**
+ * Add keys, values of `defaultProps` that does not exist in `props`
+ * @param defaultProps
+ * @param props
+ * @returns resolved props
+ */
+const resolveProps = (defaultProps, props) => {
+  const output = { ...props };
+
+  for (const key in defaultProps) {
+    if (!Object.prototype.hasOwnProperty.call(defaultProps, key)) {
+      continue;
+    }
+
+    const propName = key;
+
+    if (propName === 'slots') {
+      output[propName] = {
+        ...(defaultProps[propName] || {}),
+        ...(output[propName] || {}),
+      };
+    } else if (propName === 'slotProps') {
+      const defaultSlotProps = defaultProps[propName];
+      const slotProps = props[propName];
+
+      if (!slotProps) {
+        output[propName] = defaultSlotProps || {};
+      } else if (!defaultSlotProps) {
+        output[propName] = slotProps;
+      } else {
+        output[propName] = { ...slotProps };
+
+        for (const slotKey in defaultSlotProps) {
+          if (Object.prototype.hasOwnProperty.call(defaultSlotProps, slotKey)) {
+            const slotPropName = slotKey;
+            output[propName][slotPropName] = resolveProps(defaultSlotProps[slotPropName], slotProps[slotPropName]);
+          }
+        }
+      }
+    } else if (output[propName] === undefined) {
+      output[propName] = defaultProps[propName];
+    }
+  }
+
+  return output;
+};
+
+export default resolveProps;

--- a/packages/react/src/default-props/resolveProps.js
+++ b/packages/react/src/default-props/resolveProps.js
@@ -7,20 +7,14 @@
 const resolveProps = (defaultProps, props) => {
   const output = { ...props };
 
-  for (const key in defaultProps) {
-    if (!Object.prototype.hasOwnProperty.call(defaultProps, key)) {
-      continue;
-    }
-
-    const propName = key;
-
+  for (const [propName, defaultValue] of Object.entries(defaultProps)) {
     if (propName === 'slots') {
       output[propName] = {
-        ...(defaultProps[propName] || {}),
+        ...(defaultValue || {}),
         ...(output[propName] || {}),
       };
     } else if (propName === 'slotProps') {
-      const defaultSlotProps = defaultProps[propName];
+      const defaultSlotProps = defaultValue;
       const slotProps = props[propName];
 
       if (!slotProps) {
@@ -38,7 +32,7 @@ const resolveProps = (defaultProps, props) => {
         }
       }
     } else if (output[propName] === undefined) {
-      output[propName] = defaultProps[propName];
+      output[propName] = defaultValue;
     }
   }
 

--- a/packages/react/src/default-props/useDefaultProps.js
+++ b/packages/react/src/default-props/useDefaultProps.js
@@ -26,6 +26,9 @@ const useDefaultProps = ({ props, name }) => {
     throw new Error('The `useContext` hook is not available with your React version.');
   }
 
+  if (!name || typeof name !== 'string') {
+    throw new Error('Invalid or missing component name provided to `useDefaultProps`');
+  }
   const context = useContext(DefaultPropsContext);
   if (!context) {
     return props;

--- a/packages/react/src/default-props/useDefaultProps.js
+++ b/packages/react/src/default-props/useDefaultProps.js
@@ -1,0 +1,41 @@
+import { useContext } from 'react';
+import { DefaultPropsContext } from './context';
+import resolveProps from './resolveProps';
+
+const getThemeProps = ({ props, name, theme }) => {
+  const config = theme?.components?.[name];
+
+  if (config === undefined) {
+    return props;
+  }
+
+  if (config?.defaultProps) {
+    return resolveProps(config.defaultProps, props);
+  }
+
+  if (!(config?.styleOverrides) && !(config?.variants)) {
+    // no property 'defaultProps'
+    return resolveProps(config, props);
+  }
+
+  return props;
+};
+
+const useDefaultProps = ({ props, name }) => {
+  if (!useContext) {
+    throw new Error('The `useContext` hook is not available with your React version.');
+  }
+
+  const context = useContext(DefaultPropsContext);
+  if (!context) {
+    return props;
+  }
+
+  const theme = {
+    components: context,
+  };
+
+  return getThemeProps({ props, name, theme });
+};
+
+export default useDefaultProps;

--- a/packages/react/src/divider/Divider.js
+++ b/packages/react/src/divider/Divider.js
@@ -1,12 +1,14 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useDividerStyle } from './styles';
 
-const Divider = forwardRef(({
-  orientation = 'horizontal',
-  variant = 'solid',
-  ...rest
-}, ref) => {
+const Divider = forwardRef((inProps, ref) => {
+  const {
+    orientation = 'horizontal',
+    variant = 'solid',
+    ...rest
+  } = useDefaultProps({ props: inProps, name: 'Divider' });
   const styleProps = useDividerStyle({ orientation, variant });
 
   return (

--- a/packages/react/src/drawer/Drawer.js
+++ b/packages/react/src/drawer/Drawer.js
@@ -2,6 +2,7 @@ import { getAllFocusable, runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import FocusLock from 'react-focus-lock/dist/cjs';
+import { useDefaultProps } from '../default-props';
 import { Portal } from '../portal';
 import { AnimatePresence } from '../utils/animate-presence';
 import DrawerContainer from './DrawerContainer';
@@ -12,8 +13,8 @@ const getMemoizedState = memoize(state => ({ ...state }));
 const defaultPlacement = 'right';
 const defaultSize = 'auto';
 
-const Drawer = forwardRef((
-  {
+const Drawer = forwardRef((inProps, ref) => {
+  const {
     autoFocus = false,
     backdrop = false,
     children,
@@ -30,9 +31,7 @@ const Drawer = forwardRef((
     returnFocusOnClose = true,
     size = defaultSize,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Drawer' });
   const [isMounted, setIsMounted] = useState(isOpen);
   const containerRef = useRef();
   const contentRef = useRef(null);

--- a/packages/react/src/drawer/DrawerBody.js
+++ b/packages/react/src/drawer/DrawerBody.js
@@ -1,11 +1,13 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useDrawerBodyStyle,
 } from './styles';
 import useDrawer from './useDrawer';
 
-const DrawerBody = forwardRef((props, ref) => {
+const DrawerBody = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'DrawerBody' });
   const drawerContext = useDrawer(); // context might be an undefined value
   const {
     scrollBehavior, // internal use only

--- a/packages/react/src/drawer/DrawerCloseButton.js
+++ b/packages/react/src/drawer/DrawerCloseButton.js
@@ -2,19 +2,18 @@ import { CloseIcon } from '@tonic-ui/react-icons';
 import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
+import { useDefaultProps } from '../default-props';
 import {
   useDrawerCloseButtonStyle,
 } from './styles';
 import useDrawer from './useDrawer';
 
-const DrawerCloseButton = forwardRef((
-  {
+const DrawerCloseButton = forwardRef((inProps, ref) => {
+  const {
     children,
     onClick: onClickProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'DrawerCloseButton' });
   const drawerContext = useDrawer(); // context might be an undefined value
   const {
     onClose,

--- a/packages/react/src/drawer/DrawerContainer.js
+++ b/packages/react/src/drawer/DrawerContainer.js
@@ -1,12 +1,14 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useDrawerContainerStyle,
 } from './styles';
 import useDrawer from './useDrawer';
 
-const DrawerContainer = forwardRef((props, ref) => {
+const DrawerContainer = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'DrawerContainer' });
   const drawerContext = useDrawer(); // context might be an undefined value
   const {
     backdrop,

--- a/packages/react/src/drawer/DrawerContent.js
+++ b/packages/react/src/drawer/DrawerContent.js
@@ -1,6 +1,7 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { ariaAttr, callAll } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import { Slide } from '../transitions';
 import { useAnimatePresence } from '../utils/animate-presence';
 import DrawerCloseButton from './DrawerCloseButton';
@@ -9,15 +10,13 @@ import {
 } from './styles';
 import useDrawer from './useDrawer';
 
-const DrawerContent = forwardRef((
-  {
+const DrawerContent = forwardRef((inProps, ref) => {
+  const {
     TransitionComponent = Slide,
     TransitionProps,
     children,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'DrawerContent' });
   const [, safeToRemove] = useAnimatePresence();
   const drawerContext = useDrawer(); // context might be an undefined value
   const {

--- a/packages/react/src/drawer/DrawerFooter.js
+++ b/packages/react/src/drawer/DrawerFooter.js
@@ -1,11 +1,13 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import useDrawer from './useDrawer';
 import {
   useDrawerFooterStyle,
 } from './styles';
 
-const DrawerFooter = forwardRef((props, ref) => {
+const DrawerFooter = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'DrawerFooter' });
   const context = useDrawer(); // context might be an undefined value
   const {
     placement,

--- a/packages/react/src/drawer/DrawerHeader.js
+++ b/packages/react/src/drawer/DrawerHeader.js
@@ -1,11 +1,13 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useDrawerHeaderStyle,
 } from './styles';
 import useDrawer from './useDrawer';
 
-const DrawerHeader = forwardRef((props, ref) => {
+const DrawerHeader = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'DrawerHeader' });
   const drawerContext = useDrawer(); // context might be an undefined value
   const {
     isClosable,

--- a/packages/react/src/drawer/DrawerOverlay.js
+++ b/packages/react/src/drawer/DrawerOverlay.js
@@ -1,6 +1,7 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { callAll } from '@tonic-ui/utils';
 import React, { forwardRef, useRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import { useAnimatePresence } from '../utils/animate-presence';
 import { Fade } from '../transitions';
 import {
@@ -8,11 +9,12 @@ import {
 } from './styles';
 import useDrawer from './useDrawer';
 
-const DrawerOverlay = forwardRef(({
-  TransitionComponent = Fade,
-  TransitionProps,
-  ...rest
-}, ref) => {
+const DrawerOverlay = forwardRef((inProps, ref) => {
+  const {
+    TransitionComponent = Fade,
+    TransitionProps,
+    ...rest
+  } = useDefaultProps({ props: inProps, name: 'DrawerOverlay' });
   const drawerContext = useDrawer(); // context might be an undefined value
   const {
     isOpen,

--- a/packages/react/src/flex/Flex.js
+++ b/packages/react/src/flex/Flex.js
@@ -1,26 +1,28 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
-const Flex = forwardRef((
-  {
+const Flex = forwardRef((inProps, ref) => {
+  const {
     direction,
     wrap,
     align,
     justify,
     ...rest
-  },
-  ref
-) => (
-  <Box
-    ref={ref}
-    display="flex"
-    flexDirection={direction}
-    flexWrap={wrap}
-    alignItems={align}
-    justifyContent={justify}
-    {...rest}
-  />
-));
+  } = useDefaultProps({ props: inProps, name: 'Flex' });
+
+  return (
+    <Box
+      ref={ref}
+      display="flex"
+      flexDirection={direction}
+      flexWrap={wrap}
+      alignItems={align}
+      justifyContent={justify}
+      {...rest}
+    />
+  );
+});
 
 Flex.displayName = 'Flex';
 

--- a/packages/react/src/grid/Grid.js
+++ b/packages/react/src/grid/Grid.js
@@ -1,8 +1,9 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
-const Grid = forwardRef((
-  {
+const Grid = forwardRef((inProps, ref) => {
+  const {
     gap,
     rowGap,
     columnGap,
@@ -16,27 +17,28 @@ const Grid = forwardRef((
     templateColumns,
     templateAreas,
     ...rest
-  },
-  ref,
-) => (
-  <Box
-    ref={ref}
-    display="grid"
-    gridGap={gap}
-    gridRowGap={rowGap}
-    gridColumnGap={columnGap}
-    gridColumn={column}
-    gridRow={row}
-    gridArea={area}
-    gridAutoFlow={autoFlow}
-    gridAutoRows={autoRows}
-    gridAutoColumns={autoColumns}
-    gridTemplateRows={templateRows}
-    gridTemplateColumns={templateColumns}
-    gridTemplateAreas={templateAreas}
-    {...rest}
-  />
-));
+  } = useDefaultProps({ props: inProps, name: 'Grid' });
+
+  return (
+    <Box
+      ref={ref}
+      display="grid"
+      gridGap={gap}
+      gridRowGap={rowGap}
+      gridColumnGap={columnGap}
+      gridColumn={column}
+      gridRow={row}
+      gridArea={area}
+      gridAutoFlow={autoFlow}
+      gridAutoRows={autoRows}
+      gridAutoColumns={autoColumns}
+      gridTemplateRows={templateRows}
+      gridTemplateColumns={templateColumns}
+      gridTemplateAreas={templateAreas}
+      {...rest}
+    />
+  );
+});
 
 Grid.displayName = 'Grid';
 

--- a/packages/react/src/icon/styles.js
+++ b/packages/react/src/icon/styles.js
@@ -1,0 +1,36 @@
+import { keyframes } from '@emotion/react';
+
+const cwSpin = keyframes`
+  0% {
+      transform: rotate(0deg)
+  }
+  to {
+      transform: rotate(1turn)
+  }
+`;
+
+const ccwSpin = keyframes`
+  0% {
+      transform: rotate(0deg)
+  }
+  to {
+      transform: rotate(-1turn)
+  }
+`;
+
+const useIconStyle = ({ spin }) => {
+  let animation;
+  if (spin === 'ccw') {
+    animation = `${ccwSpin} 2s linear infinite`;
+  } else if (spin === 'cw' || spin === true) {
+    animation = `${cwSpin} 2s linear infinite`;
+  }
+
+  return {
+    animation,
+  };
+};
+
+export {
+  useIconStyle,
+};

--- a/packages/react/src/image/Image.js
+++ b/packages/react/src/image/Image.js
@@ -1,14 +1,19 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
-const Image = forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    as="img"
-    alt=""
-    {...props}
-  />
-));
+const Image = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'Image' });
+
+  return (
+    <Box
+      ref={ref}
+      as="img"
+      alt=""
+      {...props}
+    />
+  );
+});
 
 Image.displayName = 'Image';
 

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -10,6 +10,7 @@ export * from './color-mode';
 export * from './color-style';
 export * from './css-baseline';
 export * from './date-pickers';
+export * from './default-props';
 export * from './divider';
 export * from './drawer';
 export * from './flex';

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -10,7 +10,6 @@ export * from './color-mode';
 export * from './color-style';
 export * from './css-baseline';
 export * from './date-pickers';
-export * from './default-props';
 export * from './divider';
 export * from './drawer';
 export * from './flex';

--- a/packages/react/src/input/Input.js
+++ b/packages/react/src/input/Input.js
@@ -1,18 +1,17 @@
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import InputBase from './InputBase';
 import { getInputGroupCSS, useInputStyle } from './styles';
 import useInputGroup from './useInputGroup';
 import { defaultSize, defaultVariant } from './constants';
 
-const Input = forwardRef((
-  {
+const Input = forwardRef((inProps, ref) => {
+  const {
     size: sizeProp,
     variant: variantProp,
     css: cssProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Input' });
   const inputGroupContext = useInputGroup();
   const {
     size: inputGroupSize,

--- a/packages/react/src/input/InputAdornment.js
+++ b/packages/react/src/input/InputAdornment.js
@@ -1,17 +1,16 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { defaultSize, defaultVariant } from './constants';
 import { useInputAdornmentStyle } from './styles';
 import useInputGroup from './useInputGroup';
 
-const InputAdornment = forwardRef((
-  {
+const InputAdornment = forwardRef((inProps, ref) => {
+  const {
     size: sizeProp,
     variant: variantProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'InputAdornment' });
   const inputGroupContext = useInputGroup();
   const {
     size: inputGroupSize,

--- a/packages/react/src/input/InputBase.js
+++ b/packages/react/src/input/InputBase.js
@@ -1,19 +1,18 @@
 import { ariaAttr } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useInputBaseStyle } from './styles';
 
 /**
  * `InputBase` does not have appearance settings including default color, padding, outline, and border
  */
-const InputBase = forwardRef((
-  {
+const InputBase = forwardRef((inProps, ref) => {
+  const {
     children,
     error,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'InputBase' });
   const ariaProps = {
     'aria-disabled': ariaAttr(rest.disabled),
     'aria-invalid': ariaAttr(error),

--- a/packages/react/src/input/InputControl.js
+++ b/packages/react/src/input/InputControl.js
@@ -1,13 +1,14 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import InputBase from './InputBase';
 import { defaultSize, defaultVariant } from './constants';
 import { getInputGroupCSS, useInputControlBaseCSS, useInputControlBaseStyle, useInputControlInputStyle } from './styles';
 import useInputGroup from './useInputGroup';
 
-const InputControl = forwardRef((
-  {
+const InputControl = forwardRef((inProps, ref) => {
+  const {
     // InputBase (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
     autoComplete: autoCompleteProp,
     autoFocus: autoFocusProp,
@@ -47,9 +48,7 @@ const InputControl = forwardRef((
     startAdornment,
     variant: variantProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'InputControl' });
   const nodeRef = useRef();
   const combinedInputRef = useMergeRefs(nodeRef, inputRefProp);
   const [focused, setFocused] = useState(false);

--- a/packages/react/src/input/InputGroup.js
+++ b/packages/react/src/input/InputGroup.js
@@ -2,20 +2,19 @@ import { runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { InputGroupContext } from './context';
 import { useInputGroupStyle } from './styles';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const InputGroup = forwardRef((
-  {
+const InputGroup = forwardRef((inProps, ref) => {
+  const {
     children,
     size = 'md',
     variant = 'outline',
     ...rest
-  },
-  ref
-) => {
+  } = useDefaultProps({ props: inProps, name: 'InputGroup' });
   const context = getMemoizedState({ size, variant });
   const styleProps = useInputGroupStyle();
 

--- a/packages/react/src/input/InputGroupAddon.js
+++ b/packages/react/src/input/InputGroupAddon.js
@@ -1,17 +1,16 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { defaultSize, defaultVariant } from './constants';
 import { useInputGroupAddonStyle } from './styles';
 import useInputGroup from './useInputGroup';
 
-const InputGroupAddon = forwardRef((
-  {
+const InputGroupAddon = forwardRef((inProps, ref) => {
+  const {
     size: sizeProp,
     variant: variantProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'InputGroupAddon' });
   const inputGroupContext = useInputGroup();
   const {
     size: inputGroupSize,

--- a/packages/react/src/input/InputGroupAppend.js
+++ b/packages/react/src/input/InputGroupAppend.js
@@ -1,14 +1,13 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { getInputGroupAppendCSS, useInputGroupAppendStyle } from './styles';
 
-const InputGroupAppend = forwardRef((
-  {
+const InputGroupAppend = forwardRef((inProps, ref) => {
+  const {
     css: cssProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'InputGroupAppend' });
   const css = [getInputGroupAppendCSS(), cssProp];
   const styleProps = useInputGroupAppendStyle();
 

--- a/packages/react/src/input/InputGroupPrepend.js
+++ b/packages/react/src/input/InputGroupPrepend.js
@@ -1,14 +1,13 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { getInputGroupPrependCSS, useInputGroupPrependStyle } from './styles';
 
-const InputGroupPrepend = forwardRef((
-  {
+const InputGroupPrepend = forwardRef((inProps, ref) => {
+  const {
     css: cssProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'InputGroupPrepend' });
   const css = [getInputGroupPrependCSS(), cssProp];
   const styleProps = useInputGroupPrependStyle();
 

--- a/packages/react/src/link/Link.js
+++ b/packages/react/src/link/Link.js
@@ -1,17 +1,16 @@
 import { ariaAttr } from '@tonic-ui/utils';
 import React, { forwardRef, useCallback } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useLinkStyle } from './styles';
 
-const Link = forwardRef((
-  {
+const Link = forwardRef((inProps, ref) => {
+  const {
     disabled,
     onClick,
     textDecoration,
     ...rest
-  },
-  ref
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Link' });
   const styleProps = useLinkStyle({
     disabled,
     textDecoration,

--- a/packages/react/src/link/LinkButton.js
+++ b/packages/react/src/link/LinkButton.js
@@ -1,9 +1,11 @@
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
+import { useDefaultProps } from '../default-props';
 import Link from './Link';
 import { useLinkButtonStyle } from './styles';
 
-const LinkButton = forwardRef((props, ref) => {
+const LinkButton = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'LinkButton' });
   const styleProps = useLinkButtonStyle();
 
   return (

--- a/packages/react/src/menu/Menu.js
+++ b/packages/react/src/menu/Menu.js
@@ -4,6 +4,7 @@ import { ensureString } from 'ensure-type';
 import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
 import { MenuContext } from './context';
@@ -21,8 +22,8 @@ const mapPlacementToDirection = (placement) => {
   return direction;
 };
 
-const Menu = forwardRef((
-  {
+const Menu = forwardRef((inProps, ref) => {
+  const {
     anchorEl,
     autoSelect = false,
     children,
@@ -37,9 +38,7 @@ const Menu = forwardRef((
     placement = 'bottom-start', // One of: 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end'
     returnFocusOnClose = true,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Menu' });
   const menuContentRef = useRef(null);
   const menuToggleRef = useRef(null);
   const [activeIndex, setActiveIndex] = useState(defaultActiveIndex);

--- a/packages/react/src/menu/MenuButton.js
+++ b/packages/react/src/menu/MenuButton.js
@@ -1,25 +1,24 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { Button } from '../button';
+import { useDefaultProps } from '../default-props';
 import MenuToggle from './MenuToggle';
 import MenuToggleIcon from './MenuToggleIcon';
 import { useMenuButtonCSS, useMenuButtonStyle } from './styles';
 
-const MenuButton = forwardRef((
-  {
+const MenuButton = forwardRef((inProps, ref) => {
+  const {
     children,
-    css,
+    css: cssProp,
     disabled,
     onClick,
     onKeyDown,
     variant,
     ...rest
-  },
-  ref,
-) => {
-  css = [
+  } = useDefaultProps({ props: inProps, name: 'MenuButton' });
+  const css = [
     useMenuButtonCSS({ variant }),
-    css,
+    cssProp,
   ];
   const styleProps = useMenuButtonStyle();
 

--- a/packages/react/src/menu/MenuContent.js
+++ b/packages/react/src/menu/MenuContent.js
@@ -2,13 +2,14 @@ import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { callAll, callEventHandlers } from '@tonic-ui/utils';
 import { ensureArray, ensureFunction } from 'ensure-type';
 import React, { forwardRef, useMemo, useRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import { Popper } from '../popper';
 import { Collapse } from '../transitions';
 import { useMenuContentStyle } from './styles';
 import useMenu from './useMenu';
 
-const MenuContent = forwardRef((
-  {
+const MenuContent = forwardRef((inProps, ref) => {
+  const {
     PopperComponent = Popper,
     PopperProps,
     TransitionComponent = Collapse,
@@ -17,9 +18,7 @@ const MenuContent = forwardRef((
     onBlur: onBlurProp,
     onKeyDown: onKeyDownProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'MenuContent' });
   const nodeRef = useRef(null);
   const combinedRef = useMergeRefs(nodeRef, ref);
   const menuContext = useMenu(); // context might be an undefined value

--- a/packages/react/src/menu/MenuDivider.js
+++ b/packages/react/src/menu/MenuDivider.js
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import { Divider } from '../divider';
 import { useMenuItemDividerStyle } from './styles';
 
-const MenuDivider = forwardRef((props, ref) => {
+const MenuDivider = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'MenuDivider' });
   const styleProps = useMenuItemDividerStyle();
 
   return (

--- a/packages/react/src/menu/MenuGroup.js
+++ b/packages/react/src/menu/MenuGroup.js
@@ -1,15 +1,14 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useMenuGroupStyle } from './styles';
 
-const MenuGroup = forwardRef((
-  {
+const MenuGroup = forwardRef((inProps, ref) => {
+  const {
     children,
     title,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'MenuGroup' });
   const styleProps = useMenuGroupStyle();
 
   return (

--- a/packages/react/src/menu/MenuItem.js
+++ b/packages/react/src/menu/MenuItem.js
@@ -2,19 +2,18 @@ import { ariaAttr, callEventHandlers } from '@tonic-ui/utils';
 import { ensureFunction } from 'ensure-type';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
+import { useDefaultProps } from '../default-props';
 import { useMenuItemStyle } from './styles';
 import useMenu from './useMenu';
 
-const MenuItem = forwardRef((
-  {
+const MenuItem = forwardRef((inProps, ref) => {
+  const {
     disabled,
     onClick,
     onKeyDown,
     role = 'menuitem',
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'MenuItem' });
   const menuContext = useMenu(); // context might be an undefined value
   const {
     closeOnSelect,

--- a/packages/react/src/menu/MenuList.js
+++ b/packages/react/src/menu/MenuList.js
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import MenuContent from './MenuContent';
 import { useMenuListStyle } from './styles';
 
-const MenuList = forwardRef((props, ref) => {
+const MenuList = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'MenuList' });
   const styleProps = useMenuListStyle();
 
   return (

--- a/packages/react/src/menu/MenuToggle.js
+++ b/packages/react/src/menu/MenuToggle.js
@@ -3,21 +3,20 @@ import { ariaAttr, callEventHandlers } from '@tonic-ui/utils';
 import { ensureFunction } from 'ensure-type';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
+import { useDefaultProps } from '../default-props';
 import {
   useMenuToggleStyle,
 } from './styles';
 import useMenu from './useMenu';
 
-const MenuToggle = forwardRef((
-  {
+const MenuToggle = forwardRef((inProps, ref) => {
+  const {
     children,
     disabled,
     onClick: onClickProp,
     onKeyDown: onKeyDownProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'MenuToggle' });
   const menuContext = useMenu(); // context might be an undefined value
   const {
     autoSelect,

--- a/packages/react/src/menu/MenuToggleIcon.js
+++ b/packages/react/src/menu/MenuToggleIcon.js
@@ -10,6 +10,7 @@ import React, { forwardRef, useEffect, useRef } from 'react';
 import { isValidElementType } from 'react-is';
 import { Transition } from 'react-transition-group';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useMenuToggleIconStyle,
 } from './styles';
@@ -56,8 +57,8 @@ const defaultTimeout = {
   exit: Math.floor(133 * 0.7),
 };
 
-const MenuToggleIcon = forwardRef((
-  {
+const MenuToggleIcon = forwardRef((inProps, ref) => {
+  const {
     appear = false, // do not perform the enter transition when it first mounts
     children,
     disabled,
@@ -65,9 +66,7 @@ const MenuToggleIcon = forwardRef((
     style,
     timeout = defaultTimeout,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'MenuToggleIcon' });
   const menuContext = useMenu(); // context might be an undefined value
   const {
     isOpen,

--- a/packages/react/src/menu/Submenu.js
+++ b/packages/react/src/menu/Submenu.js
@@ -2,6 +2,7 @@ import { runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
 import { SubmenuContext } from './context';
@@ -9,8 +10,8 @@ import { useSubmenuStyle } from './styles';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const Submenu = forwardRef((
-  {
+const Submenu = forwardRef((inProps, ref) => {
+  const {
     children,
     defaultIsOpen = false,
     isOpen: isOpenProp,
@@ -19,9 +20,7 @@ const Submenu = forwardRef((
     onOpen: onOpenProp,
     placement = 'right-start', // One of: 'right-start', 'right-end', 'left-start', 'left-end'
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Submenu' });
   const submenuContentRef = useRef(null);
   const submenuToggleRef = useRef(null);
   const isHoveringSubmenuContentRef = useRef();

--- a/packages/react/src/menu/SubmenuContent.js
+++ b/packages/react/src/menu/SubmenuContent.js
@@ -2,13 +2,14 @@ import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { callAll, callEventHandlers } from '@tonic-ui/utils';
 import { ensureArray, ensureFunction } from 'ensure-type';
 import React, { forwardRef, useMemo, useRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import { Popper } from '../popper';
 import { Collapse } from '../transitions';
 import { useSubmenuContentStyle } from './styles';
 import useSubmenu from './useSubmenu';
 
-const SubmenuContent = forwardRef((
-  {
+const SubmenuContent = forwardRef((inProps, ref) => {
+  const {
     PopperComponent = Popper,
     PopperProps,
     TransitionComponent = Collapse,
@@ -17,9 +18,7 @@ const SubmenuContent = forwardRef((
     onMouseEnter: onMouseEnterProp,
     onMouseLeave: onMouseLeaveProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'SubmenuContent' });
   const nodeRef = useRef(null);
   const combinedRef = useMergeRefs(nodeRef, ref);
   const mouseLeaveTimeoutRef = useRef();
@@ -94,7 +93,7 @@ const SubmenuContent = forwardRef((
   }, [skidding, distance]);
 
   return (
-    <Popper
+    <PopperComponent
       aria-labelledby={submenuToggleId}
       anchorEl={submenuToggleRef?.current} // TODO: rename to `referenceRef` in a future release
       data-submenu-id={submenuId}
@@ -146,7 +145,7 @@ const SubmenuContent = forwardRef((
           </TransitionComponent>
         );
       }}
-    </Popper>
+    </PopperComponent>
   );
 });
 

--- a/packages/react/src/menu/SubmenuList.js
+++ b/packages/react/src/menu/SubmenuList.js
@@ -1,9 +1,11 @@
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import SubmenuContent from './SubmenuContent';
 import { useSubmenuListStyle } from './styles';
 import useSubmenu from './useSubmenu';
 
-const SubmenuList = forwardRef((props, ref) => {
+const SubmenuList = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'SubmenuList' });
   const submenuContext = useSubmenu(); // context might be an undefined value
   const {
     isOpen,

--- a/packages/react/src/menu/SubmenuToggle.js
+++ b/packages/react/src/menu/SubmenuToggle.js
@@ -3,21 +3,20 @@ import { ariaAttr, callEventHandlers } from '@tonic-ui/utils';
 import { ensureFunction } from 'ensure-type';
 import React, { forwardRef, useRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useSubmenuToggleStyle,
 } from './styles';
 import useSubmenu from './useSubmenu';
 
-const SubmenuToggle = forwardRef((
-  {
+const SubmenuToggle = forwardRef((inProps, ref) => {
+  const {
     children,
     disabled,
     onMouseEnter: onMouseEnterProp,
     onMouseLeave: onMouseLeaveProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'SubmenuToggle' });
   const mouseLeaveTimeoutRef = useRef();
   const submenuContext = useSubmenu(); // context might be an undefined value
   const {

--- a/packages/react/src/modal/Modal.js
+++ b/packages/react/src/modal/Modal.js
@@ -2,6 +2,7 @@ import { getAllFocusable, runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import FocusLock from 'react-focus-lock/dist/cjs';
+import { useDefaultProps } from '../default-props';
 import { Portal } from '../portal';
 import { AnimatePresence } from '../utils/animate-presence';
 import ModalContainer from './ModalContainer';
@@ -12,8 +13,8 @@ const getMemoizedState = memoize(state => ({ ...state }));
 const defaultScrollBehavior = 'inside';
 const defaultSize = 'auto';
 
-const Modal = forwardRef((
-  {
+const Modal = forwardRef((inProps, ref) => {
+  const {
     autoFocus = false,
     children,
     closeOnEsc = false,
@@ -29,9 +30,7 @@ const Modal = forwardRef((
     scrollBehavior = defaultScrollBehavior,
     size = defaultSize,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Modal' });
   const [isMounted, setIsMounted] = useState(isOpen);
   const containerRef = useRef();
   const contentRef = useRef();

--- a/packages/react/src/modal/ModalBody.js
+++ b/packages/react/src/modal/ModalBody.js
@@ -1,11 +1,13 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useModalBodyStyle,
 } from './styles';
 import useModal from './useModal';
 
-const ModalBody = forwardRef((props, ref) => {
+const ModalBody = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'ModalBody' });
   const modalContext = useModal(); // context might be an undefined value
   const {
     scrollBehavior,

--- a/packages/react/src/modal/ModalCloseButton.js
+++ b/packages/react/src/modal/ModalCloseButton.js
@@ -2,19 +2,18 @@ import { CloseIcon } from '@tonic-ui/react-icons';
 import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
+import { useDefaultProps } from '../default-props';
 import {
   useModalCloseButtonStyle,
 } from './styles';
 import useModal from './useModal';
 
-const ModalCloseButton = forwardRef((
-  {
+const ModalCloseButton = forwardRef((inProps, ref) => {
+  const {
     children,
     onClick: onClickProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'ModalCloseButton' });
   const modalContext = useModal(); // context might be an undefined value
   const {
     onClose,

--- a/packages/react/src/modal/ModalContainer.js
+++ b/packages/react/src/modal/ModalContainer.js
@@ -1,12 +1,14 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useModalContainerStyle,
 } from './styles';
 import useModal from './useModal';
 
-const ModalContainer = forwardRef((props, ref) => {
+const ModalContainer = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'ModalContainer' });
   const modalContext = useModal(); // context might be an undefined value
   const {
     closeOnOutsideClick,

--- a/packages/react/src/modal/ModalContent.js
+++ b/packages/react/src/modal/ModalContent.js
@@ -1,6 +1,7 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { ariaAttr, callAll } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import { Fade } from '../transitions';
 import { useAnimatePresence } from '../utils/animate-presence';
 import ModalCloseButton from './ModalCloseButton';
@@ -9,15 +10,13 @@ import {
 } from './styles';
 import useModal from './useModal';
 
-const ModalContent = forwardRef((
-  {
+const ModalContent = forwardRef((inProps, ref) => {
+  const {
     TransitionComponent = Fade,
     TransitionProps,
     children,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'ModalContent' });
   const [, safeToRemove] = useAnimatePresence();
   const modalContext = useModal(); // context might be an undefined value
   const {

--- a/packages/react/src/modal/ModalFooter.js
+++ b/packages/react/src/modal/ModalFooter.js
@@ -1,10 +1,12 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useModalFooterStyle,
 } from './styles';
 
-const ModalFooter = forwardRef((props, ref) => {
+const ModalFooter = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'ModalFooter' });
   const styleProps = useModalFooterStyle();
 
   return (

--- a/packages/react/src/modal/ModalHeader.js
+++ b/packages/react/src/modal/ModalHeader.js
@@ -1,11 +1,13 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useModalHeaderStyle,
 } from './styles';
 import useModal from './useModal';
 
-const ModalHeader = forwardRef((props, ref) => {
+const ModalHeader = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'ModalHeader' });
   const modalContext = useModal(); // context might be an undefined value
   const {
     isClosable,

--- a/packages/react/src/modal/ModalOverlay.js
+++ b/packages/react/src/modal/ModalOverlay.js
@@ -2,6 +2,7 @@ import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { callAll, getComputedStyle } from '@tonic-ui/utils';
 import { ensurePositiveNumber } from 'ensure-type';
 import React, { forwardRef, useEffect, useRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import { Fade } from '../transitions';
 import { useAnimatePresence } from '../utils/animate-presence';
 import {
@@ -9,14 +10,12 @@ import {
 } from './styles';
 import useModal from './useModal';
 
-const ModalOverlay = forwardRef((
-  {
+const ModalOverlay = forwardRef((inProps, ref) => {
+  const {
     TransitionComponent = Fade,
     TransitionProps,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'ModalOverlay' });
   const [, safeToRemove] = useAnimatePresence();
   const modalContext = useModal(); // context might be an undefined value
   const {

--- a/packages/react/src/pagination/Pagination.js
+++ b/packages/react/src/pagination/Pagination.js
@@ -1,11 +1,12 @@
 import React, { Fragment, forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { usePaginationStyle } from './styles';
 import PaginationItem from './PaginationItem';
 import usePagination from './usePagination';
 
-const Pagination = forwardRef((
-  {
+const Pagination = forwardRef((inProps, ref) => {
+  const {
     boundaryCount = 1,
     count = 1,
     defaultPage = 1,
@@ -16,9 +17,7 @@ const Pagination = forwardRef((
     siblingCount = 1,
     slot,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Pagination' });
   const { items } = usePagination({
     boundaryCount,
     count,

--- a/packages/react/src/pagination/PaginationItem.js
+++ b/packages/react/src/pagination/PaginationItem.js
@@ -8,6 +8,7 @@ import {
 import { ariaAttr } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { Button } from '../button';
+import { useDefaultProps } from '../default-props';
 import {
   usePaginationItemStyle,
 } from './styles';
@@ -34,8 +35,8 @@ const getAriaLabel = ({ type, page, selected }) => {
   return `Go to ${type} page`;
 };
 
-const PaginationItem = forwardRef((
-  {
+const PaginationItem = forwardRef((inProps, ref) => {
+  const {
     'aria-label': ariaLabel,
     disabled = false,
     type = 'page',
@@ -44,9 +45,7 @@ const PaginationItem = forwardRef((
     slot: slotProp,
     variant = 'ghost',
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'PaginationItem' });
   const slot = {
     ...defaultSlot,
     ...slotProp,

--- a/packages/react/src/popover/Popover.js
+++ b/packages/react/src/popover/Popover.js
@@ -2,6 +2,7 @@ import { usePrevious } from '@tonic-ui/react-hooks';
 import { runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useDefaultProps } from '../default-props';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
 import { PopoverContext } from './context';
@@ -10,26 +11,27 @@ const getMemoizedState = memoize(state => ({ ...state }));
 
 const defaultPlacement = 'bottom';
 
-const Popover = ({
-  arrow = true,
-  children,
-  closeOnBlur = true,
-  closeOnEsc = true,
-  defaultIsOpen = false,
-  disabled,
-  enterDelay = 100,
-  followCursor,
-  initialFocusRef,
-  isOpen: isOpenProp,
-  leaveDelay = 0,
-  nextToCursor,
-  offset,
-  onClose: onCloseProp,
-  onOpen: onOpenProp,
-  placement = defaultPlacement,
-  returnFocusOnClose = true,
-  trigger = 'click',
-}) => {
+const Popover = (inProps) => {
+  const {
+    arrow = true,
+    children,
+    closeOnBlur = true,
+    closeOnEsc = true,
+    defaultIsOpen = false,
+    disabled,
+    enterDelay = 100,
+    followCursor,
+    initialFocusRef,
+    isOpen: isOpenProp,
+    leaveDelay = 0,
+    nextToCursor,
+    offset,
+    onClose: onCloseProp,
+    onOpen: onOpenProp,
+    placement = defaultPlacement,
+    returnFocusOnClose = true,
+    trigger = 'click',
+  } = useDefaultProps({ props: inProps, name: 'Popover' });
   const popoverContentRef = useRef();
   const popoverTriggerRef = useRef();
   const isHoveringContentRef = useRef();

--- a/packages/react/src/popover/PopoverArrow.js
+++ b/packages/react/src/popover/PopoverArrow.js
@@ -1,18 +1,17 @@
 import { getComputedStyle, isHTMLElement } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { usePopoverArrowStyle } from './styles';
 import usePopover from './usePopover';
 
-const PopoverArrow = forwardRef((
-  {
+const PopoverArrow = forwardRef((inProps, ref) => {
+  const {
     arrowHeight = 8,
     arrowWidth = 12,
     sx,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'PopoverArrow' });
   const {
     placement,
     popoverContentRef,

--- a/packages/react/src/popover/PopoverBody.js
+++ b/packages/react/src/popover/PopoverBody.js
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { usePopoverBodyStyle } from './styles';
 
-const PopoverBody = forwardRef((props, ref) => {
+const PopoverBody = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'PopoverBody' });
   const styleProps = usePopoverBodyStyle({});
 
   return (

--- a/packages/react/src/popover/PopoverContent.js
+++ b/packages/react/src/popover/PopoverContent.js
@@ -12,6 +12,7 @@ import {
 import { ensureArray, ensureFunction } from 'ensure-type';
 import React, { forwardRef, useMemo, useRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { Popper } from '../popper';
 import { Grow } from '../transitions';
 import PopoverArrow from './PopoverArrow';
@@ -33,8 +34,8 @@ const mapPlacementToTransformOrigin = placement => ({
   'right-end': 'left bottom',
 }[placement]);
 
-const PopoverContent = forwardRef((
-  {
+const PopoverContent = forwardRef((inProps, ref) => {
+  const {
     PopperComponent = Popper,
     PopperProps,
     PopoverArrowComponent = PopoverArrow,
@@ -47,9 +48,7 @@ const PopoverContent = forwardRef((
     onMouseEnter: onMouseEnterProp,
     onMouseLeave: onMouseLeaveProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'PopoverContent' });
   const isHydrated = useHydrated();
   const nodeRef = useRef(null);
   const combinedRef = useMergeRefs(nodeRef, ref);

--- a/packages/react/src/popover/PopoverFooter.js
+++ b/packages/react/src/popover/PopoverFooter.js
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { usePopoverFooterStyle } from './styles';
 
-const PopoverFooter = forwardRef((props, ref) => {
+const PopoverFooter = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'PopoverFooter' });
   const styleProps = usePopoverFooterStyle({});
 
   return (

--- a/packages/react/src/popover/PopoverHeader.js
+++ b/packages/react/src/popover/PopoverHeader.js
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { usePopoverHeaderStyle } from './styles';
 
-const PopoverHeader = forwardRef((props, ref) => {
+const PopoverHeader = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'PopoverHeader' });
   const styleProps = usePopoverHeaderStyle({});
 
   return (

--- a/packages/react/src/popover/PopoverTrigger.js
+++ b/packages/react/src/popover/PopoverTrigger.js
@@ -2,12 +2,13 @@ import { useEventListener, useMergeRefs } from '@tonic-ui/react-hooks';
 import { ariaAttr, callEventHandlers } from '@tonic-ui/utils';
 import React, { cloneElement, forwardRef, useRef, useState } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { mergeRefs } from '../utils/refs';
 import { usePopoverTriggerStyle } from './styles';
 import usePopover from './usePopover';
 
-const PopoverTrigger = forwardRef((
-  {
+const PopoverTrigger = forwardRef((inProps, ref) => {
+  const {
     children,
     shouldWrapChildren = false,
     onBlur: onBlurProp,
@@ -18,9 +19,7 @@ const PopoverTrigger = forwardRef((
     onMouseLeave: onMouseLeaveProp,
     onMouseMove: onMouseMoveProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'PopoverTrigger' });
   const {
     followCursor,
     isHoveringContentRef,

--- a/packages/react/src/portal/Portal.js
+++ b/packages/react/src/portal/Portal.js
@@ -3,17 +3,19 @@ import { getOwnerDocument, noop } from '@tonic-ui/utils';
 import React, { useContext, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import useForceUpdate from '../utils/useForceUpdate';
 import { PortalContext } from './context';
 
 const PORTAL_CLASSNAME = 'tonic-ui-portal';
 const PORTAL_SELECTOR = `.${PORTAL_CLASSNAME}`;
 
-const Portal = ({
-  appendToParentPortal = false,
-  children,
-  containerRef,
-}) => {
+const Portal = (inProps) => {
+  const {
+    appendToParentPortal = false,
+    children,
+    containerRef,
+  } = useDefaultProps({ props: inProps, name: 'Portal' });
   const [doc, setDoc] = useState(null);
   const portalRef = useRef(null);
   const parentPortal = useContext(PortalContext);

--- a/packages/react/src/portal/PortalManager.js
+++ b/packages/react/src/portal/PortalManager.js
@@ -1,5 +1,6 @@
 import memoize from 'micro-memoize';
 import React, { useCallback, useState } from 'react';
+import { useDefaultProps } from '../default-props';
 import Portal from './Portal';
 import { PortalManagerContext } from './context';
 
@@ -13,10 +14,11 @@ const uniqueId = (() => {
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const PortalManager = ({
-  children,
-  containerRef: containerRefProp,
-}) => {
+const PortalManager = (inProps) => {
+  const {
+    children,
+    containerRef: containerRefProp,
+  } = useDefaultProps({ props: inProps, name: 'PortalManager' });
   const [portals, setPortals] = useState([]);
   const add = useCallback((render, options) => {
     const id = options?.id ?? uniqueId();

--- a/packages/react/src/progress/LinearProgress.js
+++ b/packages/react/src/progress/LinearProgress.js
@@ -1,6 +1,7 @@
 import { ensureFiniteNumber } from 'ensure-type';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useLinearProgressStyle,
   useLinearProgressBarStyle,
@@ -9,8 +10,8 @@ import {
 const defaultSize = 'sm';
 const defaultVariant = 'indeterminate';
 
-const LinearProgress = forwardRef((
-  {
+const LinearProgress = forwardRef((inProps, ref) => {
+  const {
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
     color = 'blue:60',
@@ -20,9 +21,7 @@ const LinearProgress = forwardRef((
     value,
     variant = defaultVariant,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'LinearProgress' });
   const progressStyleProps = useLinearProgressStyle({ size });
   const progressbarStyleProps = useLinearProgressBarStyle({ color, variant });
   const progressbarProps = {

--- a/packages/react/src/radio/Radio.js
+++ b/packages/react/src/radio/Radio.js
@@ -38,7 +38,6 @@ const Radio = forwardRef((inProps, ref) => {
 
   const inputRef = useRef();
   const combinedInputRef = useMergeRefs(inputRefProp, inputRef);
-  const styleProps = useRadioStyle({ disabled });
   const radioGroupContext = useRadioGroup();
 
   if (radioGroupContext) {
@@ -68,6 +67,8 @@ const Radio = forwardRef((inProps, ref) => {
     size = size ?? defaultSize;
     variantColor = variantColor ?? defaultVariantColor;
   }
+
+  const styleProps = useRadioStyle({ disabled });
 
   return (
     <Box

--- a/packages/react/src/radio/Radio.js
+++ b/packages/react/src/radio/Radio.js
@@ -2,33 +2,40 @@ import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { callAll, isNullish } from '@tonic-ui/utils';
 import React, { forwardRef, useRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { VisuallyHidden } from '../visually-hidden';
 import { defaultSize, defaultVariantColor } from './constants';
 import RadioControlBox from './RadioControlBox';
 import useRadioGroup from './useRadioGroup';
 import { useRadioStyle } from './styles';
 
-const Radio = forwardRef((
-  {
-    checked,
+const Radio = forwardRef((inProps, ref) => {
+  const {
+    checked: checkedProp,
     children,
     defaultChecked,
-    disabled,
+    disabled: disabledProp,
     id,
     inputProps,
     inputRef: inputRefProp,
-    name,
+    name: nameProp,
     onBlur,
-    onChange,
+    onChange: onChangeProp,
     onClick,
     onFocus,
-    size,
+    size: sizeProp,
     value,
-    variantColor,
+    variantColor: variantColorProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Radio' });
+
+  let checked = checkedProp;
+  let disabled = disabledProp;
+  let name = nameProp;
+  let onChange = onChangeProp;
+  let size = sizeProp;
+  let variantColor = variantColorProp;
+
   const inputRef = useRef();
   const combinedInputRef = useMergeRefs(inputRefProp, inputRef);
   const styleProps = useRadioStyle({ disabled });

--- a/packages/react/src/radio/RadioControlBox.js
+++ b/packages/react/src/radio/RadioControlBox.js
@@ -9,15 +9,13 @@ import {
   useRadioControlBoxStyle,
 } from './styles';
 
-const RadioControlBox = forwardRef((
-  {
+const RadioControlBox = forwardRef((inProps, ref) => {
+  const {
     size = defaultSize,
     variantColor = defaultVariantColor,
     sx: sxProp,
     ...rest
-  },
-  ref,
-) => {
+  } = inProps;
   const theme = useTheme();
   const [colorMode] = useColorMode();
   const width = {

--- a/packages/react/src/radio/RadioGroup.js
+++ b/packages/react/src/radio/RadioGroup.js
@@ -1,24 +1,26 @@
 import { runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { useEffect, useState } from 'react';
+import { useDefaultProps } from '../default-props';
 import config from '../shared/config';
 import useAutoId from '../utils/useAutoId';
 import { RadioGroupContext } from './context';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const RadioGroup = ({
-  children,
-  defaultValue,
-  disabled,
-  name,
-  size,
-  value: valueProp,
-  variantColor,
-  onChange,
-}) => {
+const RadioGroup = (inProps) => {
+  const {
+    children,
+    defaultValue,
+    disabled,
+    name: nameProp,
+    size,
+    value: valueProp,
+    variantColor,
+    onChange,
+  } = useDefaultProps({ props: inProps, name: 'RadioGroup' });
   const defaultId = useAutoId();
-  name = name ?? `${config.name}:RadioGroup-${defaultId}`;
+  const name = nameProp ?? `${config.name}:RadioGroup-${defaultId}`;
 
   const [state, setState] = useState({
     value: valueProp ?? defaultValue,

--- a/packages/react/src/resize-handle/ResizeHandle.js
+++ b/packages/react/src/resize-handle/ResizeHandle.js
@@ -1,20 +1,19 @@
 import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef, useCallback, useState } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useResizeHandleStyle } from './styles';
 import { getIsPassiveListenerSupported } from './utils';
 
-const ResizeHandle = forwardRef((
-  {
+const ResizeHandle = forwardRef((inProps, ref) => {
+  const {
     onMouseDown: onMouseDownProp,
     onResize: onResizeProp,
     onResizeEnd: onResizeEndProp,
     onResizeStart: onResizeStartProp,
     onTouchStart: onTouchStartProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'ResizeHandle' });
   const [isResizing, setIsResizing] = useState(false);
   const styleProps = useResizeHandleStyle({ isResizing });
 

--- a/packages/react/src/scrollbar/Scrollbar.js
+++ b/packages/react/src/scrollbar/Scrollbar.js
@@ -2,6 +2,7 @@ import { useHydrated, useMergeRefs } from '@tonic-ui/react-hooks';
 import { ensurePositiveFiniteNumber } from 'ensure-type';
 import React, { forwardRef, useCallback, useEffect, useState, useRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useContainerStyle,
   useScrollViewStyle,
@@ -18,8 +19,8 @@ import VerticalTrack from './VerticalTrack';
 import HorizontalThumb from './HorizontalThumb';
 import VerticalThumb from './VerticalThumb';
 
-const Scrollbar = forwardRef((
-  {
+const Scrollbar = forwardRef((inProps, ref) => {
+  const {
     children,
     width = 'auto',
     height = 'auto',
@@ -32,15 +33,17 @@ const Scrollbar = forwardRef((
     onScroll,
     onUpdate,
     overflow = 'auto',
-    overflowX,
-    overflowY,
+    overflowX: overflowXProp,
+    overflowY: overflowYProp,
     scrollLeft: scrollLeftProp,
     scrollTop: scrollTopProp,
     scrollViewRef: scrollViewRefProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Scrollbar' });
+
+  let overflowX = overflowXProp;
+  let overflowY = overflowYProp;
+
   { // Adjust overflow values
     overflowX = overflowX ?? overflow;
     overflowY = overflowY ?? overflow;

--- a/packages/react/src/search-input/SearchInput.js
+++ b/packages/react/src/search-input/SearchInput.js
@@ -1,6 +1,7 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { ensureString } from 'ensure-type';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import { useDefaultProps } from '../default-props';
 import { InputControl } from '../input';
 import useRunAfterUpdate from '../utils/useRunAfterUpdate';
 import SearchInputAdornment from './SearchInputAdornment';
@@ -11,8 +12,8 @@ import SearchInputSearchIcon from './SearchInputSearchIcon';
 const defaultSize = 'md';
 const defaultVariant = 'outline';
 
-const SearchInput = React.forwardRef((
-  {
+const SearchInput = forwardRef((inProps, ref) => {
+  const {
     defaultValue: defaultValueProp = '',
     disabled,
     endAdornment: endAdornmentProp,
@@ -25,9 +26,7 @@ const SearchInput = React.forwardRef((
     value: valueProp,
     variant = defaultVariant,
     ...rest
-  },
-  ref
-) => {
+  } = useDefaultProps({ props: inProps, name: 'SearchInput' });
   const nodeRef = useRef();
   const combinedRef = useMergeRefs(nodeRef, ref);
   const [value, setValue] = useState(ensureString(valueProp ?? defaultValueProp));

--- a/packages/react/src/select/Select.js
+++ b/packages/react/src/select/Select.js
@@ -3,22 +3,24 @@ import { AngleDownIcon } from '@tonic-ui/react-icons';
 import { ariaAttr, warnDeprecatedProps } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { getIconWrapperProps, useSelectStyle } from './styles';
 import splitProps from './split-props';
 
 const defaultVariant = 'outline';
 
-const Select = forwardRef((
-  {
+const Select = forwardRef((inProps, ref) => {
+  const {
     isInvalid, // deprecated
 
     children,
-    error,
-    variant,
+    error: errorProp,
+    variant = defaultVariant,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Select' });
+
+  let error = errorProp;
+
   { // deprecation warning
     const prefix = `${Select.displayName}:`;
 
@@ -32,9 +34,6 @@ const Select = forwardRef((
 
     error = error || isInvalid; // TODO: remove this line after deprecation
   }
-
-  // Use fallback values if values are null or undefined
-  variant = variant ?? defaultVariant;
 
   const iconWrapperProps = getIconWrapperProps();
   const ariaProps = {

--- a/packages/react/src/skeleton/Skeleton.js
+++ b/packages/react/src/skeleton/Skeleton.js
@@ -2,20 +2,22 @@ import { useOnceWhen } from '@tonic-ui/react-hooks';
 import { warnDeprecatedProps } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useSkeletonStyle,
 } from './styles';
 
 const defaultVariant = 'text';
 
-const Skeleton = forwardRef((
-  {
+const Skeleton = forwardRef((inProps, ref) => {
+  const {
     animation,
-    variant,
+    variant: variantProp = defaultVariant,
     ...rest
-  },
-  ref
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Skeleton' });
+
+  let variant = variantProp;
+
   { // deprecation warning
     const prefix = `${Skeleton.displayName}:`;
 
@@ -31,9 +33,6 @@ const Skeleton = forwardRef((
       variant = 'rectangle';
     }
   }
-
-  // Use fallback values if values are null or undefined
-  variant = variant ?? defaultVariant;
 
   const styleProps = useSkeletonStyle({ animation, variant });
 

--- a/packages/react/src/space/Space.js
+++ b/packages/react/src/space/Space.js
@@ -1,13 +1,20 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
+import { useSpaceStyle } from './styles';
 
-const Space = forwardRef((props, ref) => (
-  <Box
-    ref={ref}
-    display="inline-flex"
-    {...props}
-  />
-));
+const Space = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'Space' });
+  const styleProps = useSpaceStyle();
+
+  return (
+    <Box
+      ref={ref}
+      {...styleProps}
+      {...props}
+    />
+  );
+});
 
 Space.displayName = 'Space';
 

--- a/packages/react/src/space/styles.js
+++ b/packages/react/src/space/styles.js
@@ -1,0 +1,9 @@
+const useSpaceStyle = () => {
+  return {
+    display: 'inline-flex',
+  };
+};
+
+export {
+  useSpaceStyle,
+};

--- a/packages/react/src/spinner/Spinner.js
+++ b/packages/react/src/spinner/Spinner.js
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useSpinnerStyle,
   useSpinnerSVGBaseStyle,
@@ -9,17 +10,15 @@ import {
 
 const defaultSize = 'md';
 
-const Spinner = forwardRef((
-  {
+const Spinner = forwardRef((inProps, ref) => {
+  const {
     size = defaultSize,
     lineColor,
     lineWidth,
     trackColor,
     trackWidth,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Spinner' });
   const styleProps = useSpinnerStyle({ size });
   const svgBaseStyleProps = useSpinnerSVGBaseStyle({ size });
   const svgTrackStyleProps = useSpinnerSVGTrackStyle({ size, trackColor, trackWidth });

--- a/packages/react/src/stack/Stack.js
+++ b/packages/react/src/stack/Stack.js
@@ -1,21 +1,20 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import StackItem from './StackItem';
 import { useStackStyle } from './styles';
 
 const defaultDirection = 'column';
 
-const Stack = forwardRef((
-  {
+const Stack = forwardRef((inProps, ref) => {
+  const {
     children,
     direction: directionProp,
     flexDirection: flexDirectionProp,
     shouldWrapChildren,
     spacing = 0,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Stack' });
   const direction = (flexDirectionProp ?? directionProp) ?? defaultDirection;
   const styleProps = useStackStyle({ direction, spacing });
 

--- a/packages/react/src/switch/Switch.js
+++ b/packages/react/src/switch/Switch.js
@@ -2,13 +2,14 @@ import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { isNullish } from '@tonic-ui/utils';
 import React, { forwardRef, useRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { VisuallyHidden } from '../visually-hidden';
 import SwitchControlBox from './SwitchControlBox';
 import { defaultSize, defaultVariantColor } from './constants';
 import { useSwitchStyle } from './styles';
 
-const Switch = forwardRef((
-  {
+const Switch = forwardRef((inProps, ref) => {
+  const {
     checked,
     children,
     defaultChecked,
@@ -25,9 +26,7 @@ const Switch = forwardRef((
     value,
     variantColor = defaultVariantColor,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Switch' });
   const inputRef = useRef();
   const combinedInputRef = useMergeRefs(inputRefProp, inputRef);
   const styleProps = useSwitchStyle({ disabled });

--- a/packages/react/src/switch/SwitchControlBox.js
+++ b/packages/react/src/switch/SwitchControlBox.js
@@ -7,15 +7,13 @@ import { defaultSize, defaultVariantColor } from './constants';
 import { useSwitchControlBoxStyle } from './styles';
 import { useTheme } from '../theme';
 
-const SwitchControlBox = forwardRef((
-  {
+const SwitchControlBox = forwardRef((inProps, ref) => {
+  const {
     size = defaultSize,
     variantColor = defaultVariantColor,
     sx: sxProp,
     ...rest
-  },
-  ref,
-) => {
+  } = inProps;
   const theme = useTheme();
   const [colorMode] = useColorMode();
   const width = {

--- a/packages/react/src/table/Table.js
+++ b/packages/react/src/table/Table.js
@@ -1,22 +1,21 @@
 import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { LAYOUT_FLEXBOX, LAYOUT_TABLE, SIZE_MEDIUM, VARIANT_DEFAULT } from './constants';
 import { TableContext } from './context';
 import { useTableStyle } from './styles';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const Table = forwardRef((
-  {
+const Table = forwardRef((inProps, ref) => {
+  const {
     layout = LAYOUT_FLEXBOX,
     role: roleProp,
     size = SIZE_MEDIUM,
     variant = VARIANT_DEFAULT,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Table' });
   const as = layout === LAYOUT_TABLE ? 'table' : undefined;
   const role = roleProp ?? 'table';
   const context = getMemoizedState({

--- a/packages/react/src/table/TableBody.js
+++ b/packages/react/src/table/TableBody.js
@@ -1,6 +1,7 @@
 import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { GROUP_VARIANT_BODY, LAYOUT_TABLE } from './constants';
 import { TableGroupContext } from './context';
 import { useTableBodyStyle } from './styles';
@@ -8,13 +9,11 @@ import useTable from './useTable';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const TableBody = forwardRef((
-  {
+const TableBody = forwardRef((inProps, ref) => {
+  const {
     role: roleProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TableBody' });
   const { layout } = useTable();
   const as = layout === LAYOUT_TABLE ? 'tbody' : undefined;
   const role = roleProp ?? 'rowgroup';

--- a/packages/react/src/table/TableCell.js
+++ b/packages/react/src/table/TableCell.js
@@ -1,19 +1,18 @@
 import { ensureArray } from 'ensure-type';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { GROUP_VARIANT_HEADER, GROUP_VARIANT_BODY, GROUP_VARIANT_FOOTER, LAYOUT_TABLE, VARIANT_OUTLINE } from './constants';
 import { useTableCellStyle } from './styles';
 import useTable from './useTable';
 import useTableGroup from './useTableGroup';
 
-const TableCell = forwardRef((
-  {
+const TableCell = forwardRef((inProps, ref) => {
+  const {
     role: roleProp,
     sx: sxProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TableCell' });
   const { layout, size, variant } = useTable();
   const groupContext = useTableGroup();
   const groupVariant = groupContext?.groupVariant ?? GROUP_VARIANT_BODY;

--- a/packages/react/src/table/TableFooter.js
+++ b/packages/react/src/table/TableFooter.js
@@ -1,6 +1,7 @@
 import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { GROUP_VARIANT_FOOTER, LAYOUT_TABLE } from './constants';
 import { TableGroupContext } from './context';
 import { useTableFooterStyle } from './styles';
@@ -8,13 +9,11 @@ import useTable from './useTable';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const TableFooter = forwardRef((
-  {
+const TableFooter = forwardRef((inProps, ref) => {
+  const {
     role: roleProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TableFooter' });
   const { layout } = useTable();
   const as = layout === LAYOUT_TABLE ? 'tfoot' : undefined;
   const role = roleProp ?? 'rowgroup';

--- a/packages/react/src/table/TableHeader.js
+++ b/packages/react/src/table/TableHeader.js
@@ -1,6 +1,7 @@
 import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { GROUP_VARIANT_HEADER, LAYOUT_TABLE } from './constants';
 import { TableGroupContext } from './context';
 import { useTableHeaderStyle } from './styles';
@@ -8,13 +9,11 @@ import useTable from './useTable';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const TableHeader = forwardRef((
-  {
+const TableHeader = forwardRef((inProps, ref) => {
+  const {
     role: roleProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TableHeader' });
   const { layout } = useTable();
   const as = layout === LAYOUT_TABLE ? 'thead' : undefined;
   const role = roleProp ?? 'rowgroup';

--- a/packages/react/src/table/TableHeaderCell.js
+++ b/packages/react/src/table/TableHeaderCell.js
@@ -1,16 +1,15 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { GROUP_VARIANT_HEADER, LAYOUT_TABLE } from './constants';
 import { useTableCellStyle } from './styles';
 import useTable from './useTable';
 
-const TableHeaderCell = forwardRef((
-  {
+const TableHeaderCell = forwardRef((inProps, ref) => {
+  const {
     role: roleProp,
     ...rest
-  },
-  ref
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TableHeaderCell' });
   const { layout, size, variant } = useTable();
   const groupVariant = GROUP_VARIANT_HEADER;
   const as = layout === LAYOUT_TABLE ? 'th' : undefined;

--- a/packages/react/src/table/TableHeaderRow.js
+++ b/packages/react/src/table/TableHeaderRow.js
@@ -1,16 +1,15 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { GROUP_VARIANT_HEADER, LAYOUT_TABLE } from './constants';
 import { useTableRowStyle } from './styles';
 import useTable from './useTable';
 
-const TableHeaderRow = forwardRef((
-  {
+const TableHeaderRow = forwardRef((inProps, ref) => {
+  const {
     role: roleProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TableHeaderRow' });
   const { layout, variant } = useTable();
   const groupVariant = GROUP_VARIANT_HEADER;
   const as = layout === LAYOUT_TABLE ? 'tr' : undefined;

--- a/packages/react/src/table/TableRow.js
+++ b/packages/react/src/table/TableRow.js
@@ -1,17 +1,16 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { GROUP_VARIANT_BODY, LAYOUT_TABLE } from './constants';
 import { useTableRowStyle } from './styles';
 import useTable from './useTable';
 import useTableGroup from './useTableGroup';
 
-const TableRow = forwardRef((
-  {
+const TableRow = forwardRef((inProps, ref) => {
+  const {
     role: roleProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TableRow' });
   const { layout, variant } = useTable();
   const groupContext = useTableGroup();
   const groupVariant = groupContext?.groupVariant ?? GROUP_VARIANT_BODY;

--- a/packages/react/src/table/TableScrollbar.js
+++ b/packages/react/src/table/TableScrollbar.js
@@ -1,14 +1,13 @@
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import { Scrollbar } from '../scrollbar';
 import { useTableScrollbarTrackStyle } from './styles';
 
-const TableScrollbar = forwardRef((
-  {
+const TableScrollbar = forwardRef((inProps, ref) => {
+  const {
     children,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TableScrollbar' });
   const trackStyleProps = useTableScrollbarTrackStyle();
 
   return (

--- a/packages/react/src/tabs/Tab.js
+++ b/packages/react/src/tabs/Tab.js
@@ -3,22 +3,21 @@ import { ariaAttr, callEventHandlers, isNullOrUndefined, warnDeprecatedProps } f
 import { ensureFunction } from 'ensure-type';
 import React, { forwardRef, useState } from 'react';
 import { ButtonBase } from '../button';
+import { useDefaultProps } from '../default-props';
 import config from '../shared/config';
 import { useTabStyle } from './styles';
 import useTabs from './useTabs';
 
 const isIndexEqual = (index1, index2) => !isNullOrUndefined(index1) && !isNullOrUndefined(index2) && (index1 === index2);
 
-const Tab = forwardRef((
-  {
+const Tab = forwardRef((inProps, ref) => {
+  const {
     children,
     disabled: disabledProp,
     index: indexProp,
     onClick,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Tab' });
   const [index, setIndex] = useState(indexProp);
   const context = useTabs();
   const registerTab = ensureFunction(context?.registerTab);

--- a/packages/react/src/tabs/TabList.js
+++ b/packages/react/src/tabs/TabList.js
@@ -1,15 +1,14 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useTabListStyle } from './styles';
 import useTabs from './useTabs';
 
-const TabList = forwardRef((
-  {
+const TabList = forwardRef((inProps, ref) => {
+  const {
     'aria-label': ariaLabel,
     ...rest
-  },
-  ref
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TabList' });
   const context = useTabs();
   const orientation = context?.orientation;
   const styleProps = useTabListStyle({ orientation });

--- a/packages/react/src/tabs/TabPanel.js
+++ b/packages/react/src/tabs/TabPanel.js
@@ -3,20 +3,19 @@ import { ariaAttr, isNullOrUndefined, warnDeprecatedProps } from '@tonic-ui/util
 import { ensureFunction } from 'ensure-type';
 import React, { forwardRef, useState } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import config from '../shared/config';
 import useTabs from './useTabs';
 import { useTabPanelStyle } from './styles';
 
 const isIndexEqual = (index1, index2) => !isNullOrUndefined(index1) && !isNullOrUndefined(index2) && (index1 === index2);
 
-const TabPanel = forwardRef((
-  {
+const TabPanel = forwardRef((inProps, ref) => {
+  const {
     children,
     index: indexProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TabPanel' });
   const [index, setIndex] = useState(indexProp);
   const context = useTabs();
   const registerTabPanel = ensureFunction(context?.registerTabPanel);

--- a/packages/react/src/tabs/TabPanels.js
+++ b/packages/react/src/tabs/TabPanels.js
@@ -1,7 +1,10 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
-const TabPanels = forwardRef((props, ref) => {
+const TabPanels = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'TabPanels' });
+
   return (
     <Box
       ref={ref}

--- a/packages/react/src/tabs/Tabs.js
+++ b/packages/react/src/tabs/Tabs.js
@@ -3,6 +3,7 @@ import { isNullOrUndefined, runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { forwardRef, useEffect, useReducer } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { defaultOrientation, defaultVariant } from './constants';
 import { TabsContext } from './context';
 import { useTabsStyle } from './styles';
@@ -14,8 +15,8 @@ const stateReducer = (prevState, nextState) => ({
   ...(typeof nextState === 'function' ? nextState(prevState) : nextState),
 });
 
-const Tabs = forwardRef((
-  {
+const Tabs = forwardRef((inProps, ref) => {
+  const {
     children,
     defaultIndex = 0,
     disabled,
@@ -24,9 +25,7 @@ const Tabs = forwardRef((
     orientation = defaultOrientation,
     variant = defaultVariant,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Tabs' });
   const tabMap = useConst(() => new Map());
   const tabPanelMap = useConst(() => new Map());
   const [state, setState] = useReducer(stateReducer, {

--- a/packages/react/src/tag/Tag.js
+++ b/packages/react/src/tag/Tag.js
@@ -2,14 +2,15 @@ import { ariaAttr, runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useTagStyle } from './styles';
 import TagCloseButton from './TagCloseButton';
 import { TagContext } from './context';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const Tag = forwardRef((
-  {
+const Tag = forwardRef((inProps, ref) => {
+  const {
     children,
     disabled,
     error,
@@ -18,9 +19,7 @@ const Tag = forwardRef((
     size = 'md',
     variant = 'solid',
     ...rest
-  },
-  ref
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Tag' });
   const ariaProps = {
     'aria-disabled': ariaAttr(disabled),
     'aria-invalid': ariaAttr(error),

--- a/packages/react/src/tag/TagCloseButton.js
+++ b/packages/react/src/tag/TagCloseButton.js
@@ -2,17 +2,16 @@ import { CloseSIcon } from '@tonic-ui/react-icons';
 import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
+import { useDefaultProps } from '../default-props';
 import { useTagCloseButtonStyle } from './styles';
 import useTag from './useTag';
 
-const TagCloseButton = forwardRef((
-  {
+const TagCloseButton = forwardRef((inProps, ref) => {
+  const {
     children,
     onClick: onClickProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TagCloseButton' });
   const tagContext = useTag(); // context might be an undefined value
   const {
     disabled,

--- a/packages/react/src/text/Text.js
+++ b/packages/react/src/text/Text.js
@@ -1,14 +1,13 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useTextStyle } from './styles';
 
-const Text = forwardRef((
-  {
+const Text = forwardRef((inProps, ref) => {
+  const {
     size,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Text' });
   const styleProps = useTextStyle({ size });
 
   return (

--- a/packages/react/src/text/TextLabel.js
+++ b/packages/react/src/text/TextLabel.js
@@ -1,14 +1,13 @@
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import Text from './Text';
 import { useTextLabelStyle } from './styles';
 
-const TextLabel = forwardRef((
-  {
+const TextLabel = forwardRef((inProps, ref) => {
+  const {
     size,
     ...rest
-  },
-  ref
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TextLabel' });
   const styleProps = useTextLabelStyle({ size });
 
   return (

--- a/packages/react/src/textarea/Textarea.js
+++ b/packages/react/src/textarea/Textarea.js
@@ -1,19 +1,15 @@
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import { InputBase } from '../input';
 import { useTextareaStyle } from './styles';
 
 const defaultVariant = 'outline';
 
-const Textarea = forwardRef((
-  {
-    variant,
+const Textarea = forwardRef((inProps, ref) => {
+  const {
+    variant = defaultVariant,
     ...rest
-  },
-  ref,
-) => {
-  // Use the default variant if variant is null or undefined
-  variant = variant ?? defaultVariant;
-
+  } = useDefaultProps({ props: inProps, name: 'Textarea' });
   const styleProps = useTextareaStyle({ variant });
 
   return (

--- a/packages/react/src/theme/ThemeProvider.js
+++ b/packages/react/src/theme/ThemeProvider.js
@@ -1,9 +1,10 @@
 import {
-  ThemeProvider as EmotionThemeProvider,
+  ThemeProvider as StyledEngineThemeProvider,
 } from '@emotion/react';
 import originalTheme from '@tonic-ui/theme';
 import { ensurePlainObject, ensureString } from 'ensure-type';
 import React, { useMemo } from 'react';
+import { DefaultPropsProvider } from '../default-props';
 import CSSVariables from './CSSVariables';
 import defaultTheme from './theme';
 import flatten from './utils/flatten';
@@ -75,10 +76,12 @@ const ThemeProvider = ({
   }, [theme]);
 
   return (
-    <EmotionThemeProvider theme={computedTheme}>
-      <CSSVariables />
-      {children}
-    </EmotionThemeProvider>
+    <StyledEngineThemeProvider theme={computedTheme}>
+      <DefaultPropsProvider value={computedTheme.components}>
+        <CSSVariables />
+        {children}
+      </DefaultPropsProvider>
+    </StyledEngineThemeProvider>
   );
 };
 

--- a/packages/react/src/theme/theme.js
+++ b/packages/react/src/theme/theme.js
@@ -6,6 +6,7 @@ const theme = {
     prefix: 'tonic',
     useCSSVariables: false,
   },
+  components: {},
   icons: [],
 };
 

--- a/packages/react/src/toast/Toast.js
+++ b/packages/react/src/toast/Toast.js
@@ -2,6 +2,7 @@ import { runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import ToastCloseButton from './ToastCloseButton';
 import ToastIcon from './ToastIcon';
 import ToastMessage from './ToastMessage';
@@ -15,17 +16,15 @@ import {
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const Toast = forwardRef((
-  {
+const Toast = forwardRef((inProps, ref) => {
+  const {
     appearance = defaultAppearance,
     icon,
     isClosable = false,
     onClose,
     children,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Toast' });
   const context = getMemoizedState({
     appearance,
     icon,

--- a/packages/react/src/toast/ToastCloseButton.js
+++ b/packages/react/src/toast/ToastCloseButton.js
@@ -2,19 +2,18 @@ import { CloseSIcon } from '@tonic-ui/react-icons';
 import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
+import { useDefaultProps } from '../default-props';
 import {
   useToastCloseButtonStyle,
 } from './styles';
 import useToast from './useToast';
 
-const ToastCloseButton = forwardRef((
-  {
+const ToastCloseButton = forwardRef((inProps, ref) => {
+  const {
     children,
     onClick: onClickProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'ToastCloseButton' });
   const alertContext = useToast(); // context might be an undefined value
   const {
     // The `isClosable` prop determines whether the close button should be displayed and allows for control over its positioning

--- a/packages/react/src/toast/ToastContainer.js
+++ b/packages/react/src/toast/ToastContainer.js
@@ -1,11 +1,14 @@
 import { ensureString } from 'ensure-type';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
-const ToastContainer = forwardRef(({
-  placement,
-  ...rest
-}, ref) => {
+const ToastContainer = forwardRef((inProps, ref) => {
+  const {
+    placement: placementProp,
+    ...rest
+  } = useDefaultProps({ props: inProps, name: 'ToastContainer' });
+
   const styleProps = {
     boxSizing: 'border-box',
     maxHeight: '100%',
@@ -15,7 +18,7 @@ const ToastContainer = forwardRef(({
     zIndex: 'toast',
   };
 
-  placement = ensureString(placement);
+  const placement = ensureString(placementProp);
 
   if (placement.includes('top')) {
     styleProps.top = 0;

--- a/packages/react/src/toast/ToastController.js
+++ b/packages/react/src/toast/ToastController.js
@@ -2,16 +2,18 @@ import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef, useCallback, useRef, useState } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import useTimeout from '../utils/useTimeout';
 
-const ToastController = forwardRef(({
-  children,
-  duration = null,
-  onClose,
-  onMouseEnter: onMouseEnterProp,
-  onMouseLeave: onMouseLeaveProp,
-  ...rest
-}, ref) => {
+const ToastController = forwardRef((inProps, ref) => {
+  const {
+    children,
+    duration = null,
+    onClose,
+    onMouseEnter: onMouseEnterProp,
+    onMouseLeave: onMouseLeaveProp,
+    ...rest
+  } = useDefaultProps({ props: inProps, name: 'ToastController' });
   const nodeRef = useRef();
   const combinedRef = useMergeRefs(nodeRef, ref);
   const [delay, setDelay] = useState(duration);

--- a/packages/react/src/toast/ToastIcon.js
+++ b/packages/react/src/toast/ToastIcon.js
@@ -6,13 +6,15 @@ import {
 } from '@tonic-ui/react-icons';
 import React, { forwardRef, useMemo } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { Icon } from '../icon';
 import {
   useToastIconStyle,
 } from './styles';
 import useToast from './useToast';
 
-const ToastIcon = forwardRef((props, ref) => {
+const ToastIcon = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'ToastIcon' });
   const toastContext = useToast(); // context might be an undefined value
   const {
     appearance,

--- a/packages/react/src/toast/ToastManager.js
+++ b/packages/react/src/toast/ToastManager.js
@@ -7,6 +7,7 @@ import { isElement, isValidElementType } from 'react-is';
 import {
   TransitionGroup,
 } from 'react-transition-group';
+import { useDefaultProps } from '../default-props';
 import { Portal } from '../portal';
 import ToastContainer from './ToastContainer';
 import ToastController from './ToastController';
@@ -40,13 +41,14 @@ const getToastPlacementByState = (state, id) => {
   return toast?.placement;
 };
 
-const ToastManager = ({
-  TransitionComponent = ToastTransition,
-  TransitionProps,
-  children,
-  containerRef,
-  placement: placementProp = defaultPlacement,
-}) => {
+const ToastManager = (inProps) => {
+  const {
+    TransitionComponent = ToastTransition,
+    TransitionProps,
+    children,
+    containerRef,
+    placement: placementProp = defaultPlacement,
+  } = useDefaultProps({ props: inProps, name: 'ToastManager' });
   const isHydrated = useHydrated();
   const [state, setState] = useState(() => (
     placements.reduce((acc, placement) => {

--- a/packages/react/src/toast/ToastMessage.js
+++ b/packages/react/src/toast/ToastMessage.js
@@ -1,11 +1,13 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useToastMessageStyle,
 } from './styles';
 import useToast from './useToast';
 
-const ToastMessage = forwardRef((props, ref) => {
+const ToastMessage = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'ToastMessage' });
   const alertContext = useToast(); // context might be an undefined value
   const {
     isClosable,

--- a/packages/react/src/toast/ToastTransition.js
+++ b/packages/react/src/toast/ToastTransition.js
@@ -3,6 +3,7 @@ import { createTransitionStyle, getEnterTransitionProps, getExitTransitionProps,
 import React, { forwardRef, useEffect, useRef } from 'react';
 import { Transition } from 'react-transition-group';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
 const getScale = value => {
   return `scale(${value}, ${value ** 2})`;
@@ -48,8 +49,8 @@ const defaultTimeout = {
 
 const Wrapper = forwardRef((props, ref) => <Box ref={ref} {...props} />);
 
-const ToastTransition = forwardRef((
-  {
+const ToastTransition = forwardRef((inProps, ref) => {
+  const {
     appear = false, // do not perform the enter transition when it first mounts
     children,
     easing = defaultEasing,
@@ -57,9 +58,7 @@ const ToastTransition = forwardRef((
     style,
     timeout = defaultTimeout,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'ToastTransition' });
   const nodeRef = useRef(null);
   const combinedRef = useMergeRefs(nodeRef, ref);
   const wrapperRef = useRef(null);

--- a/packages/react/src/tooltip/Tooltip.js
+++ b/packages/react/src/tooltip/Tooltip.js
@@ -1,5 +1,6 @@
 import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import { useDefaultProps } from '../default-props';
 import { Popper } from '../popper';
 import config from '../shared/config';
 import { Grow } from '../transitions';
@@ -13,8 +14,8 @@ const getMemoizedState = memoize(state => ({ ...state }));
 
 const defaultPlacement = 'bottom';
 
-const Tooltip = forwardRef((
-  {
+const Tooltip = forwardRef((inProps, ref) => {
+  const {
     // TooltipContent props
     PopperComponent = Popper,
     PopperProps,
@@ -46,9 +47,7 @@ const Tooltip = forwardRef((
     openOnFocus = true,
     placement = defaultPlacement,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Tooltip' });
   const tooltipContentRef = useRef(null);
   const tooltipTriggerRef = useRef(null);
   const [mousePageX, setMousePageX] = useState(0);

--- a/packages/react/src/tooltip/TooltipArrow.js
+++ b/packages/react/src/tooltip/TooltipArrow.js
@@ -1,18 +1,17 @@
 import { getComputedStyle, isHTMLElement } from '@tonic-ui/utils';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useTooltipArrowStyle } from './styles';
 import useTooltip from './useTooltip';
 
-const TooltipArrow = forwardRef((
-  {
+const TooltipArrow = forwardRef((inProps, ref) => {
+  const {
     arrowHeight = 4,
     arrowWidth = 8,
     sx,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TooltipArrow' });
   const {
     placement,
     tooltipContentRef,

--- a/packages/react/src/tooltip/TooltipContent.js
+++ b/packages/react/src/tooltip/TooltipContent.js
@@ -9,6 +9,7 @@ import {
 import { ensureArray, ensureFiniteNumber } from 'ensure-type';
 import React, { forwardRef, useMemo, useRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { Popper } from '../popper';
 import { Grow } from '../transitions';
 import TooltipArrow from './TooltipArrow';
@@ -30,8 +31,8 @@ const mapPlacementToTransformOrigin = placement => ({
   'right-end': 'left bottom',
 }[placement]);
 
-const TooltipContent = forwardRef((
-  {
+const TooltipContent = forwardRef((inProps, ref) => {
+  const {
     PopperComponent = Popper,
     PopperProps,
     TooltipArrowComponent = TooltipArrow,
@@ -40,9 +41,7 @@ const TooltipContent = forwardRef((
     TransitionProps,
     children,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TooltipContent' });
   const isHydrated = useHydrated();
   const nodeRef = useRef(null);
   const combinedRef = useMergeRefs(nodeRef, ref);

--- a/packages/react/src/tooltip/TooltipTrigger.js
+++ b/packages/react/src/tooltip/TooltipTrigger.js
@@ -2,12 +2,13 @@ import { useEventListener, useMergeRefs } from '@tonic-ui/react-hooks';
 import { callEventHandlers, getOwnerDocument } from '@tonic-ui/utils';
 import React, { cloneElement, forwardRef, useState } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { mergeRefs } from '../utils/refs';
 import { useTooltipTriggerStyle } from './styles';
 import useTooltip from './useTooltip';
 
-const TooltipTrigger = forwardRef((
-  {
+const TooltipTrigger = forwardRef((inProps, ref) => {
+  const {
     children,
     shouldWrapChildren = false,
     onBlur: onBlurProp,
@@ -18,9 +19,7 @@ const TooltipTrigger = forwardRef((
     onMouseMove: onMouseMoveProp,
     onPointerDown: onPointerDownProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TooltipTrigger' });
   const {
     closeOnClick,
     closeOnEsc,

--- a/packages/react/src/transitions/Collapse.js
+++ b/packages/react/src/transitions/Collapse.js
@@ -3,6 +3,7 @@ import { createTransitionStyle, getEnterTransitionProps, getExitTransitionProps,
 import React, { forwardRef, useEffect, useRef } from 'react';
 import { Transition } from 'react-transition-group';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
 const mapStateToVariantStyle = (state, props) => {
   const variantStyle = {
@@ -41,8 +42,8 @@ const defaultTimeout = {
 
 const Wrapper = forwardRef((props, ref) => <Box ref={ref} {...props} />);
 
-const Collapse = forwardRef((
-  {
+const Collapse = forwardRef((inProps, ref) => {
+  const {
     appear = false, // do not perform the enter transition when it first mounts
     children,
     collapsedHeight = 0,
@@ -51,9 +52,7 @@ const Collapse = forwardRef((
     style,
     timeout = defaultTimeout,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Collapse' });
   const nodeRef = useRef(null);
   const combinedRef = useMergeRefs(nodeRef, ref);
   const wrapperRef = useRef(null);

--- a/packages/react/src/transitions/Fade.js
+++ b/packages/react/src/transitions/Fade.js
@@ -3,6 +3,7 @@ import { createTransitionStyle, getEnterTransitionProps, getExitTransitionProps,
 import React, { forwardRef, useEffect, useRef } from 'react';
 import { Transition } from 'react-transition-group';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
 const mapStateToVariantStyle = (state, props) => {
   const variantStyle = {
@@ -33,8 +34,8 @@ const defaultTimeout = {
   exit: transitionDuration.leavingScreen,
 };
 
-const Fade = forwardRef((
-  {
+const Fade = forwardRef((inProps, ref) => {
+  const {
     appear = false, // do not perform the enter transition when it first mounts
     children,
     easing = defaultEasing,
@@ -42,9 +43,7 @@ const Fade = forwardRef((
     style,
     timeout = defaultTimeout,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Fade' });
   const nodeRef = useRef(null);
   const combinedRef = useMergeRefs(nodeRef, ref);
 

--- a/packages/react/src/transitions/Grow.js
+++ b/packages/react/src/transitions/Grow.js
@@ -4,6 +4,7 @@ import { ensureFiniteNumber } from 'ensure-type';
 import React, { forwardRef, useCallback, useEffect, useRef } from 'react';
 import { Transition } from 'react-transition-group';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
 const getScale = value => {
   return `scale(${value}, ${value ** 2})`;
@@ -47,8 +48,8 @@ const getAutoHeightDuration = height => {
   return Math.round((4 + 15 * (value ** 0.25) + value / 5) * 10);
 };
 
-const Grow = forwardRef((
-  {
+const Grow = forwardRef((inProps, ref) => {
+  const {
     appear = false, // do not perform the enter transition when it first mounts
     children,
     easing = defaultEasing,
@@ -56,9 +57,7 @@ const Grow = forwardRef((
     style,
     timeout = 'auto',
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Grow' });
   const timer = useRef(null);
   const autoTimeout = useRef(0);
   const nodeRef = useRef(null);

--- a/packages/react/src/transitions/Scale.js
+++ b/packages/react/src/transitions/Scale.js
@@ -4,6 +4,7 @@ import { ensureArray } from 'ensure-type';
 import React, { forwardRef, useEffect, useRef } from 'react';
 import { Transition } from 'react-transition-group';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
 const mapStateToVariantStyle = (state, props) => {
   const variantStyle = {
@@ -49,8 +50,8 @@ const defaultTimeout = {
   exit: 150,
 };
 
-const Scale = forwardRef((
-  {
+const Scale = forwardRef((inProps, ref) => {
+  const {
     appear = false, // do not perform the enter transition when it first mounts
     children,
     easing = defaultEasing,
@@ -59,9 +60,7 @@ const Scale = forwardRef((
     style,
     timeout = defaultTimeout,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Scale' });
   const nodeRef = useRef(null);
   const combinedRef = useMergeRefs(nodeRef, ref);
 

--- a/packages/react/src/transitions/Slide.js
+++ b/packages/react/src/transitions/Slide.js
@@ -3,6 +3,7 @@ import { createTransitionStyle, getEnterTransitionProps, getExitTransitionProps,
 import React, { forwardRef, useEffect, useRef } from 'react';
 import { Transition } from 'react-transition-group';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
 const DIRECTION_LEFT = 'left';
 const DIRECTION_RIGHT = 'right';
@@ -60,8 +61,8 @@ const defaultTimeout = {
   exit: transitionDuration.leavingScreen,
 };
 
-const Slide = forwardRef((
-  {
+const Slide = forwardRef((inProps, ref) => {
+  const {
     appear = false, // do not perform the enter transition when it first mounts
     children,
     direction = DIRECTION_DOWN,
@@ -70,9 +71,7 @@ const Slide = forwardRef((
     style,
     timeout = defaultTimeout,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Slide' });
   const nodeRef = useRef(null);
   const combinedRef = useMergeRefs(nodeRef, ref);
 

--- a/packages/react/src/transitions/Zoom.js
+++ b/packages/react/src/transitions/Zoom.js
@@ -3,6 +3,7 @@ import { createTransitionStyle, getEnterTransitionProps, getExitTransitionProps,
 import React, { forwardRef, useEffect, useRef } from 'react';
 import { Transition } from 'react-transition-group';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 
 const mapStateToVariantStyle = (state, props) => {
   const variantStyle = {
@@ -33,8 +34,8 @@ const defaultTimeout = {
   exit: transitionDuration.leavingScreen,
 };
 
-const Zoom = forwardRef((
-  {
+const Zoom = forwardRef((inProps, ref) => {
+  const {
     appear = false, // do not perform the enter transition when it first mounts
     children,
     easing = defaultEasing,
@@ -42,9 +43,7 @@ const Zoom = forwardRef((
     style,
     timeout = defaultTimeout,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Zoom' });
   const nodeRef = useRef(null);
   const combinedRef = useMergeRefs(nodeRef, ref);
 

--- a/packages/react/src/tree/Tree.js
+++ b/packages/react/src/tree/Tree.js
@@ -4,6 +4,7 @@ import { ensureArray } from 'ensure-type';
 import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { Descendant } from '../utils/descendant';
 import useAutoId from '../utils/useAutoId';
 import { TreeContext } from './context';
@@ -11,8 +12,8 @@ import { useTreeStyle } from './styles';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const Tree = forwardRef((
-  {
+const Tree = forwardRef((inProps, ref) => {
+  const {
     defaultExpanded = [],
     defaultSelected = [],
     expanded: expandedProp,
@@ -28,9 +29,7 @@ const Tree = forwardRef((
     onNodeToggle: onNodeToggleProp,
     selected: selectedProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'Tree' });
   const treeId = useAutoId(idProp);
   const [focusedNodeId, setFocusedNodeId] = useState(null);
   const [expandedNodeIds, setExpandedNodeIds] = useState(ensureArray(expandedProp ?? defaultExpanded));

--- a/packages/react/src/tree/TreeItem.js
+++ b/packages/react/src/tree/TreeItem.js
@@ -4,6 +4,7 @@ import { ensureFiniteNumber } from 'ensure-type';
 import memoize from 'micro-memoize';
 import React, { forwardRef, isValidElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { Collapse } from '../transitions';
 import { Descendant, useDescendant } from '../utils/descendant';
 import { TreeItemContext } from './context';
@@ -12,8 +13,8 @@ import useTree from './useTree';
 
 const getMemoizedState = memoize(state => ({ ...state }));
 
-const TreeItem = forwardRef((
-  {
+const TreeItem = forwardRef((inProps, ref) => {
+  const {
     TransitionComponent = Collapse,
     TransitionProps,
     children,
@@ -22,9 +23,7 @@ const TreeItem = forwardRef((
     nodeId,
     render,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TreeItem' });
   const {
     focusNode,
     getIsNodeDisabled,

--- a/packages/react/src/tree/TreeItemContent.js
+++ b/packages/react/src/tree/TreeItemContent.js
@@ -2,20 +2,19 @@ import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef, useCallback } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import { useTheme } from '../theme';
 import { useTreeItemContentStyle } from './styles';
 import useTree from './useTree';
 import useTreeItem from './useTreeItem';
 
-const TreeItemContent = forwardRef((
-  {
+const TreeItemContent = forwardRef((inProps, ref) => {
+  const {
     onClick: onClickProp,
     onMouseDown: onMouseDownProp,
     style: styleProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TreeItemContent' });
   const { sizes } = useTheme();
   const {
     multiSelect,

--- a/packages/react/src/tree/TreeItemToggle.js
+++ b/packages/react/src/tree/TreeItemToggle.js
@@ -1,20 +1,19 @@
 import { ariaAttr, callEventHandlers } from '@tonic-ui/utils';
 import React, { forwardRef, useCallback } from 'react';
 import { ButtonBase } from '../button';
+import { useDefaultProps } from '../default-props';
 import {
   useTreeItemToggleStyle,
 } from './styles';
 import useTreeItem from './useTreeItem';
 
-const TreeItemToggle = forwardRef((
-  {
+const TreeItemToggle = forwardRef((inProps, ref) => {
+  const {
     children,
     disabled,
     onClick: onClickProp,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TreeItemToggle' });
   const {
     isExpanded,
     toggleExpansion,

--- a/packages/react/src/tree/TreeItemToggleIcon.js
+++ b/packages/react/src/tree/TreeItemToggleIcon.js
@@ -5,6 +5,7 @@ import { ensureBoolean } from 'ensure-type';
 import React, { forwardRef, useEffect, useRef } from 'react';
 import { Transition } from 'react-transition-group';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
 import {
   useTreeItemToggleIconStyle,
 } from './styles';
@@ -39,19 +40,16 @@ const defaultTimeout = {
   exit: Math.floor(133 * 0.7),
 };
 
-const TreeItemToggleIcon = forwardRef((
-  {
+const TreeItemToggleIcon = forwardRef((inProps, ref) => {
+  const {
     appear = false, // do not perform the enter transition when it first mounts
     children,
     disabled,
     easing = defaultEasing,
-    nodeId,
     style,
     timeout = defaultTimeout,
     ...rest
-  },
-  ref,
-) => {
+  } = useDefaultProps({ props: inProps, name: 'TreeItemToggleIcon' });
   const context = useTreeItem();
   const nodeRef = useRef(null);
   const combinedRef = useMergeRefs(nodeRef, ref);

--- a/packages/react/src/truncate/Truncate.js
+++ b/packages/react/src/truncate/Truncate.js
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
 import { Text } from '../text';
 import { useTruncateStyle } from './styles';
 
-const Truncate = forwardRef((props, ref) => {
+const Truncate = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'Truncate' });
   const styleProps = useTruncateStyle();
 
   return (

--- a/packages/react/src/visually-hidden/VisuallyHidden.js
+++ b/packages/react/src/visually-hidden/VisuallyHidden.js
@@ -1,18 +1,16 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
+import { useDefaultProps } from '../default-props';
+import { useVisuallyHiddenStyle } from './styles';
 
-const VisuallyHidden = forwardRef((props, ref) => {
+const VisuallyHidden = forwardRef((inProps, ref) => {
+  const props = useDefaultProps({ props: inProps, name: 'VisuallyHidden' });
+  const styleProps = useVisuallyHiddenStyle();
+
   return (
     <Box
       ref={ref}
-      position="absolute"
-      width={1}
-      height={1}
-      padding={0}
-      border={0}
-      overflow="hidden"
-      clipPath="inset(50%)"
-      whiteSpace="nowrap"
+      {...styleProps}
       {...props}
     />
   );

--- a/packages/react/src/visually-hidden/styles.js
+++ b/packages/react/src/visually-hidden/styles.js
@@ -1,0 +1,16 @@
+const useVisuallyHiddenStyle = () => {
+  return {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    padding: 0,
+    border: 0,
+    overflow: 'hidden',
+    clipPath: 'inset(50%)',
+    whiteSpace: 'nowrap',
+  };
+};
+
+export {
+  useVisuallyHiddenStyle,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4515,6 +4515,7 @@ __metadata:
     eslint-plugin-jsx-a11y: latest
     eslint-plugin-react: latest
     eslint-plugin-react-hooks: latest
+    glob: ^11.0.0
     jest: ^29.0.0
     jest-axe: ^8.0.0
     jest-environment-jsdom: ^29.0.0
@@ -8999,6 +9000,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "glob@npm:11.0.0"
+  dependencies:
+    foreground-child: ^3.1.0
+    jackspeak: ^4.0.1
+    minimatch: ^10.0.0
+    minipass: ^7.1.2
+    package-json-from-dist: ^1.0.0
+    path-scurry: ^2.0.0
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 8a2dd914d5776987be5244624d9491bbcaf19f2387e06783737003ff696ebfd2264190c47014f8709c1c02d8bc892f17660cf986c587b107e194c0a3151ab333
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.2.0":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -10319,6 +10336,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "jackspeak@npm:4.0.1"
+  dependencies:
+    "@isaacs/cliui": ^8.0.2
+    "@pkgjs/parseargs": ^0.11.0
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 7989d19eddeff0631ef653df413e26290db77dc3791438bd12b56bed1c0b24d5d535fdfec13cf35775cd5b47f8ee57d36fd0bceaf2df672b1f523533fd4184cc
+  languageName: node
+  linkType: hard
+
 "jake@npm:^10.8.5":
   version: 10.8.7
   resolution: "jake@npm:10.8.7"
@@ -11511,6 +11541,13 @@ __metadata:
   version: 10.2.0
   resolution: "lru-cache@npm:10.2.0"
   checksum: eee7ddda4a7475deac51ac81d7dd78709095c6fa46e8350dc2d22462559a1faa3b81ed931d5464b13d48cbd7e08b46100b6f768c76833912bc444b99c37e25db
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^11.0.0":
+  version: 11.0.1
+  resolution: "lru-cache@npm:11.0.1"
+  checksum: 6056230a99fb399234e82368b99586bd4740079e80649102f681b19337b7d8c6bc8dd7f8b8c59377c31d26deb89f548b717ae932e139b4b795879d920fccf820
   languageName: node
   linkType: hard
 
@@ -12890,6 +12927,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "minimatch@npm:10.0.1"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: f5b63c2f30606091a057c5f679b067f84a2cd0ffbd2dbc9143bda850afd353c7be81949ff11ae0c86988f07390eeca64efd7143ee05a0dab37f6c6b38a2ebb6c
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -13056,6 +13102,13 @@ __metadata:
   version: 7.0.4
   resolution: "minipass@npm:7.0.4"
   checksum: 87585e258b9488caf2e7acea242fd7856bbe9a2c84a7807643513a338d66f368c7d518200ad7b70a508664d408aa000517647b2930c259a8b1f9f0984f344a21
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 2bfd325b95c555f2b4d2814d49325691c7bee937d753814861b0b49d5edcda55cbbf22b6b6a60bb91eddac8668771f03c5ff647dcd9d0f798e9548b9cdc46ee3
   languageName: node
   linkType: hard
 
@@ -14067,6 +14120,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "package-json-from-dist@npm:1.0.0"
+  checksum: ac706ec856a5a03f5261e4e48fa974f24feb044d51f84f8332e2af0af04fbdbdd5bbbfb9cbbe354190409bc8307c83a9e38c6672c3c8855f709afb0006a009ea
+  languageName: node
+  linkType: hard
+
 "pacote@npm:^15.2.0":
   version: 15.2.0
   resolution: "pacote@npm:15.2.0"
@@ -14218,6 +14278,16 @@ __metadata:
     lru-cache: ^10.2.0
     minipass: ^5.0.0 || ^6.0.2 || ^7.0.0
   checksum: 6739b4290f7d1a949c61c758b481c07ac7d1a841964c68cf5e1fa153d7e18cbde4872b37aadf9c5173c800d627f219c47945859159de36c977dd82419997b9b8
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: ^11.0.0
+    minipass: ^7.1.2
+  checksum: 9953ce3857f7e0796b187a7066eede63864b7e1dfc14bf0484249801a5ab9afb90d9a58fc533ebb1b552d23767df8aa6a2c6c62caf3f8a65f6ce336a97bbb484
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-922/

### **User description**
- [x] accordion (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/40a661bffc233c5ff31048fc0ee31d411f2abf92)
  - Accordion
  - AccordionBody
  - AccordionContent
  - AccordionHeader
  - AccordionItem
  - AccordionToggle
  - AccordionToggleIcon
- [x] alert (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/bdd329e4f648b3caa93568deaea962bebac1014e)
  - Alert
  - AlertCloseButton
  - AlertIcon
  - AlertMessage
- [x] badge (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/14c5805d16a1c1d759424c27442901db1a75d3ed)
  - Badge
- [x] ~box~
- [x] button (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/2173038ffd0be52f87006aa7e8c6863e59d39195)
  - Button
  - ButtonBase
  - ButtonGroup
  - ButtonLink
- [x] checkbox (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/9121fa5b3eaf0507317318f3a4074093fa98a8f2)
  - Checkbox
  - CheckboxGroup
- [x] code (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/d0ee6bfac52578db51d4eda7f7ccae117afedf0b)
  - Code
- [x] color-mode (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/d72be6c560818d25538e99c75ed810e3d8135cdf)
  - ColorModeProvider
  - DarkMode
  - InvertedMode
  - LightMode
- [x] color-style (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/f42945e2f4660a7bc6318b93ba874ba92b2cdfdd)
  - ColorStyleProvider
- [x] ~css-baseline~
- [x] date-pickers (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/9e7f816f909c40f9ecb8c68a059fb14f46b4a63b)
  - Calendar
  - DatePicker
- [x] ~default-props~
- [x] ~deprecated~
- [x] divider (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/e1bb7d4133353b4a7bd89702982ef11771703999)
  - Divider
- [x] drawer (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/170e534178306670997fec0a2030e7ac8e3e6f34)
  - Drawer
  - DrawerBody
  - DrawerCloseButton
  - DrawerContainer
  - DrawerContent
  - DrawerFooter
  - DrawerHeader
  - DrawerOverlay
- [x] flex (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/63b72b7b202eeec169b2980c818525c2c24c3019)
  - Flex
- [x] grid (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/ad5d0434764b158ba73f354ec0eb726cdfca5ffd)
  - Grid
- [x] icon (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/6208388ceff55cdb9d6214d2d34331ae54041658)
  - Icon
- [x] image (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/8d8e6f9ad5e558d2424bb5a3bdc09d2889167ad5)
  - Image
- [x] input (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/dcb3c52d842dbcbac9576f7d0e81ce9f3e365811)
  - Input
  - InputAdornment
  - InputBase
  - InputControl
  - InputGroup
  - InputGroupAddon
  - InputGroupAppend
  - InputGroupPrepend
- [x] link (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/d3ea09bc76a8295edd7b2d91357d5397613f3d47)
  - Link
  - LinkButton
- [x] menu (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/c817ff165c05338915f8f1b2303979a30577ed83)
  - MenuButton
  - MenuContent
  - MenuDivider
  - MenuGroup
  - MenuItem
  - Menu
  - MenuList
  - MenuToggleIcon
  - MenuToggle
  - SubmenuContent
  - Submenu
  - SubmenuList
  - SubmenuToggle
- [x] modal (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/6208388ceff55cdb9d6214d2d34331ae54041658)
  - Modal
  - ModalBody
  - ModalCloseButton
  - ModalContainer
  - ModalContent
  - ModalFooter
  - ModalHeader
  - ModalOverlay
- [x] pagination (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/819c3cf78816081eef738b7f7ae6abb5f7f131e2)
  - Pagination
  - PaginationItem
- [x] popover (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/a62b3e6c6d6ec4417130ba1ab75887429f323a04)
  - Popover
  - PopoverArrow
  - PopoverBody
  - PopoverContent
  - PopoverFooter
  - PopoverHeader
  - PopoverTrigger
- [x] ~popper~
- [x] portal (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/fd6471ca147322c46e1ee52cdfdfbfd820c4ff77)
  - Portal
  - PortalManager
- [x] progress (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/09c8e38ff6fafbba125039170bb5dbfe49ff92f2)
  - LinearProgress
- [x] ~provider~
- [x] radio (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/688d98353fd8800c1fbb6b11abeed56dced93c87)
  - Radio
  - RadioGroup
- [x] resize-handle (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/b796ca531590937bd7b02d0d9d4cf5bf38eafffd)
  - ResizeHandle
- [x] scrollbar (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/733568130dbd10609460a1fadfe3268d3c95f6bc)
  - Scrollbar
- [x] search-input (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/299a7023675d6b64e850ac44b31a18df9cb42996)
  - SearchInput
- [x] select (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/e9e7a181c2773b0a17859a2255352c67ce3c86ea)
  - Select
- [x] skeleton (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/b97e9f380c08cd004e7de0ee0ef01bae835e191c)
  - Skeleton
- [x] space (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/35709425a9c8b6b20250b6c2525623b08225abfc)
  - Space
- [x] spinner (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/192601f5ebdf959d89a44936014b4e856e0afc21)
  - Spinner
- [x] stack (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/f7dc2ec5f0be03310e983a6c175da4648112e602)
  - Stack
- [x] switch (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/c22fb25f5e9902dedcf12fd7973a0b40f2890a07)
  - Switch
- [x] table (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/dd564923bf81ab3fa1b82acb534c1e383e963915)
  - Table
  - TableHeader
  - TableHeaderRow
  - TableHeaderCell
  - TableBody
  - TableFooter
  - TableRow
  - TableCell
  - TableScrollbar
- [x] tabs (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/28253d59fa8b0a9da1ae3cbbdf41a24c653d3cd5)
  - Tab
  - Tabs
  - TabList
  - TabPanel
  - TabPanels
- [x] tag (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/3af9c55855695ef0fd5f0a5d0caf8055c83f2786)
  - Tag
  - TagCloseButton
- [x] text (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/3d7f1d8f1ade8eef5755c7f42c40024de7a899c0)
  - Text
- [x] textarea (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/34b840de5c5df50da5789e44fd22d91655ef2872)
  - Textarea
- [x] ~theme~
- [x] toast (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/cbf7b955c564a71fafdd4f0444845d4ded346976)
  - Toast
  - ToastCloseButton
  - ToastContainer
  - ToastController
  - ToastIcon
  - ToastManager
  - ToastMessage
  - ToastTransition
- [x] tooltip (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/45b0b69204f4657f23ec5c7eea6e03d11b9b7170)
  - Tooltip
  - TooltipArrow
  - TooltipContent
  - TooltipTrigger
- [x] transitions (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/ab87b30c986a963c4e024fd9afa16572e8f51f78)
  - Collapse
  - Fade
  - Grow
  - Scale
  - Slide
  - Zoom
- [x] tree (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/50e3a5a5390265a4945b0cf6eab4357836b80616)
  - Tree
  - TreeItem
  - TreeItemContent
  - TreeItemToggle
  - TreeItemToggleIcon
- [x] truncate (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/86a99663d5d75e2065f7ce4278d9be2effbcae04)
  - Truncate
- [x] visually-hidden (https://github.com/trendmicro-frontend/tonic-ui/pull/922/commits/9ed8c1488656fb1085bbc2f677a4bf329e0bfd19)
  - VisuallyHidden

___

### **PR Type**
enhancement, tests, documentation


___

### **Description**
- Introduced `DefaultPropsProvider` component and `useDefaultProps` hook to manage default props in React components.
- Integrated `DefaultPropsProvider` into `ThemeProvider` to pass theme components.
- Applied `useDefaultProps` to `Accordion` and `Alert` components for simplified props handling.
- Added `resolveProps` function and corresponding tests to merge default and provided props.
- Updated documentation to include examples and configuration for default props.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>DefaultPropsProvider.js</strong><dd><code>Add DefaultPropsProvider component for default props context</code></dd></summary>
<hr>

packages/react/src/default-props/DefaultPropsProvider.js

<li>Introduced <code>DefaultPropsProvider</code> component.<br> <li> Provides default props context to children components.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/922/files#diff-4443360626424d916b7b15728905151d5f2ea853fe6b47908133968f1f9a6015">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useDefaultProps.js</strong><dd><code>Implement useDefaultProps hook for resolving props</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/default-props/useDefaultProps.js

<li>Implemented <code>useDefaultProps</code> hook.<br> <li> Resolves component props with default props from context.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/922/files#diff-9e2b08718529118de37fa2be5ac0db9b273da8acad370e183c598387a0da497f">+41/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resolveProps.js</strong><dd><code>Add resolveProps function for merging props</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/default-props/resolveProps.js

<li>Added <code>resolveProps</code> function.<br> <li> Merges default props with provided props.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/922/files#diff-53301b65a7bef0cc35b47b0f8ba99680614b01378a1e0da0688800746fd01095">+48/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ThemeProvider.js</strong><dd><code>Integrate DefaultPropsProvider into ThemeProvider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/theme/ThemeProvider.js

<li>Integrated <code>DefaultPropsProvider</code> into <code>ThemeProvider</code>.<br> <li> Passes theme components to <code>DefaultPropsProvider</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/922/files#diff-160beeffe0ffadbdf65362186091704b4ba343fcce76c7914d9954625048c064">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Accordion.js</strong><dd><code>Apply useDefaultProps to Accordion component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/accordion/Accordion.js

<li>Applied <code>useDefaultProps</code> to <code>Accordion</code> component.<br> <li> Simplified props handling with default props.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/922/files#diff-cfa647c29e6203dbe5c3fb6329e955573b629bf5e0339450a74841e163a8e8ed">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Alert.js</strong><dd><code>Apply useDefaultProps to Alert component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/alert/Alert.js

<li>Applied <code>useDefaultProps</code> to <code>Alert</code> component.<br> <li> Simplified props handling with default props.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/922/files#diff-d8cfcfaae3e2bcf738bd9ccc98126719796b95d3f4afe3932a47de6e61b2e21f">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Export default props utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/index.js

<li>Exported <code>DefaultPropsProvider</code> and <code>useDefaultProps</code>.<br> <li> Made default props utilities available for import.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/922/files#diff-c4c3158cfb4d39b9c02a04153dcace5a54c332a56108e62f2b5fe01b9ee087be">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>resolveProps.test.js</strong><dd><code>Add tests for resolveProps function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/default-props/__tests__/resolveProps.test.js

<li>Added tests for <code>resolveProps</code> function.<br> <li> Validates merging logic of default and provided props.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/922/files#diff-7617e3a17d9989c2165f8f3246cc7aca87ed516ce079ef0db72a611ab6340e62">+105/-0</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>_app.page.js</strong><dd><code>Configure theme components for default props</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react-docs/pages/_app.page.js

<li>Added theme components configuration for default props.<br> <li> Provided example for setting default props.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/922/files#diff-49f34385f9684300c85addd1b7dc358db1cfc469e159754c0ea81c147fa99672">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.page.mdx</strong><dd><code>Update migration guide link for icons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react-docs/pages/getting-started/icons/index.page.mdx

- Updated migration guide link for icons.



</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/922/files#diff-f55dd194c18094e739418caa88fc922f3c5e639e802f991a79e1fa84257dafda">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

