### PR TITLE
docs: ensure the date time picker remains visible even when the year-month selection button loses focus

### DIFF
--- a/packages/react-docs/pages/components/date-pickers/date-picker/range-picker.js
+++ b/packages/react-docs/pages/components/date-pickers/date-picker/range-picker.js
@@ -353,6 +353,7 @@ const App = () => {
       <Text>{dateTimeRange[1]}</Text>
     </Flex>
     <Menu
+      closeOnBlur={!state.isDateTimePickerVisible}
       onClose={() => {
         if (state.isDateTimePickerVisible) {
           setState({ isDateTimePickerVisible: false });


### PR DESCRIPTION
### **PR Type**
Bug fix, Documentation


___

### **Description**
- Ensures the date-time picker remains visible when year-month selection loses focus.

- Updates the `closeOnBlur` property in the range picker example.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>range-picker.js</strong><dd><code>Update `closeOnBlur` logic in range picker example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react-docs/pages/components/date-pickers/date-picker/range-picker.js

<li>Added a condition to <code>closeOnBlur</code> to respect <code>isDateTimePickerVisible</code>.<br> <li> Ensures the date-time picker remains open when needed.


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/973/files#diff-a4fa8f25ed5fa39fb2c55e21d64dcac054dd5cc935d34b7441639d73d3cad06a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>