### PR TITLE
feat(styled-system): introduce `_has`, `_is`, and `_not` style props to support functional pseudo-class selectors

### DIFF
--- a/.changeset/tonic-ui-971.md
+++ b/.changeset/tonic-ui-971.md
@@ -1,0 +1,6 @@
+---
+"@tonic-ui/react": patch
+"@tonic-ui/styled-system": minor
+---
+
+feat(styled-system): introduce `_has`, `_is`, and `_not` style props to support functional pseudo-class selectors

--- a/packages/react-docs/pages/components/button-base/icon-button.js
+++ b/packages/react-docs/pages/components/button-base/icon-button.js
@@ -43,14 +43,14 @@ const useIconButtonStyle = ({ size = '8x' }) => {
       borderColor: focusBorderColor,
       boxShadow: focusBoxShadowBorderColor ? `inset 0 0 0 1px ${colors[focusBoxShadowBorderColor]}` : undefined,
       color: focusColor,
-    },
-    _focusHover: {
-      color: focusHoverColor,
-    },
-    _focusActive: {
-      borderColor: focusBorderColor,
-      boxShadow: focusBoxShadowBorderColor ? `inset 0 0 0 1px ${colors[focusBoxShadowBorderColor]}` : undefined,
-      color: focusActiveColor,
+      '&:hover': {
+        color: focusHoverColor,
+      },
+      '&:active': {
+        borderColor: focusBorderColor,
+        boxShadow: focusBoxShadowBorderColor ? `inset 0 0 0 1px ${colors[focusBoxShadowBorderColor]}` : undefined,
+        color: focusActiveColor,
+      },
     },
   };
 };

--- a/packages/react-docs/pages/components/tag/components/styles.js
+++ b/packages/react-docs/pages/components/tag/components/styles.js
@@ -79,8 +79,8 @@ const getOutlineEditableTagStyle = ({
         color: hoverColor,
       },
     },
-    _focusHover: {
-      '&:not([disabled])': {
+    _focus: {
+      '&:hover:not([disabled])': {
         borderColor: focusColor,
         color: hoverColor,
       },

--- a/packages/react-docs/pages/styled-system/pseudo-style-props/_has.js
+++ b/packages/react-docs/pages/styled-system/pseudo-style-props/_has.js
@@ -1,0 +1,26 @@
+import { Box } from '@tonic-ui/react';
+import React from 'react';
+
+const List = (props) => <Box as="ul" {...props} />;
+
+const ListItem = (props) => (
+  <Box
+    as="li"
+    _has={{
+      '+ li': {
+        color: 'red:50',
+      },
+    }}
+    {...props}
+  />
+);
+
+const App = () => (
+  <List>
+    <ListItem>First</ListItem>
+    <ListItem>Second</ListItem>
+    <ListItem>Third</ListItem>
+  </List>
+);
+
+export default App;

--- a/packages/react-docs/pages/styled-system/pseudo-style-props/_is.js
+++ b/packages/react-docs/pages/styled-system/pseudo-style-props/_is.js
@@ -1,0 +1,26 @@
+import { Box } from '@tonic-ui/react';
+import React from 'react';
+
+const List = (props) => <Box as="ul" {...props} />;
+
+const ListItem = (props) => (
+  <Box
+    as="li"
+    _is={{
+      ':first-of-type, :last-of-type': {
+        color: 'red:50',
+      },
+    }}
+    {...props}
+  />
+);
+
+const App = () => (
+  <List>
+    <ListItem>First</ListItem>
+    <ListItem>Second</ListItem>
+    <ListItem>Third</ListItem>
+  </List>
+);
+
+export default App;

--- a/packages/react-docs/pages/styled-system/pseudo-style-props/_not.js
+++ b/packages/react-docs/pages/styled-system/pseudo-style-props/_not.js
@@ -1,0 +1,26 @@
+import { Box } from '@tonic-ui/react';
+import React from 'react';
+
+const List = (props) => <Box as="ul" {...props} />;
+
+const ListItem = (props) => (
+  <Box
+    as="li"
+    _not={{
+      ':first-of-type, :last-of-type': {
+        color: 'red:50',
+      },
+    }}
+    {...props}
+  />
+);
+
+const App = () => (
+  <List>
+    <ListItem>First</ListItem>
+    <ListItem>Second</ListItem>
+    <ListItem>Third</ListItem>
+  </List>
+);
+
+export default App;

--- a/packages/react-docs/pages/styled-system/pseudo-style-props/index.page.mdx.template
+++ b/packages/react-docs/pages/styled-system/pseudo-style-props/index.page.mdx.template
@@ -70,11 +70,47 @@ Add the `_lastChild` prop to style an element that is the last element among its
 
 {render('./_lastChild')}
 
-### `:nth-of-type()`
+### `:has(<relative-selector-list>)`
+
+```jsx
+_has={{
+  '+ li': {
+    color: 'red:50',
+  },
+}}
+```
+
+{render('./_has')}
+
+### `:is(<forgiving-selector-list>)`
+
+```jsx
+_is={{
+  ':first-of-type, :last-of-type': {
+    color: 'red:50',
+  },
+}}
+```
+
+{render('./_is')}
+
+### `:not(<complex-selector-list>)`
+
+```jsx
+_not={{
+  ':first-of-type, :last-of-type': {
+    color: 'red:50',
+  },
+}}
+```
+
+{render('./_not')}
+
+### `:nth-of-type(<An+B> | even | odd)`
 
 Add the `_nthOfType` prop to match elements of a given type, based on their position among a group of siblings. The value can be represented as an array or an object in the following form:
 
-```
+```jsx
 _nthOfType={{
   '2n+1': {
     color: 'red:40',

--- a/packages/react-docs/scripts/update-pseudo-style-props.mjs
+++ b/packages/react-docs/scripts/update-pseudo-style-props.mjs
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { pseudoClassSelector, pseudoElementSelector } from '@tonic-ui/styled-system';
+import { ensureArray } from 'ensure-type';
 import _ from 'lodash';
 
 const args = process.argv.slice(2);
@@ -13,11 +14,38 @@ const list = {
 
 const data = _.reduce(list, (result, selectorObject, key) => {
   for (const [prop, sx] of Object.entries(selectorObject)) {
-    const items = sx({}).map(x => ({
-      prop,
-      selector: x[0],
-    }));
-    result[key] = (result[key] || (result[key] = [])).concat(items);
+    let items = [];
+
+    if (prop === '_has') {
+      items = [{
+        prop: '_has',
+        selector: '&:has(<relative-selector-list>)',
+      }];
+    } else if (prop === '_is') {
+      items = [{
+        prop: '_is',
+        selector: '&:is(<forgiving-selector-list>)',
+      }];
+    } else if (prop === '_not') {
+      items = [{
+        prop: '_not',
+        selector: '&:not(<complex-selector-list>)',
+      }];
+    } else if (prop === '_nthOfType') {
+      items = [{
+        prop: '_nthOfType',
+        selector: '&:nth-of-type(<An+B> | even | odd)',
+      }];
+    } else {
+      items = sx({}).map(x => {
+        return {
+          prop,
+          selector: x[0],
+        };
+      });
+    }
+
+    result[key] = ensureArray(result[key]).concat(items);
   }
   return result;
 }, {});
@@ -34,7 +62,7 @@ try {
       ].concat(value.map(x => {
         const cells = [
           '`' + x.prop + '`',
-          '`' + x.selector.split(',').join('` ,<br/>`') + '`',
+          '`' + x.selector.replaceAll('|', '\\|').split(',').join('`,<br/>`') + '`',
         ];
         return '| ' + cells.join(' | ') + ' |';
       }));

--- a/packages/react/src/button/styles.js
+++ b/packages/react/src/button/styles.js
@@ -363,23 +363,27 @@ const useButtonStyle = ({
   };
   const orientationStyle = {
     'horizontal': {
-      _notFirstOfType: {
-        borderTopLeftRadius: 0,
-        borderBottomLeftRadius: 0,
-      },
-      _notLastOfType: {
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0,
+      _not: {
+        ':first-of-type': {
+          borderTopLeftRadius: 0,
+          borderBottomLeftRadius: 0,
+        },
+        ':last-of-type': {
+          borderTopRightRadius: 0,
+          borderBottomRightRadius: 0,
+        },
       },
     },
     'vertical': {
-      _notFirstOfType: {
-        borderTopLeftRadius: 0,
-        borderTopRightRadius: 0,
-      },
-      _notLastOfType: {
-        borderBottomLeftRadius: 0,
-        borderBottomRightRadius: 0,
+      _not: {
+        ':first-of-type': {
+          borderTopLeftRadius: 0,
+          borderTopRightRadius: 0,
+        },
+        ':last-of-type': {
+          borderBottomLeftRadius: 0,
+          borderBottomRightRadius: 0,
+        },
       },
     },
   }[orientation];

--- a/packages/react/src/search-input/styles.js
+++ b/packages/react/src/search-input/styles.js
@@ -85,14 +85,14 @@ const useSearchInputClearButtonStyle = ({ variant, size }) => {
       borderColor: focusBorderColor,
       boxShadow: focusBoxShadowBorderColor ? `inset 0 0 0 1px ${focusBoxShadowBorderColor}` : undefined,
       color: focusColor,
-    },
-    _focusHover: {
-      color: focusHoverColor,
-    },
-    _focusActive: {
-      borderColor: focusBorderColor,
-      boxShadow: focusBoxShadowBorderColor ? `inset 0 0 0 1px ${focusBoxShadowBorderColor}` : undefined,
-      color: focusActiveColor,
+      '&:hover': {
+        color: focusHoverColor,
+      },
+      '&:active': {
+        borderColor: focusBorderColor,
+        boxShadow: focusBoxShadowBorderColor ? `inset 0 0 0 1px ${focusBoxShadowBorderColor}` : undefined,
+        color: focusActiveColor,
+      },
     },
   };
 

--- a/packages/styled-system/src/__tests__/pseudo.test.js
+++ b/packages/styled-system/src/__tests__/pseudo.test.js
@@ -112,6 +112,17 @@ describe('pseudo class selectors', () => {
     ]);
   });
 
+  test('_has', () => {
+    const hasFunctionalSelector = pseudoClassSelector._has({
+      '> .child': { color: 'red' },
+      '~ .sibling': { backgroundColor: 'blue' },
+    });
+    expect(hasFunctionalSelector).toEqual([
+      ['&:has(> .child)', { color: 'red' }],
+      ['&:has(~ .sibling)', { backgroundColor: 'blue' }],
+    ]);
+  });
+
   test('_hover', () => {
     const hoverSelector = pseudoClassSelector._hover({ color: 'purple' });
     expect(hoverSelector).toEqual([
@@ -133,6 +144,15 @@ describe('pseudo class selectors', () => {
     ]);
   });
 
+  test('_is', () => {
+    const isFunctionalSelector = pseudoClassSelector._is({
+      ':valid, :unsupported': { color: 'white' },
+    });
+    expect(isFunctionalSelector).toEqual([
+      ['&:is(:valid, :unsupported)', { color: 'white' }],
+    ]);
+  });
+
   test('_lastChild', () => {
     const lastChildSelector = pseudoClassSelector._lastChild({ border: '1px solid black' });
     expect(lastChildSelector).toEqual([
@@ -147,37 +167,32 @@ describe('pseudo class selectors', () => {
     ]);
   });
 
-  test('_notFirstChild', () => {
-    const notFirstChildSelector = pseudoClassSelector._notFirstChild({ opacity: 0.7 });
-    expect(notFirstChildSelector).toEqual([
+  test('_not', () => {
+    const notFunctionalSelector = pseudoClassSelector._not({
+      ':first-child': {
+        opacity: 0.7,
+      },
+      ':last-child': {
+        boxShadow: '0 0 5px rgba(0,0,0,0.5)',
+      },
+      ':first-of-type': {
+        transform: 'scale(0.8)',
+      },
+      ':last-of-type': {
+        border: '1px dashed blue',
+      },
+    });
+    expect(notFunctionalSelector).toEqual([
       ['&:not(:first-child)', { opacity: 0.7 }],
-    ]);
-  });
-
-  test('_notFirstOfType', () => {
-    const notFirstOfTypeSelector = pseudoClassSelector._notFirstOfType({ transform: 'scale(0.8)' });
-    expect(notFirstOfTypeSelector).toEqual([
-      ['&:not(:first-of-type)', { transform: 'scale(0.8)' }],
-    ]);
-  });
-
-  test('_notLastChild', () => {
-    const notLastChildSelector = pseudoClassSelector._notLastChild({ boxShadow: '0 0 5px rgba(0,0,0,0.5)' });
-    expect(notLastChildSelector).toEqual([
       ['&:not(:last-child)', { boxShadow: '0 0 5px rgba(0,0,0,0.5)' }],
-    ]);
-  });
-
-  test('_notLastOfType', () => {
-    const notLastOfTypeSelector = pseudoClassSelector._notLastOfType({ border: '1px dashed blue' });
-    expect(notLastOfTypeSelector).toEqual([
+      ['&:not(:first-of-type)', { transform: 'scale(0.8)' }],
       ['&:not(:last-of-type)', { border: '1px dashed blue' }],
     ]);
   });
 
   test('_nthOfType', () => {
-    const nthOfTypeSelector = pseudoClassSelector._nthOfType({ 'odd': { backgroundColor: 'lightblue' } });
-    expect(nthOfTypeSelector).toEqual([
+    const nthOfTypeFunctionalSelector = pseudoClassSelector._nthOfType({ 'odd': { backgroundColor: 'lightblue' } });
+    expect(nthOfTypeFunctionalSelector).toEqual([
       ['&:nth-of-type(odd)', { backgroundColor: 'lightblue' }],
     ]);
   });

--- a/packages/styled-system/src/pseudo.js
+++ b/packages/styled-system/src/pseudo.js
@@ -17,7 +17,7 @@ const createSelectorFunction = (name) => {
   };
 };
 
-const createNthOfTypeSelectorFunction = (name) => {
+const createFunctionalSelectorFunction = (name) => {
   if (Array.isArray(name)) {
     name = name.join(',');
   }
@@ -76,6 +76,7 @@ const pseudoClassSelector = {
   _focusHover: createSelectorFunction('&:focus:hover'),
   _focusVisible: createSelectorFunction('&:focus-visible'),
   _focusWithin: createSelectorFunction('&:focus-within'),
+  _has: createFunctionalSelectorFunction('&:has'),
   _hover: createSelectorFunction([
     '&:hover',
     '&[data-hover]',
@@ -87,13 +88,11 @@ const pseudoClassSelector = {
     '&:invalid',
     '&[aria-invalid=true]',
   ]),
+  _is: createFunctionalSelectorFunction('&:is'),
   _lastChild: createSelectorFunction('&:last-child'),
   _lastOfType: createSelectorFunction('&:last-of-type'),
-  _notFirstChild: createSelectorFunction('&:not(:first-child)'),
-  _notFirstOfType: createSelectorFunction('&:not(:first-of-type)'),
-  _notLastChild: createSelectorFunction('&:not(:last-child)'),
-  _notLastOfType: createSelectorFunction('&:not(:last-of-type)'),
-  _nthOfType: createNthOfTypeSelectorFunction('&:nth-of-type'),
+  _not: createFunctionalSelectorFunction('&:not'),
+  _nthOfType: createFunctionalSelectorFunction('&:nth-of-type'),
   _optional: createSelectorFunction('&:optional'),
   _placeholderShown: createSelectorFunction('&:placeholder-shown'),
   _readOnly: createSelectorFunction([

--- a/packages/styled-system/src/pseudo.js
+++ b/packages/styled-system/src/pseudo.js
@@ -1,4 +1,7 @@
-const noop = () => {};
+import {
+  noop,
+  warnDeprecatedProps,
+} from '@tonic-ui/utils';
 
 const createSelectorFunction = (name) => {
   if (Array.isArray(name)) {
@@ -72,8 +75,34 @@ const pseudoClassSelector = {
     '&:focus',
     '&[data-focus]',
   ]),
-  _focusActive: createSelectorFunction('&:focus:active'),
-  _focusHover: createSelectorFunction('&:focus:hover'),
+  _focusActive: (() => { // deprecated
+    const selectorFunction = createSelectorFunction('&:focus:active');
+    let _warnedOnce = false;
+    return (props) => {
+      if (process.env.NODE_ENV !== 'production' && !_warnedOnce) {
+        warnDeprecatedProps('_focusActive', {
+          alternative: '_focus: { \'&:active\': { } }',
+          willRemove: true,
+        });
+        _warnedOnce = true;
+      }
+      return selectorFunction(props);
+    };
+  })(),
+  _focusHover: (() => { // deprecated
+    const selectorFunction = createSelectorFunction('&:focus:hover');
+    let _warnedOnce = false;
+    return (props) => {
+      if (process.env.NODE_ENV !== 'production' && !_warnedOnce) {
+        warnDeprecatedProps('_focusHover', {
+          alternative: '_focus: { \'&:hover\': { } }',
+          willRemove: true,
+        });
+        _warnedOnce = true;
+      }
+      return selectorFunction(props);
+    };
+  })(),
   _focusVisible: createSelectorFunction('&:focus-visible'),
   _focusWithin: createSelectorFunction('&:focus-within'),
   _has: createFunctionalSelectorFunction('&:has'),


### PR DESCRIPTION
Note: The minimum required version of the `styled-system` dependency must be `^2.2.0` after the update.

### Demo

#### `:has(<relative-selector-list>)`
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-972/styled-system/pseudo-style-props/#hasrelative-selector-list

#### `:is(<forgiving-selector-list>)`
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-972/styled-system/pseudo-style-props/#isforgiving-selector-list

#### `:not(<complex-selector-list>)`
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-972/styled-system/pseudo-style-props/#notcomplex-selector-list

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `_has`, `_is`, and `_not` functional pseudo-class selectors.

- Replaced specific `_not*` pseudo-class selectors with a unified `_not` selector.

- Updated tests to cover new `_has`, `_is`, and `_not` selectors.

- Refactored `createNthOfTypeSelectorFunction` to `createFunctionalSelectorFunction`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.js</strong><dd><code>Refactor button styles to use `_not` selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/button/styles.js

<li>Replaced <code>_notFirstOfType</code> and <code>_notLastOfType</code> with <code>_not</code> selector.<br> <li> Updated button styles to use functional pseudo-class selectors.


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/972/files#diff-2ee4eca2ac1fe24579cf6eeed7f81cba92d3e546174962b4aa49f2203e5ac5b8">+18/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pseudo.js</strong><dd><code>Add `_has`, `_is`, and refactor pseudo-class selector functions</code></dd></summary>
<hr>

packages/styled-system/src/pseudo.js

<li>Added <code>_has</code> and <code>_is</code> functional pseudo-class selectors.<br> <li> Replaced <code>_not*</code> selectors with a unified <code>_not</code> selector.<br> <li> Refactored <code>createNthOfTypeSelectorFunction</code> to <br><code>createFunctionalSelectorFunction</code>.


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/972/files#diff-706324b97b1404a89ab3070656805b9d657a12c72eeb84b5567f4d5880b3c4b7">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pseudo.test.js</strong><dd><code>Add and update tests for functional pseudo-class selectors</code></dd></summary>
<hr>

packages/styled-system/src/__tests__/pseudo.test.js

<li>Added tests for <code>_has</code> and <code>_is</code> functional pseudo-class selectors.<br> <li> Replaced tests for <code>_not*</code> selectors with unified <code>_not</code> tests.<br> <li> Updated test cases for functional pseudo-class selectors.


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/972/files#diff-0dea23c02790efec8fac53b2b5e9c7da9ed1c2ef240c76955cbc3048df8be1b9">+39/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>