### PR TITLE
feat: support element `ref` compatibility in `PopoverTrigger` and `TooltipTrigger` for React 19+

### DIFF
--- a/.changeset/tonic-ui-pr-1077.md
+++ b/.changeset/tonic-ui-pr-1077.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": patch
+---
+
+feat: support element `ref` compatibility in `PopoverTrigger` and `TooltipTrigger` for React 19+

--- a/packages/react/src/popover/PopoverTrigger.js
+++ b/packages/react/src/popover/PopoverTrigger.js
@@ -150,7 +150,21 @@ const PopoverTrigger = forwardRef((inProps, ref) => {
 
   // Ensure popover has only one child node
   const child = React.Children.only(children);
-  const popoverTriggerProps = getPopoverTriggerProps(child?.props, child?.ref);
+
+  // Access the child's props for later use
+  const childProps = child?.props;
+
+  // In React 19, `ref` on function components is passed as a normal prop.
+  // This fallback maintains compatibility with both React 18 and 19.
+  //
+  // React 19 will not throw an error if `ref` is `null` or `undefined`:
+  // ```
+  // Accessing `element.ref` was removed in React 19. `ref` is now a regular prop.
+  // It will be removed from the JSX Element type in a future release.
+  // ```
+  const childRef = child?.props?.ref ?? child?.ref;
+
+  const popoverTriggerProps = getPopoverTriggerProps(childProps, childRef);
 
   return cloneElement(child, popoverTriggerProps);
 });

--- a/packages/react/src/tooltip/TooltipTrigger.js
+++ b/packages/react/src/tooltip/TooltipTrigger.js
@@ -132,7 +132,21 @@ const TooltipTrigger = forwardRef((inProps, ref) => {
 
   // Ensure tooltip has only one child node
   const child = React.Children.only(children);
-  const tooltipTriggerProps = getTooltipTriggerProps(child?.props, child?.ref);
+
+  // Access the child's props for later use
+  const childProps = child?.props;
+
+  // In React 19, `ref` on function components is passed as a normal prop.
+  // This fallback maintains compatibility with both React 18 and 19.
+  //
+  // React 19 will not throw an error if `ref` is `null` or `undefined`:
+  // ```
+  // Accessing `element.ref` was removed in React 19. `ref` is now a regular prop.
+  // It will be removed from the JSX Element type in a future release.
+  // ```
+  const childRef = child?.props?.ref ?? child?.ref;
+
+  const tooltipTriggerProps = getTooltipTriggerProps(childProps, childRef);
 
   return cloneElement(child, tooltipTriggerProps);
 });


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add React 19 compatibility for `ref` handling in PopoverTrigger

- Add React 19 compatibility for `ref` handling in TooltipTrigger

- Support `ref` as normal prop in React 19 while maintaining React 18 compatibility

- Use fallback logic to access `ref` from props or element ref attribute


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["React 18/19 ref handling"] --> B["Check props.ref first"]
  B --> C["Fallback to element.ref"]
  C --> D["PopoverTrigger & TooltipTrigger updated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PopoverTrigger.js</strong><dd><code>Add React 19 ref compatibility to PopoverTrigger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/popover/PopoverTrigger.js

<ul><li>Extract child props separately for clarity<br> <li> Implement fallback logic to access <code>ref</code> from <code>child?.props?.ref</code> or <br><code>child?.ref</code><br> <li> Add detailed comments explaining React 19 ref compatibility changes<br> <li> Pass extracted <code>childRef</code> to <code>getPopoverTriggerProps()</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/1077/files#diff-5f0f46c8bfd6820fe906025dc45c45154f0692f8bac0d966b07d87c21138f803">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TooltipTrigger.js</strong><dd><code>Add React 19 ref compatibility to TooltipTrigger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/tooltip/TooltipTrigger.js

<ul><li>Extract child props separately for clarity<br> <li> Implement fallback logic to access <code>ref</code> from <code>child?.props?.ref</code> or <br><code>child?.ref</code><br> <li> Add detailed comments explaining React 19 ref compatibility changes<br> <li> Pass extracted <code>childRef</code> to <code>getTooltipTriggerProps()</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/trendmicro-frontend/tonic-ui/pull/1077/files#diff-a82784781221b4fbecf8e99d94f5414a8a70c35e8e7ef58b3562ff1af0403533">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).