### PR TITLE
revert(react/InputGroup): restore pseudo-class from 'first-of-type' to ':first-child' to align with ui spec

### DIFF
--- a/.changeset/tonic-ui-pr-1038.md
+++ b/.changeset/tonic-ui-pr-1038.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": patch
+---
+
+revert(react/InputGroup): restore pseudo-class from 'first-of-type' to ':first-child' to align with ui spec

--- a/packages/react/src/input/styles.js
+++ b/packages/react/src/input/styles.js
@@ -669,11 +669,11 @@ const getInputGroupCSS = ({
   const useNegativeMargin = (variant === VARIANT_OUTLINE || variant === VARIANT_FILLED);
 
   return sx({
-    '&:not(:first-of-type)': {
+    '&:not(:first-child)': {
       borderTopLeftRadius: 0,
       borderBottomLeftRadius: 0,
     },
-    '&:not(:last-of-type)': {
+    '&:not(:last-child)': {
       borderTopRightRadius: 0,
       borderBottomRightRadius: 0,
     },
@@ -759,7 +759,7 @@ const getInputGroupAppendCSS = () => {
 
   return sx({
     '& > *:first-of-type': notFirstChildStyle,
-    '&:not(:last-of-type) > *:first-of-type': notLastChildStyle,
+    '&:not(:last-child) > *:first-of-type': notLastChildStyle,
   });
 };
 


### PR DESCRIPTION
Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-1038/

# User description
- Restore the pseudo-class from 'first-of-type' to ':first-child' 
- Restore the pseudo-class from 'last-of-type' to ':last-child' 

# Issue
Issue: https://github.com/trendmicro-frontend/tonic-ui/issues/1036

![Screenshot2025_06_25_153852](https://github.com/user-attachments/assets/905e0dce-c2a2-4b01-bd71-53bbf9415375)

![Screenshot2025_06_25_153905](https://github.com/user-attachments/assets/bae2ef40-7595-4e44-a768-10b218d147db)

# Root Cause
The InputGroup's child elements are of different types, causing unexpected UI styling when using first-of-type/last-of-type selectors.
![Screenshot2025_06_25_154145](https://github.com/user-attachments/assets/c5222711-a879-444d-bca4-51c2ee9ccfb1)

# Fix
![Screenshot2025_06_25_154033](https://github.com/user-attachments/assets/008f9f22-c041-43dd-b9e7-e25edcad6e48)

![Screenshot2025_06_25_154043](https://github.com/user-attachments/assets/3a0f0013-2e02-4e68-a6c8-fd78054a852c)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix InputGroup border radius styling by reverting pseudo-class selectors

- Change from `:first-of-type/:last-of-type` to `:first-child/:last-child`

- Resolve incorrect styling when InputGroup contains mixed element types


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.js</strong><dd><code>Revert pseudo-class selectors for InputGroup styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/input/styles.js

<li>Replace <code>:first-of-type</code> with <code>:first-child</code> in InputGroup CSS<br> <li> Replace <code>:last-of-type</code> with <code>:last-child</code> in InputGroup CSS<br> <li> Update InputGroupAppend CSS to use <code>:last-child</code> selector


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/1038/files#diff-c6e98b8745d0e4015f4e5b683fd5546392d7d47cb3f71fc067bc9d55b75189be">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>