### PR TITLE
fix: resolve bug with `isNameConflictRef.current` in `Checkbox` and `Radio` components

### DIFF
--- a/.changeset/tonic-ui-927b.md
+++ b/.changeset/tonic-ui-927b.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": minor
+---
+
+fix: resolve bug with `isNameConflictRef.current` in `Checkbox` and `Radio` components

--- a/packages/react/src/checkbox/Checkbox.js
+++ b/packages/react/src/checkbox/Checkbox.js
@@ -58,7 +58,7 @@ const Checkbox = forwardRef((inProps, ref) => {
     disabled = (disabled ?? checkboxGroupDisabled);
 
     const isNameConflict = (!isNullish(name) && !isNullish(checkboxGroupName) && (name !== checkboxGroupName));
-    if (process.env.NODE_ENV !== 'production' && isNameConflict && !isNameConflict.current) {
+    if (process.env.NODE_ENV !== 'production' && isNameConflict && !isNameConflictRef.current) {
       // Log the warning message only once
       console.error(
         `Warning: The \`Checkbox\` has a \`name\` prop ("${name}") that conflicts with the \`CheckboxGroup\`'s \`name\` prop ("${checkboxGroupName}")`

--- a/packages/react/src/radio/Radio.js
+++ b/packages/react/src/radio/Radio.js
@@ -57,7 +57,7 @@ const Radio = forwardRef((inProps, ref) => {
     disabled = (disabled ?? radioGroupDisabled);
 
     const isNameConflict = (!isNullish(name) && !isNullish(radioGroupName) && (name !== radioGroupName));
-    if (process.env.NODE_ENV !== 'production' && isNameConflict && !isNameConflict.current) {
+    if (process.env.NODE_ENV !== 'production' && isNameConflict && !isNameConflictRef.current) {
       // Log the warning message only once
       console.error(
         `Warning: The \`Radio\` has a \`name\` prop ("${name}") that conflicts with the \`RadioGroup\`'s \`name\` prop ("${radioGroupName}")`


### PR DESCRIPTION
### **User description**
This PR aims to fix a bug introduced in PR #930.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the `Checkbox` component by correcting the reference to `isNameConflictRef.current`.
- Fixed a bug in the `Radio` component by correcting the reference to `isNameConflictRef.current`.
- Ensured that warning messages are logged correctly when there is a name conflict in both `Checkbox` and `Radio` components.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Checkbox.js</strong><dd><code>Fix reference bug in `Checkbox` component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/checkbox/Checkbox.js

<li>Fixed reference to <code>isNameConflictRef.current</code> in the <code>Checkbox</code> <br>component.<br> <li> Ensured the warning message logs correctly when there is a name <br>conflict.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/935/files#diff-d5ae55a366f7b950201c3eed96f52580aac6a13b4d1ff587e33bc597a67a5c51">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Radio.js</strong><dd><code>Fix reference bug in `Radio` component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/radio/Radio.js

<li>Fixed reference to <code>isNameConflictRef.current</code> in the <code>Radio</code> component.<br> <li> Ensured the warning message logs correctly when there is a name <br>conflict.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/935/files#diff-902e8001f5f749a8725aa09ca99a7020fb3923fca8861a8478b575090d353573">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information