### PR TITLE
feat(`react/checkbox`,`react/radio`): use `useEffectOnceWhen` hook to display warning message in non-production environments

### DIFF
--- a/packages/react/src/radio/Radio.js
+++ b/packages/react/src/radio/Radio.js
@@ -1,4 +1,4 @@
-import { useMergeRefs } from '@tonic-ui/react-hooks';
+import { useEffectOnceWhen, useMergeRefs } from '@tonic-ui/react-hooks';
 import { callAll, isNullish } from '@tonic-ui/utils';
 import React, { forwardRef, useRef } from 'react';
 import { Box } from '../box';
@@ -39,7 +39,7 @@ const Radio = forwardRef((inProps, ref) => {
   const inputRef = useRef();
   const combinedInputRef = useMergeRefs(inputRefProp, inputRef);
   const radioGroupContext = useRadioGroup();
-  const isNameConflictRef = useRef(false);
+  let warningMessage = '';
 
   if (radioGroupContext) {
     const {
@@ -55,17 +55,11 @@ const Radio = forwardRef((inProps, ref) => {
       checked = (radioGroupValue === value);
     }
     disabled = (disabled ?? radioGroupDisabled);
-
-    const isNameConflict = (!isNullish(name) && !isNullish(radioGroupName) && (name !== radioGroupName));
-    if (process.env.NODE_ENV !== 'production' && isNameConflict && !isNameConflictRef.current) {
-      // Log the warning message only once
-      console.error(
-        `Warning: The \`Radio\` has a \`name\` prop ("${name}") that conflicts with the \`RadioGroup\`'s \`name\` prop ("${radioGroupName}")`
-      );
-      isNameConflictRef.current = true;
+    const isNameConflict = !isNullish(name) && !isNullish(radioGroupName) && (name !== radioGroupName);
+    if (isNameConflict) {
+      warningMessage = `Warning: The \`Radio\` has a \`name\` prop ("${name}") that conflicts with the \`RadioGroup\`'s \`name\` prop ("${radioGroupName}")`;
     }
     name = (name ?? radioGroupName);
-
     onChange = callAll(
       onChange,
       radioGroupOnChange,
@@ -78,6 +72,13 @@ const Radio = forwardRef((inProps, ref) => {
     size = size ?? defaultSize;
     variantColor = variantColor ?? defaultVariantColor;
   }
+
+  useEffectOnceWhen(() => {
+    if (process.env.NODE_ENV !== 'production' && !!warningMessage) {
+      // Log the warning message only once
+      console.error(warningMessage);
+    }
+  }, [!!warningMessage]);
 
   const styleProps = useRadioStyle({ disabled });
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced the `useEffectOnceWhen` hook in both `Checkbox` and `Radio` components to handle warning messages.
- Removed the `isNameConflictRef` logic and replaced it with a `warningMessage` variable to streamline warning message management.
- Ensured that warning messages about name conflicts are displayed only in non-production environments.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Checkbox.js</strong><dd><code>Use `useEffectOnceWhen` for warning messages in Checkbox</code>&nbsp; </dd></summary>
<hr>

packages/react/src/checkbox/Checkbox.js

<li>Added <code>useEffectOnceWhen</code> hook to manage warning messages.<br> <li> Removed <code>isNameConflictRef</code> and replaced with <code>warningMessage</code> logic.<br> <li> Display warning messages only in non-production environments.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/937/files#diff-d5ae55a366f7b950201c3eed96f52580aac6a13b4d1ff587e33bc597a67a5c51">+12/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Radio.js</strong><dd><code>Use `useEffectOnceWhen` for warning messages in Radio</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/radio/Radio.js

<li>Added <code>useEffectOnceWhen</code> hook to manage warning messages.<br> <li> Removed <code>isNameConflictRef</code> and replaced with <code>warningMessage</code> logic.<br> <li> Display warning messages only in non-production environments.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/937/files#diff-902e8001f5f749a8725aa09ca99a7020fb3923fca8861a8478b575090d353573">+12/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information