### PR TITLE
feat(utils): add `merge` and `isPlainObject`

### DIFF
--- a/.changeset/tonic-ui-945-utils.md
+++ b/.changeset/tonic-ui-945-utils.md
@@ -2,4 +2,4 @@
 "@tonic-ui/utils": minor
 ---
 
-feat(utils): add `deepmerge` and `isPlainObject`
+feat(utils): add `merge` and `isPlainObject`

--- a/.changeset/tonic-ui-945-utils.md
+++ b/.changeset/tonic-ui-945-utils.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/utils": minor
+---
+
+feat(utils): add `deepmerge` and `isPlainObject`

--- a/packages/utils/__tests__/index.test.js
+++ b/packages/utils/__tests__/index.test.js
@@ -37,7 +37,7 @@ test('should match expected exports', () => {
     'callAll',
     'callEventHandlers',
     'dataAttr',
-    'deepmerge',
+    'merge',
     'noop',
     'once',
     'runIfFn',

--- a/packages/utils/__tests__/index.test.js
+++ b/packages/utils/__tests__/index.test.js
@@ -10,6 +10,7 @@ test('should match expected exports', () => {
     'isNullish',
     'isNullOrUndefined',
     'isObject',
+    'isPlainObject',
     'isWhitespace',
 
     // dom
@@ -36,6 +37,7 @@ test('should match expected exports', () => {
     'callAll',
     'callEventHandlers',
     'dataAttr',
+    'deepmerge',
     'noop',
     'once',
     'runIfFn',

--- a/packages/utils/src/__tests__/index.test.js
+++ b/packages/utils/src/__tests__/index.test.js
@@ -38,7 +38,7 @@ test('should match expected exports', () => {
     'callAll',
     'callEventHandlers',
     'dataAttr',
-    'deepmerge',
+    'merge',
     'noop',
     'once',
     'runIfFn',

--- a/packages/utils/src/__tests__/index.test.js
+++ b/packages/utils/src/__tests__/index.test.js
@@ -11,6 +11,7 @@ test('should match expected exports', () => {
     'isNullish',
     'isNullOrUndefined',
     'isObject',
+    'isPlainObject',
     'isWhitespace',
 
     // dom
@@ -37,6 +38,7 @@ test('should match expected exports', () => {
     'callAll',
     'callEventHandlers',
     'dataAttr',
+    'deepmerge',
     'noop',
     'once',
     'runIfFn',

--- a/packages/utils/src/__tests__/shared.test.js
+++ b/packages/utils/src/__tests__/shared.test.js
@@ -87,6 +87,75 @@ describe('dataAttr', () => {
 });
 
 describe('merge', () => {
+  it('should replace the first array with the second array', () => {
+    // Second array fully replaces the first array
+    expect(merge(
+      [1, 2],
+      [3, 4, 5],
+    )).toEqual([3, 4, 5]);
+
+    // Second array replaces corresponding elements of the first array, leaving trailing elements
+    expect(merge(
+      [1, 2, 3],
+      [4, 5],
+    )).toEqual([4, 5, 3]);
+  });
+
+  it('should merge objects and replace array values correctly', () => {
+    const result = merge(
+      { arr: [1, 2, { a: 1 }] },
+      { arr: [3, 4, { b: 2 }] }
+    );
+    expect(result).toEqual({
+      arr: [3, 4, { b: 2 }]
+    });
+  });
+
+  it('should merge arrays within nested structures', () => {
+    const result = merge(
+      { arr: [1, [2, 3], { a: [1, 2] }] },
+      { arr: [4, [5, 6], { a: [3, 4] }] }
+    );
+    expect(result).toEqual({
+      arr: [4, [5, 6], { a: [3, 4] }]
+    });
+  });
+
+  it('should handle arrays with objects correctly', () => {
+    const target = {
+      items: [
+        { id: 1, value: 'old' },
+        { id: 2, nested: { prop: 'old' } }
+      ]
+    };
+    const source = {
+      items: [
+        { id: 1, value: 'new' },
+        { id: 2, nested: { prop: 'new' } }
+      ]
+    };
+    const result = merge(target, source);
+    expect(result.items[0].value).toBe('new');
+    expect(result.items[1].nested.prop).toBe('new');
+  });
+
+  it('should handle array mutation correctly with clone option', () => {
+    const target = { arr: [1, { a: 1 }] };
+    const source = { arr: [2, { b: 2 }] };
+    const result = merge(target, source, { clone: true });
+    result.arr[1].b = 3;
+    expect(source.arr[1].b).toBe(2);
+    expect(result.arr[1].b).toBe(3);
+  });
+
+  it('should handle circular references in arrays', () => {
+    const target = { arr: [] };
+    target.arr.push(target);
+    const source = { arr: [{ value: 'test' }] };
+    const result = merge(target, source);
+    expect(result.arr[0].value).toBe('test');
+  });
+
   it('should not be subject to prototype pollution via __proto__', () => {
     const result = merge(
       {},
@@ -95,7 +164,6 @@ describe('merge', () => {
         clone: false,
       }
     );
-
     expect(result.__proto__).toHaveProperty('isAdmin'); // eslint-disable-line no-proto
     expect({}).not.toHaveProperty('isAdmin');
   });
@@ -108,7 +176,6 @@ describe('merge', () => {
         clone: true,
       }
     );
-
     expect(result.constructor.prototype).toHaveProperty('isAdmin');
     expect({}).not.toHaveProperty('isAdmin');
   });
@@ -121,7 +188,6 @@ describe('merge', () => {
         clone: false,
       }
     );
-
     expect(result.prototype).toHaveProperty('isAdmin');
     expect({}).not.toHaveProperty('isAdmin');
   });
@@ -131,7 +197,6 @@ describe('merge', () => {
       {},
       JSON.parse('{ "myProperty": "a", "__proto__" : { "isAdmin" : true } }')
     );
-
     expect(result.__proto__).toHaveProperty('isAdmin'); // eslint-disable-line no-proto
     expect({}).not.toHaveProperty('isAdmin');
   });
@@ -140,7 +205,6 @@ describe('merge', () => {
     if (!/jsdom/.test(window.navigator.userAgent)) {
       this.skip();
     }
-
     const vmObject = runInNewContext('({hello: "realm"})');
     const result = merge({ hello: 'original' }, vmObject);
     expect(result.hello).toBe('realm');
@@ -182,13 +246,9 @@ describe('merge', () => {
   it('should deep clone source key object if target key does not exist', () => {
     const foo = { foo: { baz: 'test' } };
     const bar = {};
-
     const result = merge(bar, foo);
-
     expect(result).toEqual({ foo: { baz: 'test' } });
-
     result.foo.baz = 'new test';
-
     expect(result).toEqual({ foo: { baz: 'new test' } });
     expect(foo).toEqual({ foo: { baz: 'test' } });
   });

--- a/packages/utils/src/__tests__/shared.test.js
+++ b/packages/utils/src/__tests__/shared.test.js
@@ -4,7 +4,7 @@ import {
   callAll,
   callEventHandlers,
   dataAttr,
-  deepmerge,
+  merge,
   noop,
   once,
   runIfFn,
@@ -86,9 +86,9 @@ describe('dataAttr', () => {
   });
 });
 
-describe('deepmerge', () => {
+describe('merge', () => {
   it('should not be subject to prototype pollution via __proto__', () => {
-    const result = deepmerge(
+    const result = merge(
       {},
       JSON.parse('{ "myProperty": "a", "__proto__" : { "isAdmin" : true } }'),
       {
@@ -101,7 +101,7 @@ describe('deepmerge', () => {
   });
 
   it('should not be subject to prototype pollution via constructor', () => {
-    const result = deepmerge(
+    const result = merge(
       {},
       JSON.parse('{ "myProperty": "a", "constructor" : { "prototype": { "isAdmin" : true } } }'),
       {
@@ -114,7 +114,7 @@ describe('deepmerge', () => {
   });
 
   it('should not be subject to prototype pollution via prototype', () => {
-    const result = deepmerge(
+    const result = merge(
       {},
       JSON.parse('{ "myProperty": "a", "prototype": { "isAdmin" : true } }'),
       {
@@ -127,7 +127,7 @@ describe('deepmerge', () => {
   });
 
   it('should appropriately copy the fields without prototype pollution', () => {
-    const result = deepmerge(
+    const result = merge(
       {},
       JSON.parse('{ "myProperty": "a", "__proto__" : { "isAdmin" : true } }')
     );
@@ -142,7 +142,7 @@ describe('deepmerge', () => {
     }
 
     const vmObject = runInNewContext('({hello: "realm"})');
-    const result = deepmerge({ hello: 'original' }, vmObject);
+    const result = merge({ hello: 'original' }, vmObject);
     expect(result.hello).toBe('realm');
   });
 
@@ -150,13 +150,13 @@ describe('deepmerge', () => {
     const element = document.createElement('div');
     const element2 = document.createElement('div');
 
-    const result = deepmerge({ element }, { element: element2 });
+    const result = merge({ element }, { element: element2 });
 
     expect(result.element).toBe(element2);
   });
 
   it('should reset source when target is undefined', () => {
-    const result = deepmerge(
+    const result = merge(
       {
         '&.disabled': {
           color: 'red',
@@ -172,7 +172,7 @@ describe('deepmerge', () => {
   });
 
   it('should merge keys that do not exist in source', () => {
-    const result = deepmerge({ foo: { baz: 'test' } }, { foo: { bar: 'test' }, bar: 'test' });
+    const result = merge({ foo: { baz: 'test' } }, { foo: { bar: 'test' }, bar: 'test' });
     expect(result).toEqual({
       foo: { baz: 'test', bar: 'test' },
       bar: 'test',
@@ -183,7 +183,7 @@ describe('deepmerge', () => {
     const foo = { foo: { baz: 'test' } };
     const bar = {};
 
-    const result = deepmerge(bar, foo);
+    const result = merge(bar, foo);
 
     expect(result).toEqual({ foo: { baz: 'test' } });
 

--- a/packages/utils/src/__tests__/shared.test.js
+++ b/packages/utils/src/__tests__/shared.test.js
@@ -1,8 +1,10 @@
+import { runInNewContext } from 'node:vm';
 import {
   ariaAttr,
   callAll,
   callEventHandlers,
   dataAttr,
+  deepmerge,
   noop,
   once,
   runIfFn,
@@ -14,19 +16,14 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
-describe('ariaAttr / dataAttr', () => {
-  it('should render correct aria-* and data-* attributes', () => {
-    const ariaProps = {
+describe('ariaAttr', () => {
+  it('should render correct aria-* attributes', () => {
+    const ariaAttrs = {
       'aria-disabled': ariaAttr(true),
-      'data-disabled': dataAttr(true),
       'aria-selected': ariaAttr(false),
-      'data-selected': dataAttr(false),
     };
-
-    expect(ariaProps['aria-disabled']).toBe(true);
-    expect(ariaProps['data-disabled']).toBe('');
-    expect(ariaProps['aria-selected']).toBe(undefined);
-    expect(ariaProps['data-selected']).toBe(undefined);
+    expect(ariaAttrs['aria-disabled']).toBe(true);
+    expect(ariaAttrs['aria-selected']).toBe(undefined);
   });
 });
 
@@ -75,6 +72,125 @@ describe('callEventHandlers', () => {
     expect(fn1).toHaveBeenCalled();
     expect(fn2).toHaveBeenCalled();
     expect(fn3).not.toHaveBeenCalled();
+  });
+});
+
+describe('dataAttr', () => {
+  it('should render correct data-* attributes', () => {
+    const dataAttrs = {
+      'data-disabled': dataAttr(true),
+      'data-selected': dataAttr(false),
+    };
+    expect(dataAttrs['data-disabled']).toBe('');
+    expect(dataAttrs['data-selected']).toBe(undefined);
+  });
+});
+
+describe('deepmerge', () => {
+  it('should not be subject to prototype pollution via __proto__', () => {
+    const result = deepmerge(
+      {},
+      JSON.parse('{ "myProperty": "a", "__proto__" : { "isAdmin" : true } }'),
+      {
+        clone: false,
+      }
+    );
+
+    expect(result.__proto__).toHaveProperty('isAdmin'); // eslint-disable-line no-proto
+    expect({}).not.toHaveProperty('isAdmin');
+  });
+
+  it('should not be subject to prototype pollution via constructor', () => {
+    const result = deepmerge(
+      {},
+      JSON.parse('{ "myProperty": "a", "constructor" : { "prototype": { "isAdmin" : true } } }'),
+      {
+        clone: true,
+      }
+    );
+
+    expect(result.constructor.prototype).toHaveProperty('isAdmin');
+    expect({}).not.toHaveProperty('isAdmin');
+  });
+
+  it('should not be subject to prototype pollution via prototype', () => {
+    const result = deepmerge(
+      {},
+      JSON.parse('{ "myProperty": "a", "prototype": { "isAdmin" : true } }'),
+      {
+        clone: false,
+      }
+    );
+
+    expect(result.prototype).toHaveProperty('isAdmin');
+    expect({}).not.toHaveProperty('isAdmin');
+  });
+
+  it('should appropriately copy the fields without prototype pollution', () => {
+    const result = deepmerge(
+      {},
+      JSON.parse('{ "myProperty": "a", "__proto__" : { "isAdmin" : true } }')
+    );
+
+    expect(result.__proto__).toHaveProperty('isAdmin'); // eslint-disable-line no-proto
+    expect({}).not.toHaveProperty('isAdmin');
+  });
+
+  it('should merge objects across realms', function test() {
+    if (!/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const vmObject = runInNewContext('({hello: "realm"})');
+    const result = deepmerge({ hello: 'original' }, vmObject);
+    expect(result.hello).toBe('realm');
+  });
+
+  it('should not merge HTML elements', () => {
+    const element = document.createElement('div');
+    const element2 = document.createElement('div');
+
+    const result = deepmerge({ element }, { element: element2 });
+
+    expect(result.element).toBe(element2);
+  });
+
+  it('should reset source when target is undefined', () => {
+    const result = deepmerge(
+      {
+        '&.disabled': {
+          color: 'red',
+        },
+      },
+      {
+        '&.disabled': undefined,
+      }
+    );
+    expect(result).toEqual({
+      '&.disabled': undefined,
+    });
+  });
+
+  it('should merge keys that do not exist in source', () => {
+    const result = deepmerge({ foo: { baz: 'test' } }, { foo: { bar: 'test' }, bar: 'test' });
+    expect(result).toEqual({
+      foo: { baz: 'test', bar: 'test' },
+      bar: 'test',
+    });
+  });
+
+  it('should deep clone source key object if target key does not exist', () => {
+    const foo = { foo: { baz: 'test' } };
+    const bar = {};
+
+    const result = deepmerge(bar, foo);
+
+    expect(result).toEqual({ foo: { baz: 'test' } });
+
+    result.foo.baz = 'new test';
+
+    expect(result).toEqual({ foo: { baz: 'new test' } });
+    expect(foo).toEqual({ foo: { baz: 'test' } });
   });
 });
 

--- a/packages/utils/src/assertion.js
+++ b/packages/utils/src/assertion.js
@@ -30,6 +30,16 @@ export const isObject = (value) => {
   return !isNullish(value) && (typeof value === 'object' || typeof value === 'function') && !Array.isArray(value);
 };
 
+// https://github.com/sindresorhus/is-plain-obj/blob/main/index.js
+export const isPlainObject = (value) => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return (prototype === null || prototype === Object.prototype || Object.getPrototypeOf(prototype) === null) && !(Symbol.toStringTag in value) && !(Symbol.iterator in value);
+};
+
 export const isWhitespace = (value) => {
   // @see https://github.com/jonschlinkert/whitespace-regex
   // eslint-disable-next-line no-control-regex

--- a/packages/utils/src/shared.js
+++ b/packages/utils/src/shared.js
@@ -16,17 +16,20 @@ const _joinWords = (words) => {
 };
 
 const _deepClone = (source) => {
-  if (!isPlainObject(source)) {
-    return source;
+  if (Array.isArray(source)) {
+    return source.map((item) => _deepClone(item));
   }
 
-  const output = {};
+  if (isPlainObject(source)) {
+    const output = {};
+    Object.keys(source).forEach((key) => {
+      output[key] = _deepClone(source[key]);
+    });
+    return output;
+  }
 
-  Object.keys(source).forEach((key) => {
-    output[key] = _deepClone(source[key]);
-  });
-
-  return output;
+  // For primitive values and other types, return as is
+  return source;
 };
 
 export const ariaAttr = (condition) => {
@@ -55,25 +58,33 @@ export const dataAttr = (condition) => {
 };
 
 export const merge = (target, source, options = { clone: true }) => {
-  const output = options.clone ? { ...target } : target;
-
-  if (isPlainObject(target) && isPlainObject(source)) {
-    Object.keys(source).forEach((key) => {
-      if (
-        isPlainObject(source[key]) &&
-        Object.prototype.hasOwnProperty.call(target, key) &&
-        isPlainObject(target[key])
-      ) {
-        output[key] = merge(target[key], source[key], options);
-      } else if (options.clone) {
-        output[key] = isPlainObject(source[key]) ? _deepClone(source[key]) : source[key];
+  // Merge arrays
+  if (Array.isArray(target) && Array.isArray(source)) {
+    const output = options.clone ? [...target] : target;
+    source.forEach((item, index) => {
+      if (isPlainObject(item) && isPlainObject(output[index])) {
+        output[index] = merge(output[index], item, options);
       } else {
-        output[key] = source[key];
+        output[index] = options.clone ? _deepClone(item) : item;
       }
     });
+    return output;
   }
 
-  return output;
+  // Merge plain objects
+  if (isPlainObject(target) && isPlainObject(source)) {
+    const output = options.clone ? { ...target } : target;
+    Object.keys(source).forEach((key) => {
+      if (isPlainObject(source[key]) && isPlainObject(output[key]) && Object.prototype.hasOwnProperty.call(output, key)) {
+        output[key] = merge(output[key], source[key], options);
+      } else {
+        output[key] = options.clone ? _deepClone(source[key]) : source[key];
+      }
+    });
+    return output;
+  }
+
+  return options.clone ? _deepClone(source) : source;
 };
 
 export const noop = () => {};

--- a/packages/utils/src/shared.js
+++ b/packages/utils/src/shared.js
@@ -1,4 +1,5 @@
 import { ensureArray, ensureBoolean, ensureString } from 'ensure-type';
+import { isPlainObject } from './assertion';
 
 const _joinWords = (words) => {
   words = ensureArray(words);
@@ -12,6 +13,20 @@ const _joinWords = (words) => {
     return `'${words[0]}' and '${words[1]}'`;
   }
   return `'${words.slice(0, -1).join('\', \'')}', and '${words.slice(-1)}'`;
+};
+
+const _deepClone = (source) => {
+  if (!isPlainObject(source)) {
+    return source;
+  }
+
+  const output = {};
+
+  Object.keys(source).forEach((key) => {
+    output[key] = _deepClone(source[key]);
+  });
+
+  return output;
 };
 
 export const ariaAttr = (condition) => {
@@ -37,6 +52,28 @@ export const callEventHandlers = (...fns) => {
 
 export const dataAttr = (condition) => {
   return condition ? '' : undefined;
+};
+
+export const deepmerge = (target, source, options = { clone: true }) => {
+  const output = options.clone ? { ...target } : target;
+
+  if (isPlainObject(target) && isPlainObject(source)) {
+    Object.keys(source).forEach((key) => {
+      if (
+        isPlainObject(source[key]) &&
+        Object.prototype.hasOwnProperty.call(target, key) &&
+        isPlainObject(target[key])
+      ) {
+        output[key] = deepmerge(target[key], source[key], options);
+      } else if (options.clone) {
+        output[key] = isPlainObject(source[key]) ? _deepClone(source[key]) : source[key];
+      } else {
+        output[key] = source[key];
+      }
+    });
+  }
+
+  return output;
 };
 
 export const noop = () => {};

--- a/packages/utils/src/shared.js
+++ b/packages/utils/src/shared.js
@@ -15,17 +15,29 @@ const _joinWords = (words) => {
   return `'${words.slice(0, -1).join('\', \'')}', and '${words.slice(-1)}'`;
 };
 
-const _deepClone = (source) => {
+const _deepClone = (source, seen = new WeakMap()) => {
+  // Use a `WeakMap` to track objects and detect circular references.
+  // If the object has been cloned before, return the cached cloned version.
+  if (seen.has(source)) {
+    return seen.get(source);
+  }
+
   if (Array.isArray(source)) {
-    return source.map((item) => _deepClone(item));
+    const clonedArray = [];
+    seen.set(source, clonedArray);
+    for (let i = 0; i < source.length; ++i) {
+      clonedArray[i] = _deepClone(source[i], seen);
+    }
+    return clonedArray;
   }
 
   if (isPlainObject(source)) {
-    const output = {};
-    Object.keys(source).forEach((key) => {
-      output[key] = _deepClone(source[key]);
-    });
-    return output;
+    const clonedObject = {};
+    seen.set(source, clonedObject);
+    for (const [key, value] of Object.entries(source)) {
+      clonedObject[key] = _deepClone(value, seen);
+    }
+    return clonedObject;
   }
 
   // For primitive values and other types, return as is
@@ -74,13 +86,13 @@ export const merge = (target, source, options = { clone: true }) => {
   // Merge plain objects
   if (isPlainObject(target) && isPlainObject(source)) {
     const output = options.clone ? { ...target } : target;
-    Object.keys(source).forEach((key) => {
-      if (isPlainObject(source[key]) && isPlainObject(output[key]) && Object.prototype.hasOwnProperty.call(output, key)) {
-        output[key] = merge(output[key], source[key], options);
+    for (const [key, value] of Object.entries(source)) {
+      if (isPlainObject(value) && Object.prototype.hasOwnProperty.call(output, key) && isPlainObject(output[key])) {
+        output[key] = merge(output[key], value, options);
       } else {
-        output[key] = options.clone ? _deepClone(source[key]) : source[key];
+        output[key] = options.clone ? _deepClone(value) : value;
       }
-    });
+    }
     return output;
   }
 

--- a/packages/utils/src/shared.js
+++ b/packages/utils/src/shared.js
@@ -54,7 +54,7 @@ export const dataAttr = (condition) => {
   return condition ? '' : undefined;
 };
 
-export const deepmerge = (target, source, options = { clone: true }) => {
+export const merge = (target, source, options = { clone: true }) => {
   const output = options.clone ? { ...target } : target;
 
   if (isPlainObject(target) && isPlainObject(source)) {
@@ -64,7 +64,7 @@ export const deepmerge = (target, source, options = { clone: true }) => {
         Object.prototype.hasOwnProperty.call(target, key) &&
         isPlainObject(target[key])
       ) {
-        output[key] = deepmerge(target[key], source[key], options);
+        output[key] = merge(target[key], source[key], options);
       } else if (options.clone) {
         output[key] = isPlainObject(source[key]) ? _deepClone(source[key]) : source[key];
       } else {


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Introduced `merge` function in `shared.js` to merge objects with deep clone capability.
- Added `isPlainObject` function in `assertion.js` to check if a value is a plain object.
- Enhanced test coverage by adding tests for `merge` and `isPlainObject`.
- Refined existing tests for `isEmptyArray`, `isEmptyObject`, `ariaAttr`, and `dataAttr`.
- Updated documentation to reflect new utility functions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>assertion.js</strong><dd><code>Add `isPlainObject` function to assertion utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/utils/src/assertion.js

<li>Added <code>isPlainObject</code> function to check if a value is a plain object.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/946/files#diff-9bb98fab345c19425bb6bf765ba09c993de88b5f9fd1e21b6a8023d23bebcef3">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shared.js</strong><dd><code>Add `merge` function with deep clone capability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/utils/src/shared.js

<li>Added <code>merge</code> function to merge objects.<br> <li> Implemented deep clone functionality for objects.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/946/files#diff-aeb582188d4c096beb54627221b5a143210c728a566d8328830e6d31e1fee116">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>assertion.test.js</strong><dd><code>Add tests for `isPlainObject` and refine existing tests</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/utils/src/__tests__/assertion.test.js

<li>Added tests for <code>isPlainObject</code>.<br> <li> Removed redundant test cases for <code>isEmptyArray</code> and <code>isEmptyObject</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/946/files#diff-4bf4b53006c680c0acf9f2c42a99e7ddcc18d16db29bd8380ea85f4939a99f2b">+50/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shared.test.js</strong><dd><code>Add tests for `merge` function and refine attribute tests</code></dd></summary>
<hr>

packages/utils/src/__tests__/shared.test.js

<li>Added tests for <code>merge</code> function.<br> <li> Separated tests for <code>ariaAttr</code> and <code>dataAttr</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/946/files#diff-d141d14bbe6649708f67ab3f9f67f00741331be53b2f0be2fa5335b2e2e9ad97">+126/-10</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.test.js</strong><dd><code>Update export tests to include new utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/utils/__tests__/index.test.js

- Updated expected exports to include `isPlainObject` and `merge`.



</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/946/files#diff-c93f9ef14e4b40fb5601e0e75a3330dbf8f8e9ab9b10d7669666e3c9f3d8e31f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tonic-ui-945-utils.md</strong><dd><code>Document new utility functions in changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/tonic-ui-945-utils.md

- Documented the addition of `merge` and `isPlainObject` functions.



</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/946/files#diff-d3e5b18d6b02e3b161c4c39cfc7565439aef3c9d5297bcb601961c6f4f900a43">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information