### PR TITLE
feat(react/menu): add keyboard navigation support to `Submenu` component

### DIFF
--- a/.changeset/tonic-ui-pr-1086.md
+++ b/.changeset/tonic-ui-pr-1086.md
@@ -1,5 +1,5 @@
 ---
-"@tonic-ui/react": patch
+"@tonic-ui/react": minor
 ---
 
 feat(react/menu): add keyboard navigation support to `Submenu` component

--- a/.changeset/tonic-ui-pr-1086.md
+++ b/.changeset/tonic-ui-pr-1086.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": patch
+---
+
+feat(react/menu): add keyboard navigation support to `Submenu` component

--- a/packages/react/src/menu/Submenu.js
+++ b/packages/react/src/menu/Submenu.js
@@ -72,33 +72,28 @@ const Submenu = forwardRef((inProps, ref) => {
   }, [isOpenProp, onOpenProp]);
 
   const focusOnFirstItem = useCallback(() => {
-    // Use requestAnimationFrame to ensure submenu content is rendered
-    requestAnimationFrame(() => {
-      const focusableElements = getFocusableElements();
-      if (focusableElements.length > 0) {
-        setActiveIndex(0);
-        const el = focusableElements[0];
-        el && el.focus();
-        focusableElements.forEach((node, index) => {
-          node.setAttribute('tabindex', index === 0 ? 0 : -1);
-        });
-      }
-    });
+    const focusableElements = getFocusableElements();
+    if (focusableElements.length > 0) {
+      setActiveIndex(0);
+      const el = focusableElements[0];
+      el && el.focus();
+      focusableElements.forEach((node, index) => {
+        node.setAttribute('tabindex', index === 0 ? 0 : -1);
+      });
+    }
   }, [getFocusableElements]);
 
   const focusOnLastItem = useCallback(() => {
-    requestAnimationFrame(() => {
-      const focusableElements = getFocusableElements();
-      if (focusableElements.length > 0) {
-        const lastIndex = focusableElements.length - 1;
-        setActiveIndex(lastIndex);
-        const el = focusableElements[lastIndex];
-        el && el.focus();
-        focusableElements.forEach((node, index) => {
-          node.setAttribute('tabindex', index === lastIndex ? 0 : -1);
-        });
-      }
-    });
+    const focusableElements = getFocusableElements();
+    if (focusableElements.length > 0) {
+      const lastIndex = focusableElements.length - 1;
+      setActiveIndex(lastIndex);
+      const el = focusableElements[lastIndex];
+      el && el.focus();
+      focusableElements.forEach((node, index) => {
+        node.setAttribute('tabindex', index === lastIndex ? 0 : -1);
+      });
+    }
   }, [getFocusableElements]);
 
   const focusOnNextItem = useCallback(() => {

--- a/packages/react/src/menu/Submenu.js
+++ b/packages/react/src/menu/Submenu.js
@@ -1,5 +1,5 @@
 import { useId } from '@tonic-ui/react-hooks';
-import { runIfFn } from '@tonic-ui/utils';
+import { getAllFocusable, runIfFn } from '@tonic-ui/utils';
 import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../box';
@@ -26,6 +26,16 @@ const Submenu = forwardRef((inProps, ref) => {
   const isHoveringSubmenuContentRef = useRef();
   const isHoveringSubmenuToggleRef = useRef();
   const [isOpen, setIsOpen] = useState(isOpenProp ?? defaultIsOpen);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const getFocusableElements = useCallback(() => {
+    if (!submenuContentRef.current) {
+      return [];
+    }
+    const focusableElements = getAllFocusable(submenuContentRef.current)
+      .filter(node => (node.getAttribute('role') === 'menuitem'));
+    return focusableElements;
+  }, []);
 
   useEffect(() => {
     const isControlled = (isOpenProp !== undefined);
@@ -43,7 +53,12 @@ const Submenu = forwardRef((inProps, ref) => {
     if (typeof onCloseProp === 'function') {
       onCloseProp();
     }
-  }, [isOpenProp, onCloseProp]);
+
+    // Reset active index and tab indices when closing
+    setActiveIndex(-1);
+    const focusableElements = getFocusableElements();
+    focusableElements.forEach(node => node.setAttribute('tabindex', -1));
+  }, [getFocusableElements, isOpenProp, onCloseProp]);
 
   const onOpen = useCallback(() => {
     const isControlled = (isOpenProp !== undefined);
@@ -56,12 +71,78 @@ const Submenu = forwardRef((inProps, ref) => {
     }
   }, [isOpenProp, onOpenProp]);
 
+  const focusOnFirstItem = useCallback(() => {
+    // Use requestAnimationFrame to ensure submenu content is rendered
+    requestAnimationFrame(() => {
+      const focusableElements = getFocusableElements();
+      if (focusableElements.length > 0) {
+        setActiveIndex(0);
+        const el = focusableElements[0];
+        el && el.focus();
+        focusableElements.forEach((node, index) => {
+          node.setAttribute('tabindex', index === 0 ? 0 : -1);
+        });
+      }
+    });
+  }, [getFocusableElements]);
+
+  const focusOnLastItem = useCallback(() => {
+    requestAnimationFrame(() => {
+      const focusableElements = getFocusableElements();
+      if (focusableElements.length > 0) {
+        const lastIndex = focusableElements.length - 1;
+        setActiveIndex(lastIndex);
+        const el = focusableElements[lastIndex];
+        el && el.focus();
+        focusableElements.forEach((node, index) => {
+          node.setAttribute('tabindex', index === lastIndex ? 0 : -1);
+        });
+      }
+    });
+  }, [getFocusableElements]);
+
+  const focusOnNextItem = useCallback(() => {
+    const focusableElements = getFocusableElements();
+    if (focusableElements.length > 0) {
+      const nextIndex = (activeIndex + 1) % focusableElements.length;
+      setActiveIndex(nextIndex);
+      const el = focusableElements[nextIndex];
+      el && el.focus();
+      focusableElements.forEach((node, index) => {
+        node.setAttribute('tabindex', index === nextIndex ? 0 : -1);
+      });
+    }
+  }, [activeIndex, getFocusableElements]);
+
+  const focusOnPreviousItem = useCallback(() => {
+    const focusableElements = getFocusableElements();
+    if (focusableElements.length > 0) {
+      const prevIndex = (activeIndex - 1 + focusableElements.length) % focusableElements.length;
+      setActiveIndex(prevIndex);
+      const el = focusableElements[prevIndex];
+      el && el.focus();
+      focusableElements.forEach((node, index) => {
+        node.setAttribute('tabindex', index === prevIndex ? 0 : -1);
+      });
+    }
+  }, [activeIndex, getFocusableElements]);
+
+  const focusOnSubmenuToggle = useCallback(() => {
+    const el = submenuToggleRef.current;
+    el && el.focus();
+  }, []);
+
   const defaultId = useId();
   const submenuId = `${config.name}:Submenu-${defaultId}`;
   const submenuToggleId = `${config.name}:SubmenuToggle-${defaultId}`;
   const styleProps = useSubmenuStyle();
 
   const context = getMemoizedState({
+    focusOnFirstItem,
+    focusOnLastItem,
+    focusOnNextItem,
+    focusOnPreviousItem,
+    focusOnSubmenuToggle,
     isHoveringSubmenuContentRef,
     isHoveringSubmenuToggleRef,
     isOpen,

--- a/packages/react/src/menu/SubmenuContent.js
+++ b/packages/react/src/menu/SubmenuContent.js
@@ -16,6 +16,7 @@ const SubmenuContent = forwardRef((inProps, ref) => {
     TransitionComponent = Collapse,
     TransitionProps,
     children,
+    onKeyDown: onKeyDownProp,
     onMouseEnter: onMouseEnterProp,
     onMouseLeave: onMouseLeaveProp,
     ...rest
@@ -29,6 +30,11 @@ const SubmenuContent = forwardRef((inProps, ref) => {
     submenuContentRefs,
   } = { ...menuContext };
   const {
+    focusOnFirstItem,
+    focusOnLastItem,
+    focusOnNextItem,
+    focusOnPreviousItem,
+    focusOnSubmenuToggle,
     isHoveringSubmenuContentRef,
     isHoveringSubmenuToggleRef,
     isOpen,
@@ -80,6 +86,48 @@ const SubmenuContent = forwardRef((inProps, ref) => {
     }, 100); // XXX: keep opening Submenu when cursor quickly move between SubmenuToggle and SubmenuContent
   };
 
+  // Keyboard navigation for submenu content
+  eventHandler.onKeyDown = function (event) {
+    const key = event?.key;
+    const shiftKey = event?.shiftKey;
+
+    // Determine the close direction based on placement
+    // For 'right-start' or 'right-end', ArrowLeft closes the submenu
+    // For 'left-start' or 'left-end', ArrowRight closes the submenu
+    const isRightPlacement = placement?.startsWith('right');
+    const closeKey = isRightPlacement ? 'ArrowLeft' : 'ArrowRight';
+
+    // Navigate submenu items using keyboard
+    if (key === 'ArrowDown') {
+      event.preventDefault();
+      ensureFunction(focusOnNextItem)();
+    }
+    if (key === 'ArrowUp') {
+      event.preventDefault();
+      ensureFunction(focusOnPreviousItem)();
+    }
+    if (key === 'End') {
+      event.preventDefault();
+      ensureFunction(focusOnLastItem)();
+    }
+    if (key === 'Home') {
+      event.preventDefault();
+      ensureFunction(focusOnFirstItem)();
+    }
+    if (key === 'Tab') {
+      event.preventDefault();
+      ensureFunction(shiftKey ? focusOnPreviousItem : focusOnNextItem)();
+    }
+
+    // Close submenu and return focus to toggle
+    if (key === closeKey || key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      ensureFunction(focusOnSubmenuToggle)();
+      ensureFunction(closeSubmenu)();
+    }
+  };
+
   const tabIndex = -1;
   const styleProps = useSubmenuContentStyle({ tabIndex });
 
@@ -126,6 +174,7 @@ const SubmenuContent = forwardRef((inProps, ref) => {
       usePortal={false} // Pass `true` in `PopperProps` to render menu in a portal
       willUseTransition={true}
       zIndex="dropdown"
+      onKeyDown={callEventHandlers(onKeyDownProp, eventHandler.onKeyDown)}
       onMouseEnter={callEventHandlers(onMouseEnterProp, eventHandler.onMouseEnter)}
       onMouseLeave={callEventHandlers(onMouseLeaveProp, eventHandler.onMouseLeave)}
       {...PopperProps}

--- a/packages/react/src/menu/SubmenuToggle.js
+++ b/packages/react/src/menu/SubmenuToggle.js
@@ -1,5 +1,5 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
-import { ariaAttr, callEventHandlers } from '@tonic-ui/utils';
+import { ariaAttr, callEventHandlers, getAllFocusable } from '@tonic-ui/utils';
 import { ensureFunction } from 'ensure-type';
 import React, { forwardRef, useRef } from 'react';
 import { Box } from '../box';
@@ -81,9 +81,10 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
     const wrapper = event.currentTarget;
     if (event.target === wrapper) {
       // Find the first focusable element inside the wrapper
-      const focusableElement = wrapper.querySelector('[tabindex], button, a, input, select, textarea');
-      if (focusableElement && focusableElement !== wrapper) {
-        focusableElement.focus();
+      const focusableElements = getAllFocusable(wrapper);
+      const firstFocusable = focusableElements[0];
+      if (firstFocusable && firstFocusable !== wrapper) {
+        firstFocusable.focus();
       }
     }
   };

--- a/packages/react/src/menu/SubmenuToggle.js
+++ b/packages/react/src/menu/SubmenuToggle.js
@@ -104,11 +104,16 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
     const openKey = isRightPlacement ? 'ArrowRight' : 'ArrowLeft';
     const closeKey = isRightPlacement ? 'ArrowLeft' : 'ArrowRight';
 
-    if (key === openKey || key === 'Enter' || key === ' ') {
+    if (key === openKey) {
       event.preventDefault();
       event.stopPropagation();
       ensureFunction(openSubmenu)();
-      ensureFunction(focusOnFirstItem)();
+      // Use requestAnimationFrame to ensure the submenu content is rendered in the DOM
+      // before attempting to focus. Without this, focusOnFirstItem would run before
+      // React has painted the newly opened submenu, resulting in an empty element list.
+      requestAnimationFrame(() => {
+        ensureFunction(focusOnFirstItem)();
+      });
     }
 
     // Close submenu with closeKey (ArrowLeft for right placement) or Escape when submenu is open

--- a/packages/react/src/menu/SubmenuToggle.js
+++ b/packages/react/src/menu/SubmenuToggle.js
@@ -13,6 +13,8 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
   const {
     children,
     disabled,
+    onFocus: onFocusProp,
+    onKeyDown: onKeyDownProp,
     onMouseEnter: onMouseEnterProp,
     onMouseLeave: onMouseLeaveProp,
     ...rest
@@ -20,11 +22,13 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
   const mouseLeaveTimeoutRef = useRef();
   const submenuContext = useSubmenu(); // context might be an undefined value
   const {
+    focusOnFirstItem,
     isHoveringSubmenuContentRef,
     isHoveringSubmenuToggleRef,
     isOpen,
     onClose: closeSubmenu,
     onOpen: openSubmenu,
+    placement,
     submenuId,
     submenuToggleId,
     submenuToggleRef,
@@ -67,6 +71,53 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
     }, 100); // XXX: keep opening Submenu when cursor quickly move between SubmenuToggle and SubmenuContent
   };
 
+  // When used as a wrapper, forward focus to the first focusable element (MenuItem) inside
+  eventHandler.onFocus = function (event) {
+    if (disabled) {
+      return;
+    }
+
+    // Only forward focus if the event target is the wrapper itself
+    const wrapper = event.currentTarget;
+    if (event.target === wrapper) {
+      // Find the first focusable element inside the wrapper
+      const focusableElement = wrapper.querySelector('[tabindex], button, a, input, select, textarea');
+      if (focusableElement && focusableElement !== wrapper) {
+        focusableElement.focus();
+      }
+    }
+  };
+
+  // Keyboard navigation for submenu toggle
+  eventHandler.onKeyDown = function (event) {
+    if (disabled) {
+      return;
+    }
+
+    const key = event?.key;
+
+    // Determine the open/close direction based on placement
+    // For 'right-start' or 'right-end', ArrowRight opens the submenu
+    // For 'left-start' or 'left-end', ArrowLeft opens the submenu
+    const isRightPlacement = placement?.startsWith('right');
+    const openKey = isRightPlacement ? 'ArrowRight' : 'ArrowLeft';
+    const closeKey = isRightPlacement ? 'ArrowLeft' : 'ArrowRight';
+
+    if (key === openKey || key === 'Enter' || key === ' ') {
+      event.preventDefault();
+      event.stopPropagation();
+      ensureFunction(openSubmenu)();
+      ensureFunction(focusOnFirstItem)();
+    }
+
+    // Close submenu with closeKey (ArrowLeft for right placement) or Escape when submenu is open
+    if ((key === closeKey || key === 'Escape') && isOpen) {
+      event.preventDefault();
+      event.stopPropagation();
+      ensureFunction(closeSubmenu)();
+    }
+  };
+
   const getSubmenuToggleProps = () => ({
     'aria-controls': submenuId,
     'aria-disabled': ariaAttr(disabled),
@@ -74,10 +125,13 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
     'aria-haspopup': 'menu',
     disabled,
     id: submenuToggleId,
+    onFocus: callEventHandlers(onFocusProp, eventHandler.onFocus),
+    onKeyDown: callEventHandlers(onKeyDownProp, eventHandler.onKeyDown),
     onMouseEnter: callEventHandlers(onMouseEnterProp, eventHandler.onMouseEnter),
     onMouseLeave: callEventHandlers(onMouseLeaveProp, eventHandler.onMouseLeave),
     ref: combinedRef,
-    role: 'presentation',
+    role: 'menuitem',
+    tabIndex: -1,
     ...styleProps,
     ...rest,
   });
@@ -88,8 +142,13 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
     });
   }
 
+  // When used as a wrapper, use role="presentation" since the child MenuItem
+  // has its own role="menuitem"
   return (
-    <Box {...getSubmenuToggleProps()}>
+    <Box
+      {...getSubmenuToggleProps()}
+      role="presentation"
+    >
       {children}
     </Box>
   );

--- a/packages/react/src/menu/__tests__/Menu.test.js
+++ b/packages/react/src/menu/__tests__/Menu.test.js
@@ -3,16 +3,10 @@ import userEvent from '@testing-library/user-event';
 import { render } from '@tonic-ui/react/test-utils/render';
 import { testA11y } from '@tonic-ui/react/test-utils/accessibility';
 import {
-  Flex,
   Menu,
   MenuButton,
-  MenuDivider,
   MenuList,
   MenuItem,
-  Submenu,
-  SubmenuList,
-  SubmenuToggle,
-  Text,
 } from '@tonic-ui/react/src';
 import React from 'react';
 
@@ -87,8 +81,10 @@ describe('Menu', () => {
     // Open the menu
     await user.click(button);
 
-    // The menu list should have focus
-    expect(screen.getByTestId('menu-list')).toHaveFocus();
+    // Wait for the menu list to have focus
+    await waitFor(() => {
+      expect(screen.getByTestId('menu-list')).toHaveFocus();
+    });
 
     // Close the menu
     await user.click(document.body);
@@ -112,7 +108,9 @@ describe('Menu', () => {
     // Press Enter to open menu
     await user.keyboard('[Enter]');
     expect(await screen.findByRole('menu')).toBeInTheDocument();
-    expect(screen.getByTestId('menu-list')).toHaveFocus();
+    await waitFor(() => {
+      expect(screen.getByTestId('menu-list')).toHaveFocus();
+    });
 
     // Press Escape to close menu
     await user.keyboard('[Escape]');
@@ -123,7 +121,9 @@ describe('Menu', () => {
     // Press Space to open menu
     await user.keyboard('[Space]');
     expect(await screen.findByRole('menu')).toBeInTheDocument();
-    expect(screen.getByTestId('menu-list')).toHaveFocus();
+    await waitFor(() => {
+      expect(screen.getByTestId('menu-list')).toHaveFocus();
+    });
 
     // Press Escape to close menu
     await user.keyboard('[Escape]');
@@ -143,22 +143,30 @@ describe('Menu', () => {
       await user.click(button);
       expect(await screen.findByRole('menu')).toBeInTheDocument();
 
-      // The menu list should have focus
+      // Wait for the menu list to have focus
       const menuList = screen.getByTestId('menu-list');
-      expect(menuList).toHaveFocus();
+      await waitFor(() => {
+        expect(menuList).toHaveFocus();
+      });
 
       // Press ArrowDown to focus the first menu item
       await user.keyboard('[ArrowDown]');
       const menuItems = screen.getAllByRole('menuitem');
-      expect(menuItems[0]).toHaveFocus();
+      await waitFor(() => {
+        expect(menuItems[0]).toHaveFocus();
+      });
 
       // Press ArrowDown to focus the second menu item
       await user.keyboard('[ArrowDown]');
-      expect(menuItems[1]).toHaveFocus();
+      await waitFor(() => {
+        expect(menuItems[1]).toHaveFocus();
+      });
 
       // Press ArrowUp to go back to the first menu item
       await user.keyboard('[ArrowUp]');
-      expect(menuItems[0]).toHaveFocus();
+      await waitFor(() => {
+        expect(menuItems[0]).toHaveFocus();
+      });
     });
 
     it('should navigate to first/last item with Home and End keys', async () => {
@@ -174,252 +182,21 @@ describe('Menu', () => {
       // Press ArrowDown to focus the first menu item
       await user.keyboard('[ArrowDown]');
       const menuItems = screen.getAllByRole('menuitem');
-      expect(menuItems[0]).toHaveFocus();
+      await waitFor(() => {
+        expect(menuItems[0]).toHaveFocus();
+      });
 
       // Press End to go to the last menu item
       await user.keyboard('[End]');
       // The last non-disabled item should be focused
-      expect(menuItems[1]).toHaveFocus();
+      await waitFor(() => {
+        expect(menuItems[1]).toHaveFocus();
+      });
 
       // Press Home to go back to the first menu item
       await user.keyboard('[Home]');
-      expect(menuItems[0]).toHaveFocus();
-    });
-  });
-
-  describe('Submenu with portal', () => {
-    // NOTE: Test that uses fake timers must run last to avoid test isolation issues
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
-    it('should close the menu when clicking outside both menu and submenu content', async () => {
-      const user = userEvent.setup();
-
-      const SubmenuTestComponent = () => {
-        return (
-          <Menu>
-            <MenuButton data-testid="menu-button">
-              Options
-            </MenuButton>
-            <MenuList
-              data-testid="menu-list"
-              PopperProps={{
-                usePortal: true,
-              }}
-            >
-              <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
-              <MenuDivider />
-              <Submenu>
-                <SubmenuToggle data-testid="submenu-toggle">
-                  <MenuItem>
-                    <Flex alignItems="center" justifyContent="space-between" width="100%">
-                      <Text>Submenu</Text>
-                    </Flex>
-                  </MenuItem>
-                </SubmenuToggle>
-                <SubmenuList
-                  data-testid="submenu-list"
-                  PopperProps={{
-                    usePortal: true,
-                  }}
-                >
-                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
-                </SubmenuList>
-              </Submenu>
-            </MenuList>
-          </Menu>
-        );
-      };
-
-      render(
-        <>
-          <SubmenuTestComponent />
-          <button data-testid="outside-button">Outside</button>
-        </>
-      );
-
-      const menuButton = screen.getByTestId('menu-button');
-
-      // Open the menu
-      await user.click(menuButton);
-
-      // The menu should be open
-      expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
-
-      // Hover over the submenu toggle to open the submenu
-      const submenuToggle = screen.getByTestId('submenu-toggle');
-      await user.hover(submenuToggle);
-
-      // The submenu should be open
       await waitFor(() => {
-        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
-      });
-
-      // Click outside the menu and submenu
-      const outsideButton = screen.getByTestId('outside-button');
-      await user.click(outsideButton);
-
-      // The menu should be closed
-      await waitFor(() => {
-        expect(screen.queryByTestId('menu-list')).not.toBeInTheDocument();
-      });
-    });
-
-    it('should receive click events when clicking submenu items rendered in a portal', async () => {
-      const user = userEvent.setup();
-      const handleMenuListClick = jest.fn();
-
-      const SubmenuTestComponent = () => {
-        return (
-          <Menu>
-            <MenuButton data-testid="menu-button">
-              Options
-            </MenuButton>
-            <MenuList
-              data-testid="menu-list"
-              onClick={handleMenuListClick}
-              PopperProps={{
-                usePortal: true,
-              }}
-            >
-              <MenuItem value="1">Menu item 1</MenuItem>
-              <MenuItem value="2">Menu item 2</MenuItem>
-              <MenuDivider />
-              <Submenu>
-                <SubmenuToggle data-testid="submenu-toggle">
-                  <MenuItem>
-                    <Flex alignItems="center" justifyContent="space-between" width="100%">
-                      <Text>Submenu</Text>
-                    </Flex>
-                  </MenuItem>
-                </SubmenuToggle>
-                <SubmenuList
-                  data-testid="submenu-list"
-                  PopperProps={{
-                    usePortal: true,
-                  }}
-                >
-                  <MenuItem data-testid="submenu-item-1" value="3">
-                    Submenu item 1
-                  </MenuItem>
-                  <MenuItem value="4">Submenu item 2</MenuItem>
-                </SubmenuList>
-              </Submenu>
-            </MenuList>
-          </Menu>
-        );
-      };
-
-      render(<SubmenuTestComponent />);
-
-      const menuButton = screen.getByTestId('menu-button');
-
-      // Open the menu
-      await user.click(menuButton);
-
-      // The menu should be open
-      expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
-
-      // Hover over the submenu toggle to open the submenu
-      const submenuToggle = screen.getByTestId('submenu-toggle');
-      await user.hover(submenuToggle);
-
-      // The submenu should be open
-      await waitFor(() => {
-        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
-      });
-
-      // Click on a submenu item
-      const submenuItem = screen.getByTestId('submenu-item-1');
-      await user.click(submenuItem);
-
-      // Verify the onClick event was received by the menu list
-      expect(handleMenuListClick).toHaveBeenCalledTimes(1);
-
-      // Verify the event target has the correct value
-      const clickEvent = handleMenuListClick.mock.calls[0][0];
-      expect(clickEvent.target.getAttribute('value')).toBe('3');
-
-      // The menu should still be open (not closed by the click on submenu item)
-      expect(screen.getByTestId('menu-list')).toBeInTheDocument();
-    });
-
-    it('should close submenu when mouse leaves both toggle and content', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-      const SubmenuTestComponent = () => {
-        return (
-          <Menu>
-            <MenuButton data-testid="menu-button">
-              Options
-            </MenuButton>
-            <MenuList
-              data-testid="menu-list"
-              PopperProps={{
-                usePortal: true,
-              }}
-            >
-              <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
-              <MenuDivider />
-              <Submenu>
-                <SubmenuToggle data-testid="submenu-toggle">
-                  <MenuItem>
-                    <Flex alignItems="center" justifyContent="space-between" width="100%">
-                      <Text>Submenu</Text>
-                    </Flex>
-                  </MenuItem>
-                </SubmenuToggle>
-                <SubmenuList
-                  data-testid="submenu-list"
-                  PopperProps={{
-                    usePortal: true,
-                  }}
-                >
-                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
-                </SubmenuList>
-              </Submenu>
-            </MenuList>
-          </Menu>
-        );
-      };
-
-      render(<SubmenuTestComponent />);
-
-      const menuButton = screen.getByTestId('menu-button');
-
-      // Open the menu
-      await user.click(menuButton);
-
-      // The menu should be open
-      expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
-
-      // Hover over the submenu toggle to open the submenu
-      const submenuToggle = screen.getByTestId('submenu-toggle');
-      await user.hover(submenuToggle);
-
-      // The submenu should be open
-      await waitFor(() => {
-        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
-      });
-
-      // Move to submenu content
-      const submenuList = screen.getByTestId('submenu-list');
-      await user.hover(submenuList);
-
-      // The submenu should still be open
-      expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
-
-      // Move mouse away from submenu
-      await user.unhover(submenuList);
-
-      // Advance timers to trigger the close timeout
-      jest.advanceTimersByTime(150);
-
-      // The submenu should be closed after the timeout
-      await waitFor(() => {
-        expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
+        expect(menuItems[0]).toHaveFocus();
       });
     });
   });

--- a/packages/react/src/menu/__tests__/Submenu.test.js
+++ b/packages/react/src/menu/__tests__/Submenu.test.js
@@ -1,0 +1,572 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@tonic-ui/react/test-utils/render';
+import {
+  Flex,
+  Menu,
+  MenuButton,
+  MenuDivider,
+  MenuList,
+  MenuItem,
+  Submenu,
+  SubmenuList,
+  SubmenuToggle,
+  Text,
+} from '@tonic-ui/react/src';
+import React from 'react';
+
+describe('Submenu', () => {
+  describe('Submenu keyboard navigation', () => {
+    // Note: Use the render function pattern so MenuItem receives the props (role, tabIndex, aria attributes)
+    // This ensures focus-visible styling appears on MenuItem, not on a wrapper element
+    const SubmenuKeyboardTestComponent = (props) => {
+      return (
+        <Menu {...props}>
+          <MenuButton data-testid="menu-button">
+            Options
+          </MenuButton>
+          <MenuList data-testid="menu-list">
+            <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
+            <MenuItem data-testid="menu-item-2">Menu item 2</MenuItem>
+            <MenuDivider />
+            <Submenu>
+              <SubmenuToggle>
+                {({ getSubmenuToggleProps }) => (
+                  <MenuItem data-testid="submenu-toggle" {...getSubmenuToggleProps()}>
+                    <Flex alignItems="center" justifyContent="space-between" width="100%">
+                      <Text>Submenu</Text>
+                    </Flex>
+                  </MenuItem>
+                )}
+              </SubmenuToggle>
+              <SubmenuList data-testid="submenu-list">
+                <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                <MenuItem data-testid="submenu-item-2">Submenu item 2</MenuItem>
+                <MenuItem data-testid="submenu-item-3">Submenu item 3</MenuItem>
+              </SubmenuList>
+            </Submenu>
+            <MenuItem data-testid="menu-item-3">Menu item 3</MenuItem>
+          </MenuList>
+        </Menu>
+      );
+    };
+
+    it('should open submenu with ArrowRight and focus first item', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu toggle using keyboard
+      await user.keyboard('[ArrowDown]'); // Focus menu-item-1
+      await user.keyboard('[ArrowDown]'); // Focus menu-item-2
+      await user.keyboard('[ArrowDown]'); // Focus submenu-toggle
+
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      // Press ArrowRight to open submenu
+      await user.keyboard('[ArrowRight]');
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // The first submenu item should be focused
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+    });
+
+    it('should open submenu with Enter key and focus first item', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu toggle
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      // Press Enter to open submenu
+      await user.keyboard('[Enter]');
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // The first submenu item should be focused
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+    });
+
+    it('should close submenu with ArrowLeft and return focus to toggle', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu toggle and open it
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      await user.keyboard('[ArrowRight]');
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // The first submenu item should be focused
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+
+      // Press ArrowLeft to close submenu and return to toggle
+      await user.keyboard('[ArrowLeft]');
+
+      // The submenu should be closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
+      });
+
+      // The submenu toggle should be focused again
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-toggle')).toHaveFocus();
+      });
+
+      // IMPORTANT: The parent menu should still be open
+      expect(screen.getByTestId('menu-list')).toBeInTheDocument();
+    });
+
+    it('should close submenu with Escape and return focus to toggle', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu toggle and open it
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      await user.keyboard('[ArrowRight]');
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // Press Escape to close submenu
+      await user.keyboard('[Escape]');
+
+      // The submenu should be closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
+      });
+
+      // The submenu toggle should be focused again
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-toggle')).toHaveFocus();
+      });
+
+      // IMPORTANT: The parent menu should still be open
+      expect(screen.getByTestId('menu-list')).toBeInTheDocument();
+    });
+
+    it('should navigate within submenu with ArrowDown and ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu toggle
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      // Open the submenu
+      await user.keyboard('[ArrowRight]');
+
+      // Wait for submenu to open and first item to be focused
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+
+      // Navigate down in submenu
+      await user.keyboard('[ArrowDown]');
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-2')).toHaveFocus();
+      });
+
+      await user.keyboard('[ArrowDown]');
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-3')).toHaveFocus();
+      });
+
+      // Navigate up in submenu
+      await user.keyboard('[ArrowUp]');
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-2')).toHaveFocus();
+      });
+    });
+
+    it('should navigate to first/last submenu item with Home and End keys', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu toggle and open it
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      await user.keyboard('[ArrowRight]');
+
+      // Wait for submenu to open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+
+      // Press End to go to last item (uses requestAnimationFrame, so wait)
+      await user.keyboard('[End]');
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-3')).toHaveFocus();
+      });
+
+      // Press Home to go to first item (uses requestAnimationFrame, so wait)
+      await user.keyboard('[Home]');
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+    });
+
+    it('should have role="menuitem" on submenu toggle for accessibility', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // The submenu toggle should have role="menuitem"
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      expect(submenuToggle).toHaveAttribute('role', 'menuitem');
+      expect(submenuToggle).toHaveAttribute('aria-haspopup', 'menu');
+      // aria-expanded is not present when false (ariaAttr returns undefined for false values)
+      expect(submenuToggle).not.toHaveAttribute('aria-expanded');
+
+      // Open the submenu and check aria-expanded is now "true"
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      // Wait for submenu toggle to have focus before opening it
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      await user.keyboard('[ArrowRight]');
+
+      await waitFor(() => {
+        expect(submenuToggle).toHaveAttribute('aria-expanded', 'true');
+      });
+    });
+  });
+
+  describe('Submenu with portal', () => {
+    // NOTE: Test that uses fake timers must run last to avoid test isolation issues
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should close the menu when clicking outside both menu and submenu content', async () => {
+      const user = userEvent.setup();
+
+      const SubmenuTestComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList
+              data-testid="menu-list"
+              PopperProps={{
+                usePortal: true,
+              }}
+            >
+              <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
+              <MenuDivider />
+              <Submenu>
+                <SubmenuToggle data-testid="submenu-toggle">
+                  <MenuItem>
+                    <Flex alignItems="center" justifyContent="space-between" width="100%">
+                      <Text>Submenu</Text>
+                    </Flex>
+                  </MenuItem>
+                </SubmenuToggle>
+                <SubmenuList
+                  data-testid="submenu-list"
+                  PopperProps={{
+                    usePortal: true,
+                  }}
+                >
+                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(
+        <>
+          <SubmenuTestComponent />
+          <button data-testid="outside-button">Outside</button>
+        </>
+      );
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+
+      // The menu should be open
+      expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
+
+      // Hover over the submenu toggle to open the submenu
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await user.hover(submenuToggle);
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // Click outside the menu and submenu
+      const outsideButton = screen.getByTestId('outside-button');
+      await user.click(outsideButton);
+
+      // The menu should be closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('menu-list')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should receive click events when clicking submenu items rendered in a portal', async () => {
+      const user = userEvent.setup();
+      const handleMenuListClick = jest.fn();
+
+      const SubmenuTestComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList
+              data-testid="menu-list"
+              onClick={handleMenuListClick}
+              PopperProps={{
+                usePortal: true,
+              }}
+            >
+              <MenuItem value="1">Menu item 1</MenuItem>
+              <MenuItem value="2">Menu item 2</MenuItem>
+              <MenuDivider />
+              <Submenu>
+                <SubmenuToggle data-testid="submenu-toggle">
+                  <MenuItem>
+                    <Flex alignItems="center" justifyContent="space-between" width="100%">
+                      <Text>Submenu</Text>
+                    </Flex>
+                  </MenuItem>
+                </SubmenuToggle>
+                <SubmenuList
+                  data-testid="submenu-list"
+                  PopperProps={{
+                    usePortal: true,
+                  }}
+                >
+                  <MenuItem data-testid="submenu-item-1" value="3">
+                    Submenu item 1
+                  </MenuItem>
+                  <MenuItem value="4">Submenu item 2</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(<SubmenuTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+
+      // The menu should be open
+      expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
+
+      // Hover over the submenu toggle to open the submenu
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await user.hover(submenuToggle);
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // Click on a submenu item
+      const submenuItem = screen.getByTestId('submenu-item-1');
+      await user.click(submenuItem);
+
+      // Verify the onClick event was received by the menu list
+      expect(handleMenuListClick).toHaveBeenCalledTimes(1);
+
+      // Verify the event target has the correct value
+      const clickEvent = handleMenuListClick.mock.calls[0][0];
+      expect(clickEvent.target.getAttribute('value')).toBe('3');
+
+      // The menu should still be open (not closed by the click on submenu item)
+      expect(screen.getByTestId('menu-list')).toBeInTheDocument();
+    });
+
+    it('should close submenu when mouse leaves both toggle and content', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      const SubmenuTestComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList
+              data-testid="menu-list"
+              PopperProps={{
+                usePortal: true,
+              }}
+            >
+              <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
+              <MenuDivider />
+              <Submenu>
+                <SubmenuToggle data-testid="submenu-toggle">
+                  <MenuItem>
+                    <Flex alignItems="center" justifyContent="space-between" width="100%">
+                      <Text>Submenu</Text>
+                    </Flex>
+                  </MenuItem>
+                </SubmenuToggle>
+                <SubmenuList
+                  data-testid="submenu-list"
+                  PopperProps={{
+                    usePortal: true,
+                  }}
+                >
+                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(<SubmenuTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+
+      // The menu should be open
+      expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
+
+      // Hover over the submenu toggle to open the submenu
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await user.hover(submenuToggle);
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // Move to submenu content
+      const submenuList = screen.getByTestId('submenu-list');
+      await user.hover(submenuList);
+
+      // The submenu should still be open
+      expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+
+      // Move mouse away from submenu
+      await user.unhover(submenuList);
+
+      // Advance timers to trigger the close timeout
+      jest.advanceTimersByTime(150);
+
+      // The submenu should be closed after the timeout
+      await waitFor(() => {
+        expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/packages/react/src/menu/__tests__/Submenu.test.js
+++ b/packages/react/src/menu/__tests__/Submenu.test.js
@@ -85,40 +85,6 @@ describe('Submenu', () => {
       });
     });
 
-    it('should open submenu with Enter key and focus first item', async () => {
-      const user = userEvent.setup();
-      render(<SubmenuKeyboardTestComponent />);
-
-      const menuButton = screen.getByTestId('menu-button');
-
-      // Open the menu
-      await user.click(menuButton);
-      expect(await screen.findByRole('menu')).toBeInTheDocument();
-
-      // Navigate to the submenu toggle
-      await user.keyboard('[ArrowDown]');
-      await user.keyboard('[ArrowDown]');
-      await user.keyboard('[ArrowDown]');
-
-      const submenuToggle = screen.getByTestId('submenu-toggle');
-      await waitFor(() => {
-        expect(submenuToggle).toHaveFocus();
-      });
-
-      // Press Enter to open submenu
-      await user.keyboard('[Enter]');
-
-      // The submenu should be open
-      await waitFor(() => {
-        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
-      });
-
-      // The first submenu item should be focused
-      await waitFor(() => {
-        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
-      });
-    });
-
     it('should close submenu with ArrowLeft and return focus to toggle', async () => {
       const user = userEvent.setup();
       render(<SubmenuKeyboardTestComponent />);
@@ -285,13 +251,13 @@ describe('Submenu', () => {
         expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
       });
 
-      // Press End to go to last item (uses requestAnimationFrame, so wait)
+      // Press End to go to last item
       await user.keyboard('[End]');
       await waitFor(() => {
         expect(screen.getByTestId('submenu-item-3')).toHaveFocus();
       });
 
-      // Press Home to go to first item (uses requestAnimationFrame, so wait)
+      // Press Home to go to first item
       await user.keyboard('[Home]');
       await waitFor(() => {
         expect(screen.getByTestId('submenu-item-1')).toHaveFocus();


### PR DESCRIPTION
## Overview

Closes #725

Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-1086/components/menu/

Add keyboard navigation support to `Submenu` component.

Supported navigation keys:
* ArrowDown
* ArrowUp
* End
* Home
* Tab
* Shift + Tab
* Escape

### What's Changed
- Add arrow key navigation (up/down) to cycle through menu items
- Add Home/End key support to jump to first/last items
- Implement tab index management for proper focus handling
- Add Enter/Space key support for menu item activation
- Reset focus state when submenu closes
- Forward focus to first focusable element in SubmenuToggle wrapper