### PR TITLE
feat: support `referenceRef` in `Popper` to address positioning issue

### DIFF
--- a/.changeset/tonic-ui-990.md
+++ b/.changeset/tonic-ui-990.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": patch
+---
+
+feat: support `referenceRef` in `Popper` to address positioning issue

--- a/packages/react-docs/pages/components/menu/uncontrolled.js
+++ b/packages/react-docs/pages/components/menu/uncontrolled.js
@@ -25,7 +25,7 @@ const App = () => {
 
   return (
     <Flex columnGap="4x" alignItems="center">
-      <Menu>
+      <Menu defaultIsOpen={true}>
         <MenuButton>
           Options
         </MenuButton>

--- a/packages/react-docs/pages/components/popover/uncontrolled.js
+++ b/packages/react-docs/pages/components/popover/uncontrolled.js
@@ -2,7 +2,7 @@ import { Button, Popover, PopoverContent, PopoverTrigger, Text } from '@tonic-ui
 import React from 'react';
 
 const App = () => (
-  <Popover defaultIsOpen={false}>
+  <Popover defaultIsOpen={true}>
     <PopoverTrigger>
       <Button variant="secondary">Trigger</Button>
     </PopoverTrigger>

--- a/packages/react-docs/pages/components/tooltip/uncontrolled.js
+++ b/packages/react-docs/pages/components/tooltip/uncontrolled.js
@@ -4,7 +4,7 @@ import React from 'react';
 const App = () => (
   <Tooltip
     label="This is an uncontrolled tooltip"
-    defaultIsOpen={false}
+    defaultIsOpen={true}
   >
     <Text display="inline-block">Text content</Text>
   </Tooltip>

--- a/packages/react/src/date-pickers/DatePicker/DatePickerContent.js
+++ b/packages/react/src/date-pickers/DatePicker/DatePickerContent.js
@@ -64,12 +64,12 @@ const DatePickerContent = forwardRef((
   return (
     <PopperComponent
       aria-labelledby={datePickerToggleId}
-      anchorEl={datePickerToggleRef?.current}
       id={datePickerContentId}
       isOpen={isOpen}
       modifiers={popperModifiers}
       placement={placement}
       ref={datePickerContentRef}
+      referenceRef={datePickerToggleRef}
       role="menu"
       tabIndex={-1}
       unmountOnExit={true}

--- a/packages/react/src/menu/MenuContent.js
+++ b/packages/react/src/menu/MenuContent.js
@@ -112,12 +112,12 @@ const MenuContent = forwardRef((inProps, ref) => {
   return (
     <PopperComponent
       aria-labelledby={menuToggleId}
-      anchorEl={menuToggleRef?.current} // TODO: rename to `referenceRef` in a future release
       data-menu-id={menuId}
       id={menuId}
       isOpen={isOpen}
       placement={placement}
       ref={menuContentRef}
+      referenceRef={menuToggleRef}
       role="menu"
       tabIndex={tabIndex}
       unmountOnExit={true}

--- a/packages/react/src/menu/SubmenuContent.js
+++ b/packages/react/src/menu/SubmenuContent.js
@@ -95,12 +95,12 @@ const SubmenuContent = forwardRef((inProps, ref) => {
   return (
     <PopperComponent
       aria-labelledby={submenuToggleId}
-      anchorEl={submenuToggleRef?.current} // TODO: rename to `referenceRef` in a future release
       data-submenu-id={submenuId}
       id={submenuId}
       isOpen={isOpen}
       placement={placement}
       ref={submenuContentRef}
+      referenceRef={submenuToggleRef}
       role="menu"
       tabIndex={tabIndex}
       unmountOnExit={true}

--- a/packages/react/src/popover/PopoverContent.js
+++ b/packages/react/src/popover/PopoverContent.js
@@ -176,11 +176,11 @@ const PopoverContent = forwardRef((inProps, ref) => {
     <PopperComponent
       aria-hidden={ariaAttr(!isOpen)}
       aria-labelledby={popoverTriggerId}
-      anchorEl={popoverTriggerRef.current} // TODO: rename to `referenceRef` in a future release
       id={popoverId}
       isOpen={isOpen}
       placement={placement}
       ref={popoverContentRef}
+      referenceRef={popoverTriggerRef}
       role={role}
       unmountOnExit={true}
       usePortal={false} // Pass `true` in `PopperProps` to render popover in a portal

--- a/packages/react/src/popper/Popper.js
+++ b/packages/react/src/popper/Popper.js
@@ -1,5 +1,6 @@
 import { createPopper } from '@popperjs/core';
-import { useEffectOnce } from '@tonic-ui/react-hooks';
+import { useEffectOnce, useOnceWhen } from '@tonic-ui/react-hooks';
+import { warnDeprecatedProps } from '@tonic-ui/utils';
 import { ensureArray } from 'ensure-type';
 import React, { forwardRef, useEffect, useRef, useState, useCallback } from 'react';
 import { useDefaultProps } from '../default-props';
@@ -7,26 +8,36 @@ import { Portal } from '../portal';
 import { Box } from '../box';
 import { assignRef } from '../utils/refs';
 
-function getAnchorEl(anchorEl) {
-  return typeof anchorEl === 'function' ? anchorEl() : anchorEl;
-}
-
 const defaultPlacement = 'bottom-start';
 
 const Popper = forwardRef((inProps, ref) => {
   const {
-    anchorEl, // TODO: rename to `referenceRef` in a future release
+    anchorEl, // deprecated
+
     children,
     isOpen,
     modifiers = [],
     placement: placementProp,
-    popperRef: popperRefProp,
+    popperRef: popperRefProp, // reference to receive the popper instance
     portalProps,
+    referenceRef,
     unmountOnExit = false,
     usePortal = false,
     willUseTransition = false,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Popper' });
+
+  { // deprecation warning
+    const prefix = `${Popper.displayName}:`;
+
+    useOnceWhen(() => {
+      warnDeprecatedProps('anchorEl', {
+        prefix,
+        alternative: 'referenceRef',
+        willRemove: true,
+      });
+    }, (anchorEl !== undefined));
+  }
 
   const nodeRef = useRef();
   const popperRef = useRef(null); // popper instance
@@ -41,14 +52,18 @@ const Popper = forwardRef((inProps, ref) => {
   }, [placementProp]);
 
   const setupPopper = useCallback(() => {
-    if (!anchorEl || !nodeRef.current) {
+    const anchor = (typeof anchorEl === 'function') ? anchorEl() : anchorEl; // deprecated
+    const reference = anchor ?? referenceRef?.current;
+    const popper = nodeRef.current;
+
+    if (!reference || !popper) {
       return;
     }
 
     // Destroy existing popper instance and create a new one
     popperRef.current?.destroy?.();
 
-    const popperInstance = createPopper(getAnchorEl(anchorEl), nodeRef.current, {
+    const popperInstance = createPopper(reference, popper, {
       placement: placement,
       modifiers: [
         { // https://popper.js.org/docs/v2/modifiers/arrow/
@@ -98,7 +113,7 @@ const Popper = forwardRef((inProps, ref) => {
         `${Popper.displayName}: An unexpected error occurred. The popper instance is not assigned to the "popperRef" as expected.`,
       );
     }
-  }, [anchorEl, modifiers, placement, placementProp, popperRefProp]);
+  }, [anchorEl, modifiers, placement, placementProp, popperRefProp, referenceRef]);
 
   const cleanupPopper = useCallback(() => {
     // Destroy popper instance

--- a/packages/react/src/theme/__tests__/createTheme.test.js
+++ b/packages/react/src/theme/__tests__/createTheme.test.js
@@ -1,5 +1,6 @@
 import { Box } from '@tonic-ui/react/src';
 import { render } from '@tonic-ui/react/test-utils/render';
+import React from 'react';
 import createTheme from '../createTheme';
 
 describe('createTheme', () => {

--- a/packages/react/src/toast/__tests__/Toast.test.js
+++ b/packages/react/src/toast/__tests__/Toast.test.js
@@ -50,10 +50,10 @@ describe('Toast', () => {
       return (
         <Collapse in={isOpen} unmountOnExit>
           <Toast
+            data-testid="toast"
             appearance="success"
             isClosable
             onClose={callEventHandlers(() => toggle(false), onClose)}
-            data-testid="toast"
           >
             {message}
           </Toast>
@@ -118,6 +118,7 @@ describe('Toast', () => {
                       onClose={onClose}
                     >
                       <Toast
+                        data-testid="toast"
                         appearance={toast.appearance}
                         isClosable={true}
                         onClose={onClose}
@@ -127,10 +128,14 @@ describe('Toast', () => {
                           width: 'fit-content',
                           boxShadow: colorStyle.shadow.thin,
                         }}
-                        data-testid="toast"
                       >
                         <Text pr="10x">{toast.content}</Text>
-                        <ToastCloseButton top={10} right={8} position="absolute" data-testid="toast-close-button" />
+                        <ToastCloseButton
+                          data-testid="toast-close-button"
+                          top={10}
+                          right={8}
+                          position="absolute"
+                        />
                       </Toast>
                     </ToastController>
                   </ToastTransition>

--- a/packages/react/src/toast/__tests__/ToastController.test.js
+++ b/packages/react/src/toast/__tests__/ToastController.test.js
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@tonic-ui/react/test-utils/render';
 import { Toast, ToastController } from '@tonic-ui/react/src';
+import React from 'react';
 
 jest.useFakeTimers();
 

--- a/packages/react/src/toast/__tests__/ToastManager.test.js
+++ b/packages/react/src/toast/__tests__/ToastManager.test.js
@@ -183,12 +183,17 @@ describe('ToastManager', () => {
         toast(({ onClose, placement }) => {
           return (
             <Toast
+              data-testid={toastTestId}
               appearance="success"
               onClose={onClose}
-              data-testid={toastTestId}
             >
               {message}
-              <ToastCloseButton top={10} right={8} position="absolute" data-testid={toastCloseButtonTestId} />
+              <ToastCloseButton
+                data-testid={toastCloseButtonTestId}
+                top={10}
+                right={8}
+                position="absolute"
+              />
             </Toast>
           );
         }, { placement });
@@ -659,7 +664,7 @@ describe('ToastManager', () => {
         <>
           <Button onClick={handleClickAddToasts}>Add Toasts</Button>
           {/* Access toast.state here to check order */}
-          {toast.state && (
+          {!!toast.state && (
             <pre data-testid="toast-state">{JSON.stringify(toast.state, null, 2)}</pre>
           )}
         </>

--- a/packages/react/src/tooltip/TooltipContent.js
+++ b/packages/react/src/tooltip/TooltipContent.js
@@ -144,12 +144,12 @@ const TooltipContent = forwardRef((inProps, ref) => {
       aria-hidden={ariaAttr(!isOpen)}
       aria-labelledby={tooltipTriggerId}
       data-popper-placement={placement}
-      anchorEl={tooltipTriggerRef.current} // TODO: rename to `referenceRef` in a future release
       id={tooltipId}
       isOpen={isOpen}
       placement={placement}
       pointerEvents="none"
       ref={tooltipContentRef}
+      referenceRef={tooltipTriggerRef}
       role="tooltip"
       unmountOnExit={true}
       usePortal={false} // Pass `true` in `PopperProps` to render tooltip in a portal

--- a/packages/react/src/utils/__tests__/renderComponentOrValue.test.js
+++ b/packages/react/src/utils/__tests__/renderComponentOrValue.test.js
@@ -3,7 +3,7 @@ import { render } from '@tonic-ui/react/test-utils/render';
 import React from 'react';
 import { renderComponentOrValue } from '../renderComponentOrValue';
 
-class ReactClassComponent extends React.Component {
+class ReactClassComponent extends React.PureComponent {
   render() {
     return (
       <div>{this.props.message}</div>


### PR DESCRIPTION
## What's Changed

This PR updates the `DatePicker`, `Tooltip`, `Popover`, and `Menu` components to use `referenceRef` instead of `anchorEl` when passing the reference to `Popper`.

This ensures the popper instance is properly aligned, particularly when `defaultIsOpen` is set to `true` and the anchor element may not be available on the initial render.

### Tooltip
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-991/components/tooltip/#controlled-and-uncontrolled-tooltip
![{9CFE0523-ED5C-4A01-8BF8-A911D7B3824E}](https://github.com/user-attachments/assets/4b05c38c-e2b5-48e8-8f5f-4cef739aa1a6)

### Popover
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-991/components/popover/#controlled-and-uncontrolled-popover
![{10772A40-66E1-44C6-BE3E-7C8F9B9C287F}](https://github.com/user-attachments/assets/8751b272-c15e-4792-85df-0977db7da093)

### Menu
https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-991/components/menu/#controlled-and-uncontrolled-menu
![{E1CA95D2-34F2-4655-AE25-EAF0756C1A18}](https://github.com/user-attachments/assets/dee0e103-1eb4-406a-83d7-9b6a4356d427)


### **PR Type**
Enhancement, Tests


___

### **Description**
- Replaced `anchorEl` with `referenceRef` in `Popper` for better positioning.
  - Added deprecation warning for `anchorEl` in `Popper`.
  - Updated `Popper` logic to use `referenceRef` instead of `anchorEl`.

- Updated components (`DatePickerContent`, `MenuContent`, `SubmenuContent`, `PopoverContent`, `TooltipContent`) to use `referenceRef`.

- Improved test files with additional attributes and formatting adjustments.

- Enhanced `renderComponentOrValue` test by switching to `React.PureComponent`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>DatePickerContent.js</strong><dd><code>Updated `DatePickerContent` to use `referenceRef` in `Popper`</code></dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/991/files#diff-6306ecc1af851be22af5c905032378d86319422c5a05d1171b1f13b7a977360a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MenuContent.js</strong><dd><code>Updated `MenuContent` to use `referenceRef` in `Popper`</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/991/files#diff-fbfbee8b32abf112fa5928ade05954ec314b3a96322d89162dfd99bce4fd99f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SubmenuContent.js</strong><dd><code>Updated `SubmenuContent` to use `referenceRef` in `Popper`</code></dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/991/files#diff-76c758eb47971d017d38fe1bdb01fe31495d39f44377a67f8785205f5af26c36">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PopoverContent.js</strong><dd><code>Updated `PopoverContent` to use `referenceRef` in `Popper`</code></dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/991/files#diff-743cfacf3013213dbe143f01108ceba43dc829e5f8e93f13eadb5b31b9d5a176">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Popper.js</strong><dd><code>Replaced `anchorEl` with `referenceRef` and added deprecation warning</code></dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/991/files#diff-8b6273f169fa7f84aadbe25a7cfa96d683240feb9b6d8044715a54813cc9f9ab">+25/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TooltipContent.js</strong><dd><code>Updated `TooltipContent` to use `referenceRef` in `Popper`</code></dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/991/files#diff-1f36317cf4d70085ec792a74b9088f7722f10ffc97999b65c3524729941a9722">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>createTheme.test.js</strong><dd><code>Added missing `React` import in `createTheme` test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/991/files#diff-8128de524902f36885eee8cc3e32cd291569b446c6903858d6d91f550991e7a3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Toast.test.js</strong><dd><code>Adjusted test attributes and formatting in `Toast` tests</code>&nbsp; </dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/991/files#diff-470c2f4c895a82f0e926da525c9e6bdb918faf66d946e6f5de48fd14fe56a374">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ToastController.test.js</strong><dd><code>Added missing `React` import in `ToastController` test</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/991/files#diff-04fd2ce45ae005f06f02bee10e5e3d438287be549c8c2656e9d29ad04ad7b1d2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ToastManager.test.js</strong><dd><code>Adjusted test attributes and formatting in `ToastManager` tests</code></dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/991/files#diff-a714bfd891160b1c5310973f95241c6de3043d2624603b56b7faf76e57a98c2b">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>renderComponentOrValue.test.js</strong><dd><code>Switched to `React.PureComponent` in `renderComponentOrValue` test</code></dd></td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/991/files#diff-008ea470b2cba2d56ca14d1f7079153472df28320c12d85787baba26fd2c17f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>