### PR TITLE
fix(react/InputGroup): fix pseudo-class ':first-child' warning

### DIFF
--- a/packages/react/src/input/styles.js
+++ b/packages/react/src/input/styles.js
@@ -669,7 +669,7 @@ const getInputGroupCSS = ({
   const useNegativeMargin = (variant === VARIANT_OUTLINE || variant === VARIANT_FILLED);
 
   return sx({
-    '&:not(:first-child)': {
+    '&:not(:first-of-type)': {
       borderTopLeftRadius: 0,
       borderBottomLeftRadius: 0,
     },

--- a/packages/react/src/input/styles.js
+++ b/packages/react/src/input/styles.js
@@ -673,7 +673,7 @@ const getInputGroupCSS = ({
       borderTopLeftRadius: 0,
       borderBottomLeftRadius: 0,
     },
-    '&:not(:last-child)': {
+    '&:not(:last-of-type)': {
       borderTopRightRadius: 0,
       borderBottomRightRadius: 0,
     },
@@ -759,7 +759,7 @@ const getInputGroupAppendCSS = () => {
 
   return sx({
     '& > *:first-of-type': notFirstChildStyle,
-    '&:not(:last-child) > *:first-of-type': notLastChildStyle,
+    '&:not(:last-of-type) > *:first-of-type': notLastChildStyle,
   });
 };
 

--- a/packages/react/src/table/TableCell.js
+++ b/packages/react/src/table/TableCell.js
@@ -35,7 +35,7 @@ const TableCell = forwardRef((inProps, ref) => {
   if ((groupVariant === GROUP_VARIANT_BODY) && (layout !== LAYOUT_TABLE) && (variant === VARIANT_OUTLINE)) {
     sx = {
       ...sx,
-      '*:last-child > &': {
+      '*:last-of-type > &': {
         borderBottom: 0,
         borderBottomColor: 'transparent',
       },


### PR DESCRIPTION
demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-996/

# User description
- Replace the pseudo-class ':first-child' with ':first-of-type' to fix console error.
- Replace the pseudo-class ':last-child' with ':last-of-type' to fix console error.

# Issue
Issue: https://github.com/trendmicro-frontend/tonic-ui/issues/995

![Screenshot2025_04_18_151853](https://github.com/user-attachments/assets/df00eff5-5b3b-4250-8c3b-d2f115fd4cb2)

![Screenshot2025_04_18_151838](https://github.com/user-attachments/assets/210cafe0-501f-4f4b-a206-f99e3767173c)

# Preview
![Screenshot2025_04_18_151605](https://github.com/user-attachments/assets/3ab34ff2-162b-4777-9c10-911b2f321865)


___

### **PR Type**
Bug fix


___

### **Description**
- Replaced the pseudo-class `:first-child` with `:first-of-type` to address server-side rendering warnings.

- Updated `InputGroup` styles to ensure compatibility and eliminate console errors.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.js</strong><dd><code>Update CSS selectors for `InputGroup` compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/input/styles.js

<li>Replaced <code>:first-child</code> pseudo-class with <code>:first-of-type</code>.<br> <li> Adjusted CSS selectors for <code>InputGroup</code> to fix server-side rendering <br>issues.


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/996/files#diff-c6e98b8745d0e4015f4e5b683fd5546392d7d47cb3f71fc067bc9d55b75189be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>