### PR TITLE
docs(tree): change the icon color from yellow to primary text color

### DIFF
--- a/packages/react-docs/pages/components/tree/controlled.js
+++ b/packages/react-docs/pages/components/tree/controlled.js
@@ -45,7 +45,7 @@ const TreeItemRender = ({
       }
       return ServerIcon;
     })();
-    const iconColor = isExpandable ? 'yellow:50' : 'currentColor';
+    const iconColor = colorStyle.color.primary;
 
     return (
       <TreeItemContent

--- a/packages/react-docs/pages/components/tree/dnd/TreeView.js
+++ b/packages/react-docs/pages/components/tree/dnd/TreeView.js
@@ -29,7 +29,7 @@ const TreeItemRender = ({
 
   const render = useCallback(({ isExpandable, isExpanded, isSelected }) => {
     const icon = isExpanded ? FolderOpenIcon : FolderIcon;
-    const iconColor = 'yellow:50';
+    const iconColor = colorStyle.color.primary;
 
     return (
       <Droppable

--- a/packages/react-docs/pages/components/tree/dropdown.js
+++ b/packages/react-docs/pages/components/tree/dropdown.js
@@ -47,7 +47,7 @@ const TreeItemRender = ({
       }
       return ServerIcon;
     })();
-    const iconColor = isExpandable ? 'yellow:50' : 'currentColor';
+    const iconColor = colorStyle.color.primary;
 
     return (
       <TreeItemContent

--- a/packages/react-docs/pages/components/tree/load-on-demand.js
+++ b/packages/react-docs/pages/components/tree/load-on-demand.js
@@ -61,7 +61,7 @@ const TreeItemRender = ({
       }
       return ServerIcon;
     })();
-    const iconColor = isExpandable ? 'yellow:50' : 'currentColor';
+    const iconColor = colorStyle.color.primary;
 
     return (
       <TreeItemContent

--- a/packages/react-docs/pages/components/tree/multi-selection-checkboxes-with-custom-selection-behavior.js
+++ b/packages/react-docs/pages/components/tree/multi-selection-checkboxes-with-custom-selection-behavior.js
@@ -51,7 +51,7 @@ const TreeItemRender = ({
       }
       return ServerIcon;
     })();
-    const iconColor = isExpandable ? 'yellow:50' : 'currentColor';
+    const iconColor = colorStyle.color.primary;
 
     return (
       <TreeItemContent

--- a/packages/react-docs/pages/components/tree/multi-selection-checkboxes.js
+++ b/packages/react-docs/pages/components/tree/multi-selection-checkboxes.js
@@ -42,7 +42,7 @@ const TreeItemRender = ({
       }
       return ServerIcon;
     })();
-    const iconColor = isExpandable ? 'yellow:50' : 'currentColor';
+    const iconColor = colorStyle.color.primary;
 
     return (
       <TreeItemContent

--- a/packages/react-docs/pages/components/tree/multi-selection.js
+++ b/packages/react-docs/pages/components/tree/multi-selection.js
@@ -41,7 +41,7 @@ const TreeItemRender = ({
       }
       return ServerIcon;
     })();
-    const iconColor = isExpandable ? 'yellow:50' : 'currentColor';
+    const iconColor = colorStyle.color.primary;
 
     return (
       <TreeItemContent

--- a/packages/react-docs/pages/components/tree/resizable.js
+++ b/packages/react-docs/pages/components/tree/resizable.js
@@ -44,7 +44,7 @@ const TreeItemRender = ({
       }
       return ServerIcon;
     })();
-    const iconColor = isExpandable ? 'yellow:50' : 'currentColor';
+    const iconColor = colorStyle.color.primary;
 
     return (
       <TreeItemContent

--- a/packages/react-docs/pages/components/tree/selection.js
+++ b/packages/react-docs/pages/components/tree/selection.js
@@ -41,7 +41,7 @@ const TreeItemRender = ({
       }
       return ServerIcon;
     })();
-    const iconColor = isExpandable ? 'yellow:50' : 'currentColor';
+    const iconColor = colorStyle.color.primary;
 
     return (
       <TreeItemContent


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-980/components/tree/

### **PR Type**
Documentation


___

### **Description**
- Updated icon color from `yellow:50` to `currentColor` across multiple tree component examples.

- Ensured consistent icon color usage for expandable and non-expandable nodes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>controlled.js</strong><dd><code>Updated icon color logic for controlled tree example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/980/files#diff-b60c81e5f904a7dee56710d6aad58fb2d3118a154595e5087a798cb35ea7be35">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TreeView.js</strong><dd><code>Updated icon color logic for drag-and-drop tree example</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/980/files#diff-ce5c76f17b2251f09ed23ef1d0af46af1ee186d1a2c49097a42ba7f64500efa0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dropdown.js</strong><dd><code>Updated icon color logic for dropdown tree example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/980/files#diff-da8365020f0835cab3612c17f08532a6e33b99df96c190d16814df0e43b606ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>load-on-demand.js</strong><dd><code>Updated icon color logic for load-on-demand tree example</code>&nbsp; </dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/980/files#diff-b17291a75b04d1f20d0567cf4dc69db818ee06aba8baa9d6b35af6612fe61b31">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>multi-selection-checkboxes-with-custom-selection-behavior.js</strong><dd><code>Updated icon color logic for multi-selection with custom behavior </code><br><code>example</code></dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/980/files#diff-7b9714240d3507f339e7daba4bb02ad626c82204a5d1bc48252da91902c9fe1e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>multi-selection-checkboxes.js</strong><dd><code>Updated icon color logic for multi-selection checkboxes example</code></dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/980/files#diff-9f8ab532b25fa0f952e40a0a94dbf4f52c29604fc4fd97825e14720aa09e1fee">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>multi-selection.js</strong><dd><code>Updated icon color logic for multi-selection tree example</code></dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/980/files#diff-c7490e3b745513203d5df6c4f10cadb248d068b3e55877b581add5417044973f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resizable.js</strong><dd><code>Updated icon color logic for resizable tree example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/980/files#diff-fef8f4ce43774817e7aa5b10675332eac7fadef7da1eae4facbc3e1cd987803f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>selection.js</strong><dd><code>Updated icon color logic for selection tree example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/980/files#diff-9eae1bd23f1c2cb5407da9279d90fa8bb3d1b814ba15312e7bfef33fe037eb2d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>