### PR TITLE
feat(react/search-input): change `_focus` to `_focusVisible` for the close button in `SearchInput`

### DIFF
--- a/.changeset/tonic-ui-998-search-input.md
+++ b/.changeset/tonic-ui-998-search-input.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": patch
+---
+
+feat(react/search-input): change `_focus` to `_focusVisible` for the close button in `SearchInput`

--- a/packages/react/src/search-input/styles.js
+++ b/packages/react/src/search-input/styles.js
@@ -16,7 +16,6 @@ const useSearchInputAdornmentStyle = () => {
 
 const useSearchInputClearButtonStyle = ({ variant, size }) => {
   const [colorMode] = useColorMode();
-  const { colors } = useTheme();
   const color = {
     dark: 'white:tertiary',
     light: 'black:tertiary',
@@ -29,11 +28,7 @@ const useSearchInputClearButtonStyle = ({ variant, size }) => {
     dark: 'white:primary',
     light: 'black:primary',
   }[colorMode];
-  const focusColor = color;
-  const focusHoverColor = hoverColor;
-  const focusActiveColor = activeColor;
-  const focusBorderColor = colors['blue:60'];
-  const focusBoxShadowBorderColor = colors['blue:60'];
+  const focusVisibleOutlineColor = 'blue:60';
   const sizeStyle = (() => {
     const width = {
       sm: '6x',
@@ -75,24 +70,17 @@ const useSearchInputClearButtonStyle = ({ variant, size }) => {
     color,
     ...sizeStyle,
     transition: createTransitionStyle('border-color', { duration: 200 }),
+    _focusVisible: {
+      outlineColor: focusVisibleOutlineColor,
+      outlineOffset: '-1h',
+      outlineStyle: 'solid',
+      outlineWidth: '1h',
+    },
     _hover: {
       color: hoverColor,
     },
     _active: {
       color: activeColor,
-    },
-    _focus: {
-      borderColor: focusBorderColor,
-      boxShadow: focusBoxShadowBorderColor ? `inset 0 0 0 1px ${focusBoxShadowBorderColor}` : undefined,
-      color: focusColor,
-      '&:hover': {
-        color: focusHoverColor,
-      },
-      '&:active': {
-        borderColor: focusBorderColor,
-        boxShadow: focusBoxShadowBorderColor ? `inset 0 0 0 1px ${focusBoxShadowBorderColor}` : undefined,
-        color: focusActiveColor,
-      },
     },
   };
 


### PR DESCRIPTION
# Overview

Only `:focus-visible`—not `:focus`—will trigger the blue outline on actionable buttons.

### **PR Type**
Enhancement


___

### **Description**
- Replaced `_focus` styles with `_focusVisible` for clear button

- Updated focus styling to use outline instead of border/box-shadow

- Simplified color and style logic for focus states


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.js</strong><dd><code>Refactor clear button focus styles to use _focusVisible</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/search-input/styles.js

<li>Removed <code>_focus</code> and related hover/active styles for clear button<br> <li> Added <code>_focusVisible</code> style with outline properties<br> <li> Simplified focus color logic, removing unused variables<br> <li> Updated style logic to align with accessibility best practices


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/1014/files#diff-5ee15d82a40d547a216a941797a455ab62302496ebf634cbc15177de93ef3afa">+7/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>