### PR TITLE
docs: use style props instead of `sx` for base components to simplify style overrides

### DIFF
--- a/packages/react-docs/experiments/dropdown/Dropdown.js
+++ b/packages/react-docs/experiments/dropdown/Dropdown.js
@@ -7,6 +7,7 @@ const Dropdown = forwardRef((
     children,
     onSelect,
     items = [],
+    portalled,
     renderContent,
     renderItem,
     slots = {},
@@ -19,6 +20,7 @@ const Dropdown = forwardRef((
     <DropdownBase
       items={items}
       onSelect={onSelect}
+      portalled={portalled}
       renderContent={renderContent}
       renderItem={renderItem}
       slots={{

--- a/packages/react-docs/experiments/dropdown/Dropdown.js
+++ b/packages/react-docs/experiments/dropdown/Dropdown.js
@@ -21,6 +21,7 @@ const Dropdown = forwardRef((
       items={items}
       onSelect={onSelect}
       portalled={portalled}
+      ref={ref}
       renderContent={renderContent}
       renderItem={renderItem}
       slots={{

--- a/packages/react-docs/experiments/dropdown/DropdownBase.js
+++ b/packages/react-docs/experiments/dropdown/DropdownBase.js
@@ -8,6 +8,7 @@ import {
   Submenu,
   SubmenuToggle,
   SubmenuList,
+  useTheme,
 } from '@tonic-ui/react';
 import { isPlainObject, runIfFn } from '@tonic-ui/utils';
 import { ensureArray } from 'ensure-type';
@@ -26,8 +27,9 @@ const defaultRenderItem = (item, context) => isPlainObject(item) ? item.label : 
 const DropdownBase = forwardRef((
   {
     children,
-    onSelect,
     items = [],
+    onSelect,
+    portalled = false,
     renderContent = null,
     renderItem: renderItemProp = defaultRenderItem,
     slots = {},
@@ -36,6 +38,7 @@ const DropdownBase = forwardRef((
   },
   ref,
 ) => {
+  const theme = useTheme();
   const handleClickBy = useCallback((item) => (event) => {
     onSelect?.(item);
   }, [onSelect]);
@@ -113,33 +116,51 @@ const DropdownBase = forwardRef((
       ref={ref}
       {...rest}
     >
-      <MenuToggle
-        {...slotProps?.toggle}
-      >
-        {({ getMenuToggleProps: getToggleProps }) => {
-          const Toggle = slots?.toggle;
-          if (isValidElementType(Toggle)) {
-            return (
-              // The `Toggle` component must be wrapped with `forwardRef` to ensure correct positioning
-              <Toggle {...getToggleProps()}>
-                {children}
-              </Toggle>
-            );
-          }
-          return runIfFn(children, { getToggleProps });
-        }}
-      </MenuToggle>
-      <MenuList
-        // Set the minimum width to fit the menu's content while occupying full width
-        minWidth="max-content"
-        width="100%"
-        {...slotProps?.content}
-      >
-        {(typeof renderContent === 'function')
-          ? renderContent({ items, renderItem, renderItems })
-          : renderItems(items)
-        }
-      </MenuList>
+      {({ menuToggleRef }) => {
+        const menuListProps = portalled
+          ? {
+              PopperProps: {
+                usePortal: true,
+              },
+              minWidth: menuToggleRef.current?.offsetWidth,
+              zIndex: theme?.zIndices?.modal + 1,
+            }
+          : {
+              // Set the minimum width to fit the menu's content while occupying full width
+              minWidth: 'max-content',
+              width: '100%',
+            };
+
+        return (
+          <>
+            <MenuToggle
+              {...slotProps?.toggle}
+            >
+              {({ getMenuToggleProps: getToggleProps }) => {
+                const Toggle = slots?.toggle;
+                if (isValidElementType(Toggle)) {
+                  return (
+                    // The `Toggle` component must be wrapped with `forwardRef` to ensure correct positioning
+                    <Toggle {...getToggleProps()}>
+                      {children}
+                    </Toggle>
+                  );
+                }
+                return runIfFn(children, { getToggleProps });
+              }}
+            </MenuToggle>
+            <MenuList
+              {...menuListProps}
+              {...slotProps?.content}
+            >
+              {(typeof renderContent === 'function')
+                ? renderContent({ items, renderItem, renderItems })
+                : renderItems(items)
+              }
+            </MenuList>
+          </>
+        );
+      }}
     </Menu>
   );
 });

--- a/packages/react-docs/experiments/dropdown/DropdownBase.js
+++ b/packages/react-docs/experiments/dropdown/DropdownBase.js
@@ -81,18 +81,14 @@ const DropdownBase = forwardRef((
         return (
           <Submenu key={`${key}_submenu`}>
             <SubmenuToggle
-              sx={{
-                width: '100%',
-              }}
+              width="100%"
             >
               <MenuItem {...item.props}>
                 {renderItem?.(item)}
               </MenuItem>
             </SubmenuToggle>
             <SubmenuList
-              sx={{
-                width: 'max-content',
-              }}
+              width="max-content"
             >
               {renderItems(item.children, key)}
             </SubmenuList>
@@ -134,11 +130,10 @@ const DropdownBase = forwardRef((
         }}
       </MenuToggle>
       <MenuList
-        sx={{
-          // Set the minimum width to fit the menu's content while occupying full width
-          minWidth: 'max-content',
-          width: '100%',
-        }}
+        // Set the minimum width to fit the menu's content while occupying full width
+        minWidth="max-content"
+        width="100%"
+        {...slotProps?.content}
       >
         {(typeof renderContent === 'function')
           ? renderContent({ items, renderItem, renderItems })

--- a/packages/react-docs/experiments/search-dropdown/SearchDropdown.js
+++ b/packages/react-docs/experiments/search-dropdown/SearchDropdown.js
@@ -102,6 +102,7 @@ const SearchDropdown = forwardRef((
       onClose={callEventHandlers(onCloseProp, onClose)}
       onSelect={onSelect}
       portalled={portalled}
+      ref={ref}
       renderContent={renderContent}
       renderItem={renderItem}
       slots={slots}

--- a/packages/react-docs/experiments/search-dropdown/SearchDropdown.js
+++ b/packages/react-docs/experiments/search-dropdown/SearchDropdown.js
@@ -6,9 +6,10 @@ import { Dropdown } from '../dropdown';
 
 const SearchDropdown = forwardRef((
   {
+    items = [],
     onClose: onCloseProp,
     onSelect,
-    items = [],
+    portalled,
     renderContent: renderContentProp,
     renderItem: renderItemProp,
     slots = {},
@@ -97,9 +98,10 @@ const SearchDropdown = forwardRef((
   return (
     <Dropdown
       defaultActiveIndex={0}
-      onClose={callEventHandlers(onCloseProp, onClose)}
       items={filteredOptions}
+      onClose={callEventHandlers(onCloseProp, onClose)}
       onSelect={onSelect}
+      portalled={portalled}
       renderContent={renderContent}
       renderItem={renderItem}
       slots={slots}

--- a/packages/react-docs/pages/experiments/dropdown-base/index.page.mdx
+++ b/packages/react-docs/pages/experiments/dropdown-base/index.page.mdx
@@ -15,13 +15,13 @@ Here's the simplest configuration to get started with the `DropdownBase` compone
 
 ```jsx
 <DropdownBase
-  onSelect={(item) => {
-    setItem(item);
-  }}
   items={[
     { label: 'Item 1', value: 1 },
     { label: 'Item 2', value: 2 },
   ]}
+  onSelect={(item) => {
+    setItem(item);
+  }}
   slots={{
     toggle: CustomDropdownToggle,
   }}
@@ -91,16 +91,21 @@ export interface DropdownBaseProps {
   children?: ((args: { getToggleProps: () => any }) => ReactNode) | ReactNode;
 
   /**
+   * Array of items to be rendered in the dropdown menu.
+   * Each item typically includes a `label`, and optionally a `type`, `props`, and `children`.
+   */
+  items?: DropdownItem[];
+
+  /**
    * Callback triggered when an item is selected.
    * Receives the full `item` object, allowing access to custom fields or props.
    */
   onSelect?: (item: DropdownItem) => void;
 
   /**
-   * Array of items to be rendered in the dropdown menu.
-   * Each item typically includes a `label`, and optionally a `type`, `props`, and `children`.
+   * Whether to render the dropdown menu in a portal.
    */
-  items?: DropdownItem[];
+  portalled?: boolean;
 
   /**
    * Optional custom render function for rendering individual items in the dropdown.
@@ -210,8 +215,9 @@ Each dropdown item is an object that may include the following fields:
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
 | children <sub>[1]</sub> | ReactNode | | The content inside the dropdown toggle. Can be a React node or a function that returns a React node. |
-| onSelect | `(item: DropdownItem) => void` | | Callback triggered when an item is selected. Receives the full `item` object, allowing you to access any custom fields or props defined for the item. |
 | items | `Array<DropdownItem>` | [] | An array of items to be rendered in the dropdown menu. Each item should include a `value` (required), and optionally a `label`, `type`, `props`, and `children`. |
+| onSelect | `(item: DropdownItem) => void` | | Callback triggered when an item is selected. Receives the full `item` object, allowing you to access any custom fields or props defined for the item. |
+| portalled | boolean | false | Whether to render the dropdown menu in a portal. |
 | renderItem | `(item: DropdownItem) => ReactNode` | `defaultRenderItem` <sub>[2]</sub> | Optional custom render function for rendering dropdown items. |
 | renderContent | `(args: { items: DropdownItem[], renderItem: (item: DropdownItem) => ReactNode, renderItems: (items: DropdownItem[], prefix?: string) => ReactNode[] }) => ReactNode` | | Optional custom function to render the entire dropdown's content. Provides access to `items`, `renderItem`, and `renderItems`. Use this to fully customize the dropdown content beyond the default rendering behavior. |
 | slots	<sub>[1]</sub> | `{ toggle?: React.ComponentType<any> }` | \{\} |	The components used for each slot inside the `DropdownBase`. Either a string to use a HTML element or a component. |

--- a/packages/react-docs/pages/experiments/dropdown-base/usage.js
+++ b/packages/react-docs/pages/experiments/dropdown-base/usage.js
@@ -66,8 +66,8 @@ const App = () => {
 
   return (
     <DropdownBase
-      onSelect={handleSelect}
       items={items}
+      onSelect={handleSelect}
       slots={{
         toggle: MenuButtonToggle,
       }}

--- a/packages/react-docs/pages/experiments/dropdown/index.page.mdx
+++ b/packages/react-docs/pages/experiments/dropdown/index.page.mdx
@@ -17,13 +17,13 @@ Here's the simplest configuration to get started with the `Dropdown` component.
 
 ```jsx
 <Dropdown
-  onSelect={(item) => {
-    setItem(item);
-  }}
   items={[
     { label: 'Item 1', value: 1 },
     { label: 'Item 2', value: 2 },
   ]}
+  onSelect={(item) => {
+    setItem(item);
+  }}
 >
   {item.label}
 </Dropdown>
@@ -45,8 +45,8 @@ By default, the dropdown uses a `MenuButton` as its toggle. To customize the tog
 
 ```jsx
 <Dropdown
-  onSelect={onSelect}
   items={items}
+  onSelect={onSelect}
   slots={{
     toggle: CustomDropdownToggle,
   }}

--- a/packages/react-docs/pages/experiments/dropdown/usage.js
+++ b/packages/react-docs/pages/experiments/dropdown/usage.js
@@ -180,9 +180,9 @@ const App = () => {
       </FormGroup>
       <Divider my="4x" />
       <Dropdown
+        items={items}
         offset={toggleOffset}
         onSelect={handleSelect}
-        items={items}
         renderContent={({ items, renderItems }) => (
           <Scrollbar
             maxHeight={200}

--- a/packages/react-docs/pages/experiments/search-dropdown/index.page.mdx
+++ b/packages/react-docs/pages/experiments/search-dropdown/index.page.mdx
@@ -15,13 +15,13 @@ Here's the simplest configuration to get started with the `SearchDropdown` compo
 
 ```jsx
 <SearchDropdown
-  onSelect={(item) => {
-    setItem(item);
-  }}
   items={[
     { label: 'Item 1', value: 1 },
     { label: 'Item 2', value: 2 },
   ]}
+  onSelect={(item) => {
+    setItem(item);
+  }}
   renderContent={({ items, renderItems, renderSearchInput }) => (
     <>
       <Box px="3x" mb="2x">

--- a/packages/react-docs/pages/experiments/search-dropdown/multi-select-dropdown.js
+++ b/packages/react-docs/pages/experiments/search-dropdown/multi-select-dropdown.js
@@ -197,6 +197,7 @@ const App = () => {
       <Divider my="4x" />
       <SearchDropdown
         closeOnSelect={false}
+        items={items}
         offset={toggleOffset}
         onClose={() => {
           if (isNoneSelected) {
@@ -204,7 +205,6 @@ const App = () => {
             setValues(items.map(item => item.value));
           }
         }}
-        items={items}
         renderContent={({ items, renderItems, renderSearchInput, searchKeyword }) => (
           <>
             <Box px="3x" mb="2x">

--- a/packages/react-docs/pages/experiments/search-dropdown/single-select-dropdown.js
+++ b/packages/react-docs/pages/experiments/search-dropdown/single-select-dropdown.js
@@ -154,9 +154,9 @@ const App = () => {
       </FormGroup>
       <Divider my="4x" />
       <SearchDropdown
+        items={items}
         offset={toggleOffset}
         onSelect={handleSelect}
-        items={items}
         renderContent={({ items, renderItems, renderSearchInput }) => (
           <>
             <Box px="3x" mb="2x">


### PR DESCRIPTION
### **PR Type**
Documentation, Enhancement


___

### **Description**
- Replaced `sx` prop usage with direct style props for base components

- Simplified style overrides in dropdown and submenu elements

- Improved code clarity and maintainability in dropdown base component


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DropdownBase.js</strong><dd><code>Use style props instead of `sx` in DropdownBase</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react-docs/experiments/dropdown/DropdownBase.js

<li>Replaced <code>sx</code> prop with direct style props (e.g., <code>width</code>, <code>minWidth</code>)<br> <li> Updated <code>SubmenuToggle</code>, <code>SubmenuList</code>, and <code>MenuList</code> to use style props<br> <li> Enhanced code readability and simplified style overrides


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/1035/files#diff-d92a280588a325e41730d02d53e9ad118107b643cef6d90a66df20934cd982c1">+6/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>