### PR TITLE
feat: add compound border radius syntax support

### DIFF
--- a/packages/styled-system/src/config/__tests__/border.test.js
+++ b/packages/styled-system/src/config/__tests__/border.test.js
@@ -155,3 +155,66 @@ test('returns border styles', () => {
     borderSpacing: '.125rem',
   });
 });
+
+describe('borderRadius with compoundThemeValueTransform', () => {
+  const theme = {
+    radii: {
+      sm: '0.125rem',
+      md: '0.25rem',
+      lg: '0.5rem',
+      xl: '1rem'
+    }
+  };
+
+  test('single value should apply to all corners', () => {
+    const style = border({
+      theme,
+      borderRadius: 'sm'
+    });
+    expect(style).toEqual({
+      borderTopLeftRadius: '0.125rem',
+      borderTopRightRadius: '0.125rem',
+      borderBottomLeftRadius: '0.125rem',
+      borderBottomRightRadius: '0.125rem'
+    });
+  });
+
+  test('two values should apply to diagonal corners', () => {
+    const style = border({
+      theme,
+      borderRadius: 'sm md'
+    });
+    expect(style).toEqual({
+      borderTopLeftRadius: '0.125rem',
+      borderTopRightRadius: '0.25rem',
+      borderBottomLeftRadius: '0.25rem',
+      borderBottomRightRadius: '0.125rem'
+    });
+  });
+
+  test('four values should apply clockwise from top-left', () => {
+    const style = border({
+      theme,
+      borderRadius: 'sm md lg xl'
+    });
+    expect(style).toEqual({
+      borderTopLeftRadius: '0.125rem',
+      borderTopRightRadius: '0.25rem',
+      borderBottomRightRadius: '0.5rem',
+      borderBottomLeftRadius: '1rem'
+    });
+  });
+
+  test('should handle mixed theme and raw values', () => {
+    const style = border({
+      theme,
+      borderRadius: 'sm 8px'
+    });
+    expect(style).toEqual({
+      borderTopLeftRadius: '0.125rem',
+      borderTopRightRadius: '8px',
+      borderBottomLeftRadius: '8px',
+      borderBottomRightRadius: '0.125rem'
+    });
+  });
+});

--- a/packages/styled-system/src/config/border.js
+++ b/packages/styled-system/src/config/border.js
@@ -1,5 +1,6 @@
 import system from '../core/system';
 import positiveOrNegativeTransform from '../transforms/positiveOrNegative';
+import compoundThemeValueTransform from '../transforms/compoundBorderValue';
 
 const _border = {
   /**
@@ -109,6 +110,7 @@ const _borderRadius = {
   borderRadius: {
     property: 'borderRadius',
     scale: 'radii',
+    transform: compoundThemeValueTransform
   },
   borderTopLeftRadius: {
     property: 'borderTopLeftRadius',

--- a/packages/styled-system/src/transforms/__tests__/compoundBorderValue.test.js
+++ b/packages/styled-system/src/transforms/__tests__/compoundBorderValue.test.js
@@ -1,4 +1,4 @@
-import { compoundBorderValue } from '../transforms';
+import { compoundBorderValue } from '../compoundBorderValue';
 
 describe('compoundBorderValue', () => {
   const scale = {
@@ -8,44 +8,34 @@ describe('compoundBorderValue', () => {
     xl: '1rem'
   };
 
-  describe('single value', () => {
-    test('should apply same value to all corners', () => {
-      expect(compoundBorderValue(scale, 'sm'))
-        .toBe('0.125rem 0.125rem 0.125rem 0.125rem');
-    });
+  test('should apply same value to all corners', () => {
+    expect(compoundBorderValue(scale, 'sm'))
+      .toBe('0.125rem 0.125rem 0.125rem 0.125rem');
   });
 
-  describe('two values', () => {
-    test('should apply first value to top-left/bottom-left and second value to top-right/bottom-right', () => {
-      expect(compoundBorderValue(scale, 'sm md'))
-        .toBe('0.125rem 0.25rem 0.25rem 0.125rem');
-    });
+  test('should apply first value to top-left/bottom-left and second value to top-right/bottom-right', () => {
+    expect(compoundBorderValue(scale, 'sm md'))
+      .toBe('0.125rem 0.25rem 0.25rem 0.125rem');
   });
 
-  describe('three values', () => {
-    test('should apply values in order: top-left, top-right, bottom-right, and copy top-right for bottom-left', () => {
-      expect(compoundBorderValue(scale, 'sm md lg'))
-        .toBe('0.125rem 0.25rem 0.5rem 0.25rem');
-    });
+  test('should apply values in order: top-left, top-right, bottom-right, and copy top-right for bottom-left', () => {
+    expect(compoundBorderValue(scale, 'sm md lg'))
+      .toBe('0.125rem 0.25rem 0.5rem 0.25rem');
   });
 
-  describe('four values', () => {
-    test('should apply values in clockwise order: top-left, top-right, bottom-right, bottom-left', () => {
-      expect(compoundBorderValue(scale, 'sm md lg xl'))
-        .toBe('0.125rem 0.25rem 0.5rem 1rem');
-    });
+  test('should apply values in clockwise order: top-left, top-right, bottom-right, bottom-left', () => {
+    expect(compoundBorderValue(scale, 'sm md lg xl'))
+      .toBe('0.125rem 0.25rem 0.5rem 1rem');
   });
 
-  describe('mixed values', () => {
-    test('should handle theme values with raw values', () => {
-      expect(compoundBorderValue(scale, 'sm 0 4px md'))
-        .toBe('0.125rem 0 4px 0.25rem');
-    });
+  test('should handle theme values with raw values', () => {
+    expect(compoundBorderValue(scale, 'sm 0 4px md'))
+      .toBe('0.125rem 0 4px 0.25rem');
+  });
 
-    test('should handle zero values', () => {
-      expect(compoundBorderValue(scale, 'sm 0 0 sm'))
-        .toBe('0.125rem 0 0 0.125rem');
-    });
+  test('should handle zero values', () => {
+    expect(compoundBorderValue(scale, 'sm 0 0 sm'))
+      .toBe('0.125rem 0 0 0.125rem');
   });
 
   describe('edge cases', () => {

--- a/packages/styled-system/src/transforms/__tests__/compoundBorderValue.test.js
+++ b/packages/styled-system/src/transforms/__tests__/compoundBorderValue.test.js
@@ -1,0 +1,71 @@
+import { compoundBorderValue } from '../transforms';
+
+describe('compoundBorderValue', () => {
+  const scale = {
+    sm: '0.125rem',
+    md: '0.25rem',
+    lg: '0.5rem',
+    xl: '1rem'
+  };
+
+  describe('single value', () => {
+    test('should apply same value to all corners', () => {
+      expect(compoundBorderValue(scale, 'sm'))
+        .toBe('0.125rem 0.125rem 0.125rem 0.125rem');
+    });
+  });
+
+  describe('two values', () => {
+    test('should apply first value to top-left/bottom-left and second value to top-right/bottom-right', () => {
+      expect(compoundBorderValue(scale, 'sm md'))
+        .toBe('0.125rem 0.25rem 0.25rem 0.125rem');
+    });
+  });
+
+  describe('three values', () => {
+    test('should apply values in order: top-left, top-right, bottom-right, and copy top-right for bottom-left', () => {
+      expect(compoundBorderValue(scale, 'sm md lg'))
+        .toBe('0.125rem 0.25rem 0.5rem 0.25rem');
+    });
+  });
+
+  describe('four values', () => {
+    test('should apply values in clockwise order: top-left, top-right, bottom-right, bottom-left', () => {
+      expect(compoundBorderValue(scale, 'sm md lg xl'))
+        .toBe('0.125rem 0.25rem 0.5rem 1rem');
+    });
+  });
+
+  describe('mixed values', () => {
+    test('should handle theme values with raw values', () => {
+      expect(compoundBorderValue(scale, 'sm 0 4px md'))
+        .toBe('0.125rem 0 4px 0.25rem');
+    });
+
+    test('should handle zero values', () => {
+      expect(compoundBorderValue(scale, 'sm 0 0 sm'))
+        .toBe('0.125rem 0 0 0.125rem');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('should handle null/undefined', () => {
+      expect(compoundBorderValue(scale, null)).toBe(null);
+      expect(compoundBorderValue(scale, undefined)).toBe(undefined);
+    });
+
+    test('should handle empty string', () => {
+      expect(compoundBorderValue(scale, '')).toBe('');
+    });
+
+    test('should handle extra whitespace', () => {
+      expect(compoundBorderValue(scale, '  sm    md  '))
+        .toBe('0.125rem 0.25rem 0.25rem 0.125rem');
+    });
+
+    test('should handle invalid theme values', () => {
+      expect(compoundBorderValue(scale, 'invalid md lg xl'))
+        .toBe('invalid 0.25rem 0.5rem 1rem');
+    });
+  });
+});

--- a/packages/styled-system/src/transforms/compoundBorderValue.js
+++ b/packages/styled-system/src/transforms/compoundBorderValue.js
@@ -1,0 +1,96 @@
+import { isNullish } from '@tonic-ui/utils';
+import getter from './getter';
+
+const hasOwnSafe = (obj, key) => {
+  if (isNullish(obj)) {
+    return false;
+  }
+
+  return Object.hasOwn
+    ? Object.hasOwn(obj, key)
+    : Object.prototype.hasOwnProperty.call(obj, key);
+};
+/**
+   * Border radius values follow this order:
+   * 1 value:  all corners
+   * 2 values: [top-left/bottom-right] [top-right/bottom-left]
+   * 3 values: [top-left] [top-right/bottom-left] [bottom-right]
+   * 4 values: [top-left] [top-right] [bottom-right] [bottom-left]
+   */
+const normalizeRadiusValues =(parts) => {
+  switch (parts.length) {
+    case 1:
+      // all corners get the same value
+      return [parts[0], parts[0], parts[0], parts[0]];
+    case 2:
+      // top-left/bottom-right | top-right/bottom-left
+      return [parts[0], parts[1], parts[0], parts[1]];
+    case 3:
+      // top-left | top-right | bottom-left | bottom-right
+      return [parts[0], parts[1], parts[1], parts[2]];
+    case 4:
+      // top-left | top-right | bottom-right | bottom-left
+      return parts; // return as is  
+    default:
+      // invalid number of values, return as is
+      return parts;
+  }
+}; 
+
+const compoundBorderValue = (scale, value, options) => {
+  /**
+   * Scale object
+   *
+   * ```js
+   * {
+   *   'sm': '0.125rem',
+   *   'md': '0.25rem',
+   * }
+   * ```
+   *
+   * Example
+   *
+   * ```jsx
+   * <Box borderRadius="sm" />
+   * // => borderRadius: var(--radii-sm)
+   * <Box borderRadius="sm md sm md" />
+   * // => borderRadius: var(--radii-sm) var(--radii-md) var(--radii-sm) var(--radii-md)
+   * <Box borderRadius="sm 0 md 4px" />
+   * // => borderRadius: var(--radii-sm) 0 var(--radii-md) 4px
+   * ```
+   */
+  if (typeof value === 'string') {
+    // Handle single values
+    if (!value.includes(' ')) {
+      const singleValue = getter(scale, value, options);
+      return `${singleValue} ${singleValue} ${singleValue} ${singleValue}`;
+    }
+
+    // Handle compound values
+    const parts = value.split(/\s+/).filter(Boolean);
+    const normalizedParts = normalizeRadiusValues(parts);
+
+    return normalizedParts
+      .map(part => {
+        // Handle raw numeric values with units
+        if (/^[0-9]+(\.[0-9]+)?(px|em|rem|%|vh|vw)$/.test(part)) {
+          return part;
+        }
+        // Handle zero value
+        if (part === '0') {
+          return part;
+        }
+        // Handle theme values sm, md, lg, etc. 
+        if (hasOwnSafe(scale, part)) {
+          return getter(scale, part, options);
+        }
+        // Pass through unknown values
+        return part;
+      })
+      .join(' ');
+  }
+
+  return getter(scale, value, options);
+};
+
+export default compoundBorderValue;

--- a/packages/styled-system/src/transforms/compoundBorderValue.js
+++ b/packages/styled-system/src/transforms/compoundBorderValue.js
@@ -10,32 +10,32 @@ const hasOwnSafe = (obj, key) => {
     ? Object.hasOwn(obj, key)
     : Object.prototype.hasOwnProperty.call(obj, key);
 };
-/**
+  /**
    * Border radius values follow this order:
    * 1 value:  all corners
    * 2 values: [top-left/bottom-right] [top-right/bottom-left]
    * 3 values: [top-left] [top-right/bottom-left] [bottom-right]
    * 4 values: [top-left] [top-right] [bottom-right] [bottom-left]
    */
-const normalizeRadiusValues =(parts) => {
+const normalizeRadiusValues = (parts) => {
   switch (parts.length) {
-    case 1:
-      // all corners get the same value
-      return [parts[0], parts[0], parts[0], parts[0]];
-    case 2:
-      // top-left/bottom-right | top-right/bottom-left
-      return [parts[0], parts[1], parts[0], parts[1]];
-    case 3:
-      // top-left | top-right | bottom-left | bottom-right
-      return [parts[0], parts[1], parts[1], parts[2]];
-    case 4:
-      // top-left | top-right | bottom-right | bottom-left
-      return parts; // return as is  
-    default:
-      // invalid number of values, return as is
-      return parts;
+  case 1:
+    // all corners get the same value
+    return [parts[0], parts[0], parts[0], parts[0]];
+  case 2:
+    // top-left/bottom-right | top-right/bottom-left
+    return [parts[0], parts[1], parts[0], parts[1]];
+  case 3:
+    // top-left | top-right | bottom-left | bottom-right
+    return [parts[0], parts[1], parts[1], parts[2]];
+  case 4:
+    // top-left | top-right | bottom-right | bottom-left
+    return parts;
+  default:
+    // invalid number of values, return as is
+    return parts;
   }
-}; 
+};
 
 const compoundBorderValue = (scale, value, options) => {
   /**
@@ -80,7 +80,7 @@ const compoundBorderValue = (scale, value, options) => {
         if (part === '0') {
           return part;
         }
-        // Handle theme values sm, md, lg, etc. 
+        // Handle theme values sm, md, lg, etc.
         if (hasOwnSafe(scale, part)) {
           return getter(scale, part, options);
         }

--- a/packages/styled-system/src/transforms/compoundBorderValue.js
+++ b/packages/styled-system/src/transforms/compoundBorderValue.js
@@ -10,30 +10,30 @@ const hasOwnSafe = (obj, key) => {
     ? Object.hasOwn(obj, key)
     : Object.prototype.hasOwnProperty.call(obj, key);
 };
-/**
+  /**
    * Border radius values follow this order:
    * 1 value:  all corners
    * 2 values: [top-left/bottom-right] [top-right/bottom-left]
    * 3 values: [top-left] [top-right/bottom-left] [bottom-right]
    * 4 values: [top-left] [top-right] [bottom-right] [bottom-left]
    */
-const normalizeRadiusValues =(parts) => {
+const normalizeRadiusValues = (parts) => {
   switch (parts.length) {
-    case 1:
-      // all corners get the same value
-      return [parts[0], parts[0], parts[0], parts[0]];
-    case 2:
-      // top-left/bottom-right | top-right/bottom-left
-      return [parts[0], parts[1], parts[0], parts[1]];
-    case 3:
-      // top-left | top-right | bottom-left | bottom-right
-      return [parts[0], parts[1], parts[1], parts[2]];
-    case 4:
-      // top-left | top-right | bottom-right | bottom-left
-      return parts; // return as is  
-    default:
-      // invalid number of values, return as is
-      return parts;
+  case 1:
+    // all corners get the same value
+    return [parts[0], parts[0], parts[0], parts[0]];
+  case 2:
+    // top-left/bottom-right | top-right/bottom-left
+    return [parts[0], parts[1], parts[0], parts[1]];
+  case 3:
+    // top-left | top-right | bottom-left | bottom-right
+    return [parts[0], parts[1], parts[1], parts[2]];
+  case 4:
+    // top-left | top-right | bottom-right | bottom-left
+    return parts; // return as is  
+  default:
+    // invalid number of values, return as is
+    return parts;
   }
 }; 
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


### **Major Changed file**
- compoundBorderValue.js 
- compoundBorderValue.test.js 
- border.js 
- border.test.js 

### **Change Reason**
- Add support for assigning multiple `borderRadius` values (e.g., `sm` `md`  `lg` `xl`) in a single declaration.

- Allow a single `borderRadius` variable to define values for all four corners, replacing the need for separate values per direction.


### **Description**
- Added support for compound border radius syntax in the styled-system.

- Implemented `compoundBorderValue` transform for handling complex border radius values.

- Enhanced tests to validate compound border radius functionality.

- Introduced edge case handling for invalid or mixed border radius inputs.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>border.test.js</strong><dd><code>Add tests for compound border radius functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/styled-system/src/config/__tests__/border.test.js

<li>Added tests for compound border radius syntax.<br> <li> Validated single, two, and four value scenarios.<br> <li> Tested mixed theme and raw value handling.


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/994/files#diff-4cb53327f1f1ce5a982e86df60e0614ee1e2ec9714196d67897d5bd0ee294d5d">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>compoundBorderValue.test.js</strong><dd><code>Add tests for `compoundBorderValue` transform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/styled-system/src/transforms/__tests__/compoundBorderValue.test.js

<li>Added unit tests for <code>compoundBorderValue</code> transform.<br> <li> Covered single, two, three, and four value scenarios.<br> <li> Included edge case tests for invalid inputs and whitespace.


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/994/files#diff-8acca1f088bd1024412b490294010b4af0d71fca5c240ac74a5908aa3d94e557">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>border.js</strong><dd><code>Add compound border radius transform to configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/styled-system/src/config/border.js

<li>Integrated <code>compoundThemeValueTransform</code> for border radius.<br> <li> Enhanced border radius configuration to support compound values.


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/994/files#diff-575f486c1767639ca5fab227edc4d50c16458aa523559dbc0595d90dd561df10">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>compoundBorderValue.js</strong><dd><code>Implement `compoundBorderValue` transform for border radius</code></dd></summary>
<hr>

packages/styled-system/src/transforms/compoundBorderValue.js

<li>Implemented <code>compoundBorderValue</code> transform for border radius.<br> <li> Added logic to normalize and process compound values.<br> <li> Handled edge cases like null, empty strings, and invalid inputs.


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/994/files#diff-709497f1013eb5f9f43185ed27f16aceb3e7c89a35872a3ffb82f3467f67c274">+96/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>