### PR TITLE
docs: remove `closeOnOutsideClick` toggle to avoid overriding the default value of `closeOnInteractOutside`

### DIFF
--- a/packages/react-docs/pages/components/drawer/usage.js
+++ b/packages/react-docs/pages/components/drawer/usage.js
@@ -80,7 +80,6 @@ const App = () => {
   const [backdrop, toggleBackdrop] = useToggle(true);
   const [closeOnEsc, toggleCloseOnEsc] = useToggle(true);
   const [closeOnInteractOutside, toggleCloseOnInteractOutside] = useToggle(true);
-  const [closeOnOutsideClick, toggleCloseOnOutsideClick] = useToggle(false);
   const [ensureFocus, toggleEnsureFocus] = useToggle(true);
   const [isClosable, toggleIsClosable] = useToggle(true);
   const [returnFocusOnClose, toggleReturnFocusOnClose] = useToggle(true);
@@ -228,10 +227,7 @@ const App = () => {
     </FormGroup>
     <FormGroup>
       <TextLabel display="flex" alignItems="center">
-        <Checkbox
-          checked={closeOnOutsideClick}
-          onChange={() => toggleCloseOnOutsideClick()}
-        />
+        <Checkbox disabled />
         <Space width="2x" />
         <Text fontFamily="mono" whiteSpace="nowrap">closeOnOutsideClick (deprecated)</Text>
         <Space width="2x" />
@@ -343,7 +339,6 @@ const App = () => {
       backdrop={backdrop}
       closeOnEsc={closeOnEsc}
       closeOnInteractOutside={closeOnInteractOutside}
-      closeOnOutsideClick={closeOnOutsideClick}
       ensureFocus={ensureFocus}
       initialFocusRef={initialFocusRef}
       isClosable={isClosable}

--- a/packages/react-docs/pages/components/modal/usage.js
+++ b/packages/react-docs/pages/components/modal/usage.js
@@ -82,7 +82,6 @@ const App = () => {
   const [autoFocus, toggleAutoFocus] = useToggle(true);
   const [closeOnEsc, toggleCloseOnEsc] = useToggle(true);
   const [closeOnInteractOutside, toggleCloseOnInteractOutside] = useToggle(true);
-  const [closeOnOutsideClick, toggleCloseOnOutsideClick] = useToggle(false);
   const [ensureFocus, toggleEnsureFocus] = useToggle(true);
   const [isClosable, toggleIsCloseButtonVisible] = useToggle(true);
   const [returnFocusOnClose, toggleReturnFocusOnClose] = useToggle(true);
@@ -228,10 +227,7 @@ const App = () => {
       </FormGroup>
       <FormGroup>
         <TextLabel display="flex" alignItems="center">
-          <Checkbox
-            checked={closeOnOutsideClick}
-            onChange={() => toggleCloseOnOutsideClick()}
-          />
+          <Checkbox disabled />
           <Space width="2x" />
           <Text fontFamily="mono" whiteSpace="nowrap">closeOnOutsideClick (deprecated)</Text>
           <Space width="2x" />
@@ -409,7 +405,6 @@ const App = () => {
         autoFocus={autoFocus}
         closeOnEsc={closeOnEsc}
         closeOnInteractOutside={closeOnInteractOutside}
-        closeOnOutsideClick={closeOnOutsideClick}
         ensureFocus={ensureFocus}
         initialFocusRef={initialFocusRef}
         isClosable={isClosable}


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Remove deprecated `closeOnOutsideClick` prop from Drawer and Modal usage examples

- Replace interactive checkbox with disabled one for deprecated prop

- Clean up unused state variables and handlers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Usage Examples"] --> B["Remove closeOnOutsideClick State"]
  B --> C["Disable Deprecated Checkbox"]
  C --> D["Remove Prop from Components"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usage.js</strong><dd><code>Remove deprecated closeOnOutsideClick from Drawer usage</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/react-docs/pages/components/drawer/usage.js

<ul><li>Remove <code>closeOnOutsideClick</code> state variable and toggle handler<br> <li> Replace interactive checkbox with disabled one for deprecated prop<br> <li> Remove <code>closeOnOutsideClick</code> prop from Drawer component</ul>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/1054/files#diff-54040df90e871545d3b80e0530f45ad5945fc864b9df9e0bf903143d98c4b2dd">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>usage.js</strong><dd><code>Remove deprecated closeOnOutsideClick from Modal usage</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react-docs/pages/components/modal/usage.js

<ul><li>Remove <code>closeOnOutsideClick</code> state variable and toggle handler<br> <li> Replace interactive checkbox with disabled one for deprecated prop<br> <li> Remove <code>closeOnOutsideClick</code> prop from Modal component</ul>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/1054/files#diff-03b71f37144eef46a9e4a92b078b1f6af4a87cf45f73bf2c5d36f189ae8811e4">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

