### PR TITLE
feat(react/tag): update `_focus` to `_focusVisible` in `Tag` component to enable focus outline on keyboard navigation

### DIFF
--- a/.changeset/tonic-ui-998.md
+++ b/.changeset/tonic-ui-998.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": patch
+---
+
+feat(react/tag): update `_focus` to `_focusVisible` in `Tag` component to enable focus outline on keyboard navigation

--- a/packages/react/src/tag/styles.js
+++ b/packages/react/src/tag/styles.js
@@ -15,17 +15,10 @@ const getSolidTagStyle = ({
     dark: 'gray:20',
     light: 'black:emphasis',
   }[colorMode];
-  // Focus
-  const focusColor = {
-    dark: theme?.colors?.['blue:60'],
-    light: theme?.colors?.['blue:60'],
+  const focusVisibleOutlineColor = {
+    dark: 'blue:60',
+    light: 'blue:60',
   }[colorMode];
-  const focusBoxShadowSpreadRadius = theme?.sizes?.['1q'];
-  const boxShadowColor = {
-    dark: theme?.colors?.['black:emphasis'],
-    light: theme?.colors?.['white:emphasis'],
-  }[colorMode];
-  const boxShadowSpreadRadius = theme?.sizes?.['2q'];
   // Disable
   const disabledOpacity = {
     dark: 0.28,
@@ -44,11 +37,11 @@ const getSolidTagStyle = ({
   return {
     backgroundColor,
     color,
-    _focus: {
-      '&:not([disabled])': {
-        borderColor: focusColor,
-        boxShadow: `inset 0 0 0 ${focusBoxShadowSpreadRadius} ${focusColor}, inset 0 0 0 ${boxShadowSpreadRadius} ${boxShadowColor}`,
-      },
+    _focusVisible: {
+      outlineColor: focusVisibleOutlineColor,
+      outlineOffset: '-1h',
+      outlineStyle: 'solid',
+      outlineWidth: '1h',
     },
     _invalid: {
       backgroundColor: invalidBackgroundColor,
@@ -74,17 +67,10 @@ const getOutlineTagStyle = ({
     dark: 'gray:40',
     light: 'gray:60',
   }[colorMode];
-  // Focus
-  const focusColor = {
-    dark: theme?.colors?.['blue:60'],
-    light: theme?.colors?.['blue:60'],
+  const focusVisibleOutlineColor = {
+    dark: 'blue:60',
+    light: 'blue:60',
   }[colorMode];
-  const focusBoxShadowSpreadRadius = theme?.sizes?.['1q'];
-  const boxShadowColor = {
-    dark: theme?.colors?.['black:emphasis'],
-    light: theme?.colors?.['white:emphasis'],
-  }[colorMode];
-  const boxShadowSpreadRadius = theme?.sizes?.['2q'];
   // Disable
   const disabledOpacity = {
     dark: 0.28,
@@ -103,11 +89,11 @@ const getOutlineTagStyle = ({
   return {
     borderColor,
     color,
-    _focus: {
-      '&:not([disabled])': {
-        borderColor: focusColor,
-        boxShadow: `inset 0 0 0 ${focusBoxShadowSpreadRadius} ${focusColor}, inset 0 0 0 ${boxShadowSpreadRadius} ${boxShadowColor}`,
-      },
+    _focusVisible: {
+      outlineColor: focusVisibleOutlineColor,
+      outlineOffset: '-1h',
+      outlineStyle: 'solid',
+      outlineWidth: '1h',
     },
     _invalid: {
       borderColor: invalidBackgroundColor,


### PR DESCRIPTION
The blue outline should only appear when navigating with a keyboard. The `_focus` style has been updated to `_focusVisible` for all button-like components, with the exception of the `Tag` component, which has not yet been updated.

![{5160D824-2585-4208-8851-048928287B68}](https://github.com/user-attachments/assets/0eae4b6e-e246-40ea-a85f-34d70d1bf622)


### **PR Type**
Enhancement


___

### **Description**
- Replaced `_focus` with `_focusVisible` for better keyboard navigation support.

- Updated focus styles to use `outline` properties instead of `boxShadow`.

- Simplified focus-related style definitions by removing redundant variables.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.js</strong><dd><code>Refactor focus styles in `Tag` component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/tag/styles.js

<li>Replaced <code>_focus</code> with <code>_focusVisible</code> for focus styles.<br> <li> Introduced <code>outline</code> properties for focus styling.<br> <li> Removed redundant variables related to <code>boxShadow</code> and focus colors.<br> <li> Simplified style definitions for better maintainability.


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/999/files#diff-3c4d3d83218f72e0162317ba3f28bd028cdd2477783d1223bd702ae7fcc223bd">+16/-30</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>