### PR TITLE
feat(react/menu): add `SubmenuTrigger` component to combine `MenuItem` functionality with submenu trigger behavior

### DIFF
--- a/.changeset/tonic-ui-pr-1091.md
+++ b/.changeset/tonic-ui-pr-1091.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": minor
+---
+
+feat(react/menu): add `SubmenuTrigger` component to combine `MenuItem` functionality with submenu trigger behavior

--- a/packages/react-docs/experiments/dropdown/DropdownBase.js
+++ b/packages/react-docs/experiments/dropdown/DropdownBase.js
@@ -42,6 +42,11 @@ const DropdownBase = forwardRef((
   const handleClickBy = useCallback((item) => (event) => {
     onSelect?.(item);
   }, [onSelect]);
+  const handleKeyDownBy = useCallback((item) => (event) => {
+    if ((event.key === ' ' || event.key === 'Enter') && !event.repeat) {
+      onSelect?.(item);
+    }
+  }, [onSelect]);
 
   const renderItem = (item) => (typeof renderItemProp === 'function') ? renderItemProp(item) : null;
 
@@ -102,6 +107,7 @@ const DropdownBase = forwardRef((
         <MenuItem
           key={key}
           onClick={handleClickBy(item)}
+          onKeyDown={handleKeyDownBy(item)}
           {...item.props}
         >
           {renderItem?.(item)}

--- a/packages/react-docs/experiments/dropdown/DropdownBase.js
+++ b/packages/react-docs/experiments/dropdown/DropdownBase.js
@@ -6,7 +6,7 @@ import {
   MenuList,
   MenuToggle,
   Submenu,
-  SubmenuToggle,
+  SubmenuTrigger,
   SubmenuList,
   useTheme,
 } from '@tonic-ui/react';
@@ -83,13 +83,12 @@ const DropdownBase = forwardRef((
       if (item.type === 'submenu') {
         return (
           <Submenu key={`${key}_submenu`}>
-            <SubmenuToggle
+            <SubmenuTrigger
               width="100%"
+              {...item.props}
             >
-              <MenuItem {...item.props}>
-                {renderItem?.(item)}
-              </MenuItem>
-            </SubmenuToggle>
+              {renderItem?.(item)}
+            </SubmenuTrigger>
             <SubmenuList
               width="max-content"
             >

--- a/packages/react-docs/pages/components/menu/controlled-menu.js
+++ b/packages/react-docs/pages/components/menu/controlled-menu.js
@@ -5,6 +5,7 @@ import {
   MenuDivider,
   MenuItem,
   MenuList,
+  Space,
   Submenu,
   SubmenuList,
   SubmenuTrigger,
@@ -48,7 +49,8 @@ const App = () => {
           <MenuDivider />
           <Submenu>
             <SubmenuTrigger>
-              Submenu
+              <Text>Submenu</Text>
+              <Space width="1x" />
               <AngleRightIcon ml="auto" />
             </SubmenuTrigger>
             <SubmenuList

--- a/packages/react-docs/pages/components/menu/controlled-menu.js
+++ b/packages/react-docs/pages/components/menu/controlled-menu.js
@@ -7,7 +7,7 @@ import {
   MenuList,
   Submenu,
   SubmenuList,
-  SubmenuToggle,
+  SubmenuTrigger,
   Text,
 } from '@tonic-ui/react';
 import { AngleRightIcon } from '@tonic-ui/react-icons';
@@ -47,19 +47,10 @@ const App = () => {
           </MenuItem>
           <MenuDivider />
           <Submenu>
-            <SubmenuToggle>
-              <MenuItem>
-                <Flex
-                  alignItems="center"
-                  columnGap="2x"
-                  justifyContent="space-between"
-                  width="100%"
-                >
-                  Submenu
-                  <AngleRightIcon />
-                </Flex>
-              </MenuItem>
-            </SubmenuToggle>
+            <SubmenuTrigger>
+              Submenu
+              <AngleRightIcon ml="auto" />
+            </SubmenuTrigger>
             <SubmenuList
               PopperProps={{
                 usePortal: true,

--- a/packages/react-docs/pages/components/menu/controlled-menu.js
+++ b/packages/react-docs/pages/components/menu/controlled-menu.js
@@ -20,17 +20,34 @@ const App = () => {
   const [isOpen, toggleIsOpen] = useToggle(false);
   const onClose = () => toggleIsOpen(false);
   const [selectedValue, setSelectedValue] = useState(null);
+
   const handleClickMenuItem = (event) => {
     const value = event.target.getAttribute('value');
     if (!isNullish(value)) {
       setSelectedValue(value);
     }
   };
+  const handleKeyDownMenuItem = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      const value = event.target.getAttribute('value');
+      if (!isNullish(value)) {
+        setSelectedValue(value);
+      }
+    }
+  };
 
   return (
     <Flex columnGap="4x" alignItems="center">
       <Menu isOpen={isOpen} onClose={onClose}>
-        <MenuButton onClick={toggleIsOpen}>
+        <MenuButton
+          onClick={toggleIsOpen}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              toggleIsOpen();
+            }
+          }}
+        >
           Options
         </MenuButton>
         <MenuList
@@ -38,6 +55,7 @@ const App = () => {
             usePortal: true,
           }}
           onClick={handleClickMenuItem}
+          onKeyDown={handleKeyDownMenuItem}
           width="max-content"
         >
           <MenuItem value={1}>

--- a/packages/react-docs/pages/components/menu/index.page.mdx
+++ b/packages/react-docs/pages/components/menu/index.page.mdx
@@ -16,7 +16,8 @@ A menu is used to display a list of options to the user. It appears when the use
 - `Submenu`: The component that provides the submenu functionality.
 - `SubmenuContent`: An unstyled component that provides the submenu content.
 - `SubmenuList`: A styled `SubmenuContent` that wraps the submenu items.
-- `SubmenuToggle`: The toggle that opens the submenu when the menu item is hovered over.
+- `SubmenuTrigger`: A trigger that opens a submenu when interacted with.
+- `SubmenuToggle`: (Deprecated) Use `SubmenuTrigger` instead.
 
 ```js
 import {
@@ -32,7 +33,7 @@ import {
   Submenu,
   SubmenuContent,
   SubmenuList,
-  SubmenuToggle,
+  SubmenuTrigger,
   useMenu,
   useSubmenu,
 } from '@tonic-ui/react';
@@ -352,7 +353,18 @@ Check out the following components for more details:
 | :--- | :--- | :------ | :---------- |
 | children | ReactNode | | |
 
-### SubmenuToggle
+### SubmenuTrigger
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| children | ReactNode | | The content of the submenu trigger. |
+| disabled | boolean | | Whether the submenu trigger is disabled. |
+| onClick | function | | Callback when the submenu trigger is clicked. |
+| onKeyDown | function | | Callback when a key is pressed. |
+
+### SubmenuToggle (Deprecated)
+
+**Deprecated:** Use `SubmenuTrigger` instead.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |

--- a/packages/react-docs/pages/components/menu/index.page.mdx
+++ b/packages/react-docs/pages/components/menu/index.page.mdx
@@ -17,7 +17,6 @@ A menu is used to display a list of options to the user. It appears when the use
 - `SubmenuContent`: An unstyled component that provides the submenu content.
 - `SubmenuList`: A styled `SubmenuContent` that wraps the submenu items.
 - `SubmenuTrigger`: A trigger that opens a submenu when interacted with.
-- `SubmenuToggle`: (Deprecated) Use `SubmenuTrigger` instead.
 
 ```js
 import {
@@ -36,6 +35,9 @@ import {
   SubmenuTrigger,
   useMenu,
   useSubmenu,
+
+  // deprecated
+  SubmenuToggle, // Use `SubmenuTrigger` instead
 } from '@tonic-ui/react';
 ```
 
@@ -361,12 +363,3 @@ Check out the following components for more details:
 | disabled | boolean | | Whether the submenu trigger is disabled. |
 | onClick | function | | Callback when the submenu trigger is clicked. |
 | onKeyDown | function | | Callback when a key is pressed. |
-
-### SubmenuToggle (Deprecated)
-
-**Deprecated:** Use `SubmenuTrigger` instead.
-
-| Name | Type | Default | Description |
-| :--- | :--- | :------ | :---------- |
-| children | ReactNode \| `({ getSubmenuToggleProps }) => ReactNode` | | |
-| disabled | boolean | | Whether the submenu toggle is disabled. |

--- a/packages/react-docs/pages/components/menu/scrolling-native.js
+++ b/packages/react-docs/pages/components/menu/scrolling-native.js
@@ -1,11 +1,10 @@
 import {
-  Flex,
   Menu,
   MenuButton,
   MenuItem,
   MenuList,
   Submenu,
-  SubmenuToggle,
+  SubmenuTrigger,
   SubmenuList,
   Text,
 } from '@tonic-ui/react';
@@ -32,19 +31,10 @@ const App = () => (
           key={key}
           placement="right-start"
         >
-          <SubmenuToggle width="100%">
-            <MenuItem>
-              <Flex
-                alignItems="center"
-                columnGap="2x"
-                justifyContent="space-between"
-                width="100%"
-              >
-                <Text>List Item {key + 1}</Text>
-                <AngleRightIcon />
-              </Flex>
-            </MenuItem>
-          </SubmenuToggle>
+          <SubmenuTrigger width="100%">
+            <Text>List Item {key + 1}</Text>
+            <AngleRightIcon ml="auto" />
+          </SubmenuTrigger>
           <SubmenuList
             PopperProps={{
               usePortal: true,

--- a/packages/react-docs/pages/components/menu/scrolling-native.js
+++ b/packages/react-docs/pages/components/menu/scrolling-native.js
@@ -3,9 +3,10 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
+  Space,
   Submenu,
-  SubmenuTrigger,
   SubmenuList,
+  SubmenuTrigger,
   Text,
 } from '@tonic-ui/react';
 import { AngleRightIcon } from '@tonic-ui/react-icons';
@@ -33,6 +34,7 @@ const App = () => (
         >
           <SubmenuTrigger width="100%">
             <Text>List Item {key + 1}</Text>
+            <Space width="1x" />
             <AngleRightIcon ml="auto" />
           </SubmenuTrigger>
           <SubmenuList

--- a/packages/react-docs/pages/components/menu/scrolling-scrollbar.js
+++ b/packages/react-docs/pages/components/menu/scrolling-scrollbar.js
@@ -1,5 +1,4 @@
 import {
-  Flex,
   Menu,
   MenuButton,
   MenuItem,
@@ -7,7 +6,7 @@ import {
   Scrollbar,
   Submenu,
   SubmenuList,
-  SubmenuToggle,
+  SubmenuTrigger,
   Text,
 } from '@tonic-ui/react';
 import { AngleRightIcon } from '@tonic-ui/react-icons';
@@ -30,19 +29,10 @@ const App = () => (
             key={key}
             placement="right-start"
           >
-            <SubmenuToggle width="100%">
-              <MenuItem>
-                <Flex
-                  alignItems="center"
-                  columnGap="2x"
-                  justifyContent="space-between"
-                  width="100%"
-                >
-                  <Text>List Item {key + 1}</Text>
-                  <AngleRightIcon />
-                </Flex>
-              </MenuItem>
-            </SubmenuToggle>
+            <SubmenuTrigger width="100%">
+              <Text>List Item {key + 1}</Text>
+              <AngleRightIcon ml="auto" />
+            </SubmenuTrigger>
             <SubmenuList
               PopperProps={{
                 usePortal: true,

--- a/packages/react-docs/pages/components/menu/scrolling-scrollbar.js
+++ b/packages/react-docs/pages/components/menu/scrolling-scrollbar.js
@@ -4,6 +4,7 @@ import {
   MenuItem,
   MenuList,
   Scrollbar,
+  Space,
   Submenu,
   SubmenuList,
   SubmenuTrigger,
@@ -31,6 +32,7 @@ const App = () => (
           >
             <SubmenuTrigger width="100%">
               <Text>List Item {key + 1}</Text>
+              <Space width="1x" />
               <AngleRightIcon ml="auto" />
             </SubmenuTrigger>
             <SubmenuList

--- a/packages/react-docs/pages/components/menu/submenu-ltr.js
+++ b/packages/react-docs/pages/components/menu/submenu-ltr.js
@@ -50,19 +50,10 @@ const App = () => (
             <Text>List item</Text>
           </MenuItem>
           <Submenu>
-            <SubmenuToggle>
-              <MenuItem>
-                <Flex
-                  alignItems="center"
-                  columnGap="2x"
-                  justifyContent="space-between"
-                  width="100%"
-                >
-                  <Text>Submenu</Text>
-                  <AngleRightIcon />
-                </Flex>
-              </MenuItem>
-            </SubmenuToggle>
+            <SubmenuTrigger>
+              <Text>Submenu</Text>
+              <AngleRightIcon ml="auto" />
+            </SubmenuTrigger>
             <SubmenuList
               PopperProps={{
                 usePortal: true,

--- a/packages/react-docs/pages/components/menu/submenu-ltr.js
+++ b/packages/react-docs/pages/components/menu/submenu-ltr.js
@@ -4,6 +4,7 @@ import {
   MenuDivider,
   MenuItem,
   MenuList,
+  Space,
   Submenu,
   SubmenuList,
   SubmenuTrigger,
@@ -35,6 +36,7 @@ const App = () => (
       <Submenu>
         <SubmenuTrigger>
           <Text>Submenu</Text>
+          <Space width="1x" />
           <AngleRightIcon ml="auto" />
         </SubmenuTrigger>
         <SubmenuList
@@ -52,6 +54,7 @@ const App = () => (
           <Submenu>
             <SubmenuTrigger>
               <Text>Submenu</Text>
+              <Space width="1x" />
               <AngleRightIcon ml="auto" />
             </SubmenuTrigger>
             <SubmenuList

--- a/packages/react-docs/pages/components/menu/submenu-ltr.js
+++ b/packages/react-docs/pages/components/menu/submenu-ltr.js
@@ -1,5 +1,4 @@
 import {
-  Flex,
   Menu,
   MenuButton,
   MenuDivider,
@@ -7,7 +6,7 @@ import {
   MenuList,
   Submenu,
   SubmenuList,
-  SubmenuToggle,
+  SubmenuTrigger,
   Text,
 } from '@tonic-ui/react';
 import { AngleRightIcon } from '@tonic-ui/react-icons';
@@ -34,19 +33,10 @@ const App = () => (
       </MenuItem>
       <MenuDivider />
       <Submenu>
-        <SubmenuToggle>
-          <MenuItem>
-            <Flex
-              alignItems="center"
-              columnGap="2x"
-              justifyContent="space-between"
-              width="100%"
-            >
-              <Text>Submenu</Text>
-              <AngleRightIcon />
-            </Flex>
-          </MenuItem>
-        </SubmenuToggle>
+        <SubmenuTrigger>
+          <Text>Submenu</Text>
+          <AngleRightIcon ml="auto" />
+        </SubmenuTrigger>
         <SubmenuList
           PopperProps={{
             usePortal: true,

--- a/packages/react-docs/pages/components/menu/submenu-rtl.js
+++ b/packages/react-docs/pages/components/menu/submenu-rtl.js
@@ -4,6 +4,7 @@ import {
   MenuDivider,
   MenuItem,
   MenuList,
+  Space,
   Submenu,
   SubmenuList,
   SubmenuTrigger,
@@ -33,6 +34,7 @@ const App = () => (
       <Submenu placement="left-start">
         <SubmenuTrigger>
           <AngleLeftIcon mr="auto" />
+          <Space width="1x" />
           <Text>Submenu</Text>
         </SubmenuTrigger>
         <SubmenuList
@@ -55,6 +57,7 @@ const App = () => (
           <Submenu placement="left-start">
             <SubmenuTrigger>
               <AngleLeftIcon mr="auto" />
+              <Space width="1x" />
               <Text>Submenu</Text>
             </SubmenuTrigger>
             <SubmenuList

--- a/packages/react-docs/pages/components/menu/submenu-rtl.js
+++ b/packages/react-docs/pages/components/menu/submenu-rtl.js
@@ -1,5 +1,4 @@
 import {
-  Flex,
   Menu,
   MenuButton,
   MenuDivider,
@@ -7,7 +6,7 @@ import {
   MenuList,
   Submenu,
   SubmenuList,
-  SubmenuToggle,
+  SubmenuTrigger,
   Text,
 } from '@tonic-ui/react';
 import { AngleLeftIcon } from '@tonic-ui/react-icons';
@@ -32,19 +31,10 @@ const App = () => (
       </MenuItem>
       <MenuDivider />
       <Submenu placement="left-start">
-        <SubmenuToggle>
-          <MenuItem>
-            <Flex
-              alignItems="center"
-              columnGap="2x"
-              justifyContent="space-between"
-              width="100%"
-            >
-              <AngleLeftIcon />
-              <Text>Submenu</Text>
-            </Flex>
-          </MenuItem>
-        </SubmenuToggle>
+        <SubmenuTrigger>
+          <AngleLeftIcon mr="auto" />
+          <Text>Submenu</Text>
+        </SubmenuTrigger>
         <SubmenuList
           PopperProps={{
             usePortal: true,

--- a/packages/react-docs/pages/components/menu/submenu-rtl.js
+++ b/packages/react-docs/pages/components/menu/submenu-rtl.js
@@ -53,19 +53,10 @@ const App = () => (
             <Text>List item</Text>
           </MenuItem>
           <Submenu placement="left-start">
-            <SubmenuToggle>
-              <MenuItem>
-                <Flex
-                  alignItems="center"
-                  columnGap="2x"
-                  justifyContent="space-between"
-                  width="100%"
-                >
-                  <AngleLeftIcon />
-                  <Text>Submenu</Text>
-                </Flex>
-              </MenuItem>
-            </SubmenuToggle>
+            <SubmenuTrigger>
+              <AngleLeftIcon mr="auto" />
+              <Text>Submenu</Text>
+            </SubmenuTrigger>
             <SubmenuList
               PopperProps={{
                 usePortal: true,

--- a/packages/react-docs/pages/components/menu/uncontrolled-menu.js
+++ b/packages/react-docs/pages/components/menu/uncontrolled-menu.js
@@ -23,6 +23,14 @@ const App = () => {
       setSelectedValue(value);
     }
   };
+  const handleKeyDownMenuItem = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      const value = event.target.getAttribute('value');
+      if (!isNullish(value)) {
+        setSelectedValue(value);
+      }
+    }
+  };
 
   return (
     <Flex columnGap="4x" alignItems="center">
@@ -35,6 +43,7 @@ const App = () => {
             usePortal: true,
           }}
           onClick={handleClickMenuItem}
+          onKeyDown={handleKeyDownMenuItem}
           width="max-content"
         >
           <MenuItem value={1}>

--- a/packages/react-docs/pages/components/menu/uncontrolled-menu.js
+++ b/packages/react-docs/pages/components/menu/uncontrolled-menu.js
@@ -5,6 +5,7 @@ import {
   MenuDivider,
   MenuItem,
   MenuList,
+  Space,
   Submenu,
   SubmenuList,
   SubmenuTrigger,
@@ -45,7 +46,8 @@ const App = () => {
           <MenuDivider />
           <Submenu>
             <SubmenuTrigger>
-              Submenu
+              <Text>Submenu</Text>
+              <Space width="1x" />
               <AngleRightIcon ml="auto" />
             </SubmenuTrigger>
             <SubmenuList

--- a/packages/react-docs/pages/components/menu/uncontrolled-menu.js
+++ b/packages/react-docs/pages/components/menu/uncontrolled-menu.js
@@ -7,7 +7,7 @@ import {
   MenuList,
   Submenu,
   SubmenuList,
-  SubmenuToggle,
+  SubmenuTrigger,
   Text,
 } from '@tonic-ui/react';
 import { AngleRightIcon } from '@tonic-ui/react-icons';
@@ -44,19 +44,10 @@ const App = () => {
           </MenuItem>
           <MenuDivider />
           <Submenu>
-            <SubmenuToggle>
-              <MenuItem>
-                <Flex
-                  alignItems="center"
-                  columnGap="2x"
-                  justifyContent="space-between"
-                  width="100%"
-                >
-                  Submenu
-                  <AngleRightIcon />
-                </Flex>
-              </MenuItem>
-            </SubmenuToggle>
+            <SubmenuTrigger>
+              Submenu
+              <AngleRightIcon ml="auto" />
+            </SubmenuTrigger>
             <SubmenuList
               PopperProps={{
                 usePortal: true,

--- a/packages/react-docs/pages/components/table/index.page.mdx
+++ b/packages/react-docs/pages/components/table/index.page.mdx
@@ -14,9 +14,9 @@ import {
   TableCell,
   TableScrollbar,
 
-  // Deprecated components
-  TableHeaderRow, // Deprecated in v2: use `TableRow` instead.
-  TableHeaderCell, // Deprecated in v2: use `TableCell` instead.
+  // deprecated
+  TableHeaderRow, // Use `TableRow` instead
+  TableHeaderCell, // Use `TableCell` instead
 } from '@tonic-ui/react';
 ```
 
@@ -156,8 +156,8 @@ const tableHeight = headerHeight + rowsToDisplay * cellHeight;
 >
   <TableHeader>
     <TableRow>
-      <TableHeaderCell>Cell<TableHeaderCell>
-      <TableHeaderCell>Cell<TableHeaderCell>
+      <TableCell>Cell</TableCell>
+      <TableCell>Cell</TableCell>
     </TableRow>
   </TableHeader>
   <TableScrollbar
@@ -166,8 +166,8 @@ const tableHeight = headerHeight + rowsToDisplay * cellHeight;
   >
     <TableBody>
       <TableRow>
-        <TableCell>Cell<TableCell>
-        <TableCell>Cell<TableCell>
+        <TableCell>Cell</TableCell>
+        <TableCell>Cell</TableCell>
       </TableRow>
     </TableBody>
   </TableScrollbar>
@@ -198,8 +198,8 @@ And here's how you can use it in your code:
 >
   <TableHeader>
     <TableRow>
-      <TableHeaderCell>Cell<TableHeaderCell>
-      <TableHeaderCell>Cell<TableHeaderCell>
+      <TableCell>Cell</TableCell>
+      <TableCell>Cell</TableCell>
     </TableRow>
   </TableHeader>
   <ConditionalWrapper
@@ -215,8 +215,8 @@ And here's how you can use it in your code:
   >
     <TableBody>
       <TableRow>
-        <TableCell>Cell<TableCell>
-        <TableCell>Cell<TableCell>
+        <TableCell>Cell</TableCell>
+        <TableCell>Cell</TableCell>
       </TableRow>
     </TableBody>
   </ConditionalWrapper>  

--- a/packages/react-docs/pages/experiments/dropdown-base/usage.js
+++ b/packages/react-docs/pages/experiments/dropdown-base/usage.js
@@ -1,5 +1,7 @@
 import {
   Flex,
+  Space,
+  Text,
 } from '@tonic-ui/react';
 import {
   AngleRightIcon,
@@ -19,15 +21,11 @@ const items = [
   {
     type: 'submenu',
     label: (
-      <Flex
-        alignItems="center"
-        columnGap="2x"
-        justifyContent="space-between"
-        width="100%"
-      >
-        Export
-        <AngleRightIcon />
-      </Flex>
+      <>
+        <Text>Export</Text>
+	<Space width="1x" />
+        <AngleRightIcon ml="auto" />
+      </>
     ),
     children: [
       { value: 'pdf', label: 'Export as PDF' },

--- a/packages/react-docs/pages/experiments/dropdown-base/usage.js
+++ b/packages/react-docs/pages/experiments/dropdown-base/usage.js
@@ -1,5 +1,4 @@
 import {
-  Flex,
   Space,
   Text,
 } from '@tonic-ui/react';
@@ -23,7 +22,7 @@ const items = [
     label: (
       <>
         <Text>Export</Text>
-	<Space width="1x" />
+        <Space width="1x" />
         <AngleRightIcon ml="auto" />
       </>
     ),

--- a/packages/react/__tests__/index.test.js
+++ b/packages/react/__tests__/index.test.js
@@ -130,7 +130,7 @@ test('should match expected exports', () => {
     'Submenu',
     'SubmenuContent',
     'SubmenuList',
-    'SubmenuToggle',
+    'SubmenuToggle', // deprecated
     'SubmenuTrigger',
     'useMenu',
     'useSubmenu',

--- a/packages/react/__tests__/index.test.js
+++ b/packages/react/__tests__/index.test.js
@@ -131,6 +131,7 @@ test('should match expected exports', () => {
     'SubmenuContent',
     'SubmenuList',
     'SubmenuToggle',
+    'SubmenuTrigger',
     'useMenu',
     'useSubmenu',
 

--- a/packages/react/src/menu/Submenu.js
+++ b/packages/react/src/menu/Submenu.js
@@ -22,9 +22,9 @@ const Submenu = forwardRef((inProps, ref) => {
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Submenu' });
   const submenuContentRef = useRef(null);
-  const submenuToggleRef = useRef(null);
+  const submenuTriggerRef = useRef(null);
   const isHoveringSubmenuContentRef = useRef();
-  const isHoveringSubmenuToggleRef = useRef();
+  const isHoveringSubmenuTriggerRef = useRef();
   const [isOpen, setIsOpen] = useState(isOpenProp ?? defaultIsOpen);
   const [activeIndex, setActiveIndex] = useState(-1);
 
@@ -122,14 +122,14 @@ const Submenu = forwardRef((inProps, ref) => {
     }
   }, [activeIndex, getFocusableElements]);
 
-  const focusOnSubmenuToggle = useCallback(() => {
-    const el = submenuToggleRef.current;
+  const focusOnSubmenuTrigger = useCallback(() => {
+    const el = submenuTriggerRef.current;
     el && el.focus();
   }, []);
 
   const defaultId = useId();
   const submenuId = `${config.name}:Submenu-${defaultId}`;
-  const submenuToggleId = `${config.name}:SubmenuToggle-${defaultId}`;
+  const submenuTriggerId = `${config.name}:SubmenuTrigger-${defaultId}`;
   const styleProps = useSubmenuStyle();
 
   const context = getMemoizedState({
@@ -137,18 +137,18 @@ const Submenu = forwardRef((inProps, ref) => {
     focusOnLastItem,
     focusOnNextItem,
     focusOnPreviousItem,
-    focusOnSubmenuToggle,
+    focusOnSubmenuTrigger,
     isHoveringSubmenuContentRef,
-    isHoveringSubmenuToggleRef,
+    isHoveringSubmenuTriggerRef,
     isOpen,
     offset,
     onClose,
     onOpen,
     placement,
     submenuId,
-    submenuToggleId,
     submenuContentRef,
-    submenuToggleRef,
+    submenuTriggerId,
+    submenuTriggerRef,
   });
 
   return (

--- a/packages/react/src/menu/SubmenuContent.js
+++ b/packages/react/src/menu/SubmenuContent.js
@@ -34,16 +34,16 @@ const SubmenuContent = forwardRef((inProps, ref) => {
     focusOnLastItem,
     focusOnNextItem,
     focusOnPreviousItem,
-    focusOnSubmenuToggle,
+    focusOnSubmenuTrigger,
     isHoveringSubmenuContentRef,
-    isHoveringSubmenuToggleRef,
+    isHoveringSubmenuTriggerRef,
     isOpen,
     offset,
     onClose: closeSubmenu,
     placement,
     submenuId,
-    submenuToggleId,
-    submenuToggleRef,
+    submenuTriggerId,
+    submenuTriggerRef,
     submenuContentRef,
   } = { ...submenuContext };
 
@@ -80,7 +80,7 @@ const SubmenuContent = forwardRef((inProps, ref) => {
     }
     mouseLeaveTimeoutRef.current = setTimeout(() => {
       mouseLeaveTimeoutRef.current = undefined;
-      if (!isHoveringSubmenuToggleRef.current && !isHoveringSubmenuContentRef.current) {
+      if (!isHoveringSubmenuTriggerRef.current && !isHoveringSubmenuContentRef.current) {
         ensureFunction(closeSubmenu)();
       }
     }, 100); // XXX: keep opening Submenu when cursor quickly move between SubmenuToggle and SubmenuContent
@@ -123,7 +123,7 @@ const SubmenuContent = forwardRef((inProps, ref) => {
     if (key === closeKey || key === 'Escape') {
       event.preventDefault();
       event.stopPropagation();
-      ensureFunction(focusOnSubmenuToggle)();
+      ensureFunction(focusOnSubmenuTrigger)();
       ensureFunction(closeSubmenu)();
     }
   };
@@ -161,13 +161,13 @@ const SubmenuContent = forwardRef((inProps, ref) => {
 
   return (
     <PopperComponent
-      aria-labelledby={submenuToggleId}
+      aria-labelledby={submenuTriggerId}
       data-submenu-id={submenuId}
       id={submenuId}
       isOpen={isOpen}
       placement={placement}
       ref={submenuContentRef}
-      referenceRef={submenuToggleRef}
+      referenceRef={submenuTriggerRef}
       role="menu"
       tabIndex={tabIndex}
       unmountOnExit={true}

--- a/packages/react/src/menu/SubmenuTrigger.js
+++ b/packages/react/src/menu/SubmenuTrigger.js
@@ -5,7 +5,7 @@ import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
 import { useDefaultProps } from '../default-props';
 import useButtonEventHandlers from '../utils/useButtonEventHandlers';
-import { useMenuItemStyle } from './styles';
+import { useSubmenuTriggerStyle } from './styles';
 import useMenu from './useMenu';
 import useSubmenu from './useSubmenu';
 
@@ -47,7 +47,7 @@ const SubmenuTrigger = forwardRef((inProps, ref) => {
 
   const combinedRef = useMergeRefs(submenuTriggerRef, ref);
   const tabIndex = -1;
-  const styleProps = useMenuItemStyle({ tabIndex });
+  const styleProps = useSubmenuTriggerStyle({ tabIndex });
 
   const mouseLeaveTimeoutRef = React.useRef();
 

--- a/packages/react/src/menu/SubmenuTrigger.js
+++ b/packages/react/src/menu/SubmenuTrigger.js
@@ -35,17 +35,17 @@ const SubmenuTrigger = forwardRef((inProps, ref) => {
   const {
     focusOnFirstItem,
     isHoveringSubmenuContentRef,
-    isHoveringSubmenuToggleRef,
+    isHoveringSubmenuTriggerRef,
     isOpen,
     onClose: closeSubmenu,
     onOpen: openSubmenu,
     placement,
     submenuId,
-    submenuToggleId,
-    submenuToggleRef,
+    submenuTriggerId,
+    submenuTriggerRef,
   } = { ...submenuContext };
 
-  const combinedRef = useMergeRefs(submenuToggleRef, ref);
+  const combinedRef = useMergeRefs(submenuTriggerRef, ref);
   const tabIndex = -1;
   const styleProps = useMenuItemStyle({ tabIndex });
 
@@ -65,7 +65,7 @@ const SubmenuTrigger = forwardRef((inProps, ref) => {
       return;
     }
 
-    isHoveringSubmenuToggleRef.current = true;
+    isHoveringSubmenuTriggerRef.current = true;
     if (mouseLeaveTimeoutRef.current) {
       clearTimeout(mouseLeaveTimeoutRef.current);
       mouseLeaveTimeoutRef.current = undefined;
@@ -80,14 +80,14 @@ const SubmenuTrigger = forwardRef((inProps, ref) => {
       return;
     }
 
-    isHoveringSubmenuToggleRef.current = false;
+    isHoveringSubmenuTriggerRef.current = false;
     if (mouseLeaveTimeoutRef.current) {
       clearTimeout(mouseLeaveTimeoutRef.current);
       mouseLeaveTimeoutRef.current = undefined;
     }
     mouseLeaveTimeoutRef.current = setTimeout(() => {
       mouseLeaveTimeoutRef.current = undefined;
-      if (!isHoveringSubmenuToggleRef.current && !isHoveringSubmenuContentRef.current) {
+      if (!isHoveringSubmenuTriggerRef.current && !isHoveringSubmenuContentRef.current) {
         ensureFunction(closeSubmenu)();
       }
     }, 100);
@@ -138,7 +138,7 @@ const SubmenuTrigger = forwardRef((inProps, ref) => {
       aria-controls={submenuId}
       aria-expanded={ariaAttr(isOpen)}
       aria-haspopup="menu"
-      id={submenuToggleId}
+      id={submenuTriggerId}
       onClick={callEventHandlers(onClickProp, onClick)}
       onFocus={callEventHandlers(onFocusProp, eventHandler.onFocus)}
       onKeyDown={callEventHandlers(onKeyDownProp, onKeyDown, eventHandler.onKeyDown)}

--- a/packages/react/src/menu/SubmenuTrigger.js
+++ b/packages/react/src/menu/SubmenuTrigger.js
@@ -4,22 +4,32 @@ import { ensureFunction } from 'ensure-type';
 import React, { forwardRef } from 'react';
 import { ButtonBase } from '../button';
 import { useDefaultProps } from '../default-props';
+import useButtonEventHandlers from '../utils/useButtonEventHandlers';
 import { useMenuItemStyle } from './styles';
+import useMenu from './useMenu';
 import useSubmenu from './useSubmenu';
 
 /**
  * SubmenuTrigger acts as a menu item that opens a submenu when interacted with.
+ * It combines MenuItem functionality with submenu trigger behavior for a cleaner API.
  */
 const SubmenuTrigger = forwardRef((inProps, ref) => {
   const {
     children,
     disabled,
+    onClick: onClickProp,
     onFocus: onFocusProp,
     onKeyDown: onKeyDownProp,
     onMouseEnter: onMouseEnterProp,
     onMouseLeave: onMouseLeaveProp,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'SubmenuTrigger' });
+
+  const menuContext = useMenu(); // context might be an undefined value
+  const {
+    closeOnSelect,
+    onClose: closeMenu,
+  } = { ...menuContext };
 
   const submenuContext = useSubmenu(); // context might be an undefined value
   const {
@@ -40,6 +50,13 @@ const SubmenuTrigger = forwardRef((inProps, ref) => {
   const styleProps = useMenuItemStyle({ tabIndex });
 
   const mouseLeaveTimeoutRef = React.useRef();
+
+  // Use button event handlers for click and Enter/Space key activation
+  // Unlike regular MenuItem, we don't close the parent menu when clicking the submenu trigger
+  const { onClick, onKeyDown } = useButtonEventHandlers({
+    disabled,
+    onActivate: () => {}, // No-op: submenu triggers don't close the parent menu
+  });
 
   const eventHandler = {};
 
@@ -123,8 +140,9 @@ const SubmenuTrigger = forwardRef((inProps, ref) => {
       aria-expanded={ariaAttr(isOpen)}
       aria-haspopup="menu"
       id={submenuToggleId}
+      onClick={callEventHandlers(onClickProp, onClick)}
       onFocus={callEventHandlers(onFocusProp, eventHandler.onFocus)}
-      onKeyDown={callEventHandlers(onKeyDownProp, eventHandler.onKeyDown)}
+      onKeyDown={callEventHandlers(onKeyDownProp, onKeyDown, eventHandler.onKeyDown)}
       onMouseEnter={callEventHandlers(onMouseEnterProp, eventHandler.onMouseEnter)}
       onMouseLeave={callEventHandlers(onMouseLeaveProp, eventHandler.onMouseLeave)}
       {...styleProps}

--- a/packages/react/src/menu/SubmenuTrigger.js
+++ b/packages/react/src/menu/SubmenuTrigger.js
@@ -1,28 +1,16 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
-import { ariaAttr, callEventHandlers, getAllFocusable } from '@tonic-ui/utils';
+import { ariaAttr, callEventHandlers } from '@tonic-ui/utils';
 import { ensureFunction } from 'ensure-type';
-import React, { forwardRef, useRef } from 'react';
-import { Box } from '../box';
+import React, { forwardRef } from 'react';
+import { ButtonBase } from '../button';
 import { useDefaultProps } from '../default-props';
-import {
-  useSubmenuToggleStyle,
-} from './styles';
+import { useMenuItemStyle } from './styles';
 import useSubmenu from './useSubmenu';
 
 /**
- * @deprecated SubmenuToggle is deprecated and will be removed in a future version.
- * Use SubmenuTrigger instead, which combines MenuItem functionality with submenu trigger behavior.
- *
- * Migration example:
- * Before:
- *   <SubmenuToggle>
- *     <MenuItem>Submenu</MenuItem>
- *   </SubmenuToggle>
- *
- * After:
- *   <SubmenuTrigger>Submenu</SubmenuTrigger>
+ * SubmenuTrigger acts as a menu item that opens a submenu when interacted with.
  */
-const SubmenuToggle = forwardRef((inProps, ref) => {
+const SubmenuTrigger = forwardRef((inProps, ref) => {
   const {
     children,
     disabled,
@@ -31,8 +19,8 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
     onMouseEnter: onMouseEnterProp,
     onMouseLeave: onMouseLeaveProp,
     ...rest
-  } = useDefaultProps({ props: inProps, name: 'SubmenuToggle' });
-  const mouseLeaveTimeoutRef = useRef();
+  } = useDefaultProps({ props: inProps, name: 'SubmenuTrigger' });
+
   const submenuContext = useSubmenu(); // context might be an undefined value
   const {
     focusOnFirstItem,
@@ -46,8 +34,13 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
     submenuToggleId,
     submenuToggleRef,
   } = { ...submenuContext };
+
   const combinedRef = useMergeRefs(submenuToggleRef, ref);
-  const styleProps = useSubmenuToggleStyle();
+  const tabIndex = -1;
+  const styleProps = useMenuItemStyle({ tabIndex });
+
+  const mouseLeaveTimeoutRef = React.useRef();
+
   const eventHandler = {};
 
   eventHandler.onMouseEnter = function (event) {
@@ -81,28 +74,10 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
       if (!isHoveringSubmenuToggleRef.current && !isHoveringSubmenuContentRef.current) {
         ensureFunction(closeSubmenu)();
       }
-    }, 100); // XXX: keep opening Submenu when cursor quickly move between SubmenuToggle and SubmenuContent
+    }, 100);
   };
 
-  // When used as a wrapper, forward focus to the first focusable element (MenuItem) inside
-  eventHandler.onFocus = function (event) {
-    if (disabled) {
-      return;
-    }
-
-    // Only forward focus if the event target is the wrapper itself
-    const wrapper = event.currentTarget;
-    if (event.target === wrapper) {
-      // Find the first focusable element inside the wrapper
-      const focusableElements = getAllFocusable(wrapper);
-      const firstFocusable = focusableElements[0];
-      if (firstFocusable && firstFocusable !== wrapper) {
-        firstFocusable.focus();
-      }
-    }
-  };
-
-  // Keyboard navigation for submenu toggle
+  // Keyboard navigation for submenu trigger
   eventHandler.onKeyDown = function (event) {
     if (disabled) {
       return;
@@ -137,42 +112,29 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
     }
   };
 
-  const getSubmenuToggleProps = () => ({
-    'aria-controls': submenuId,
-    'aria-disabled': ariaAttr(disabled),
-    'aria-expanded': ariaAttr(isOpen),
-    'aria-haspopup': 'menu',
-    disabled,
-    id: submenuToggleId,
-    onFocus: callEventHandlers(onFocusProp, eventHandler.onFocus),
-    onKeyDown: callEventHandlers(onKeyDownProp, eventHandler.onKeyDown),
-    onMouseEnter: callEventHandlers(onMouseEnterProp, eventHandler.onMouseEnter),
-    onMouseLeave: callEventHandlers(onMouseLeaveProp, eventHandler.onMouseLeave),
-    ref: combinedRef,
-    role: 'menuitem',
-    tabIndex: -1,
-    ...styleProps,
-    ...rest,
-  });
-
-  if (typeof children === 'function') {
-    return children({
-      getSubmenuToggleProps,
-    });
-  }
-
-  // When used as a wrapper, use role="presentation" since the child MenuItem
-  // has its own role="menuitem"
   return (
-    <Box
-      {...getSubmenuToggleProps()}
-      role="presentation"
+    <ButtonBase
+      ref={combinedRef}
+      role="menuitem"
+      tabIndex={tabIndex}
+      disabled={disabled}
+      aria-disabled={ariaAttr(disabled)}
+      aria-controls={submenuId}
+      aria-expanded={ariaAttr(isOpen)}
+      aria-haspopup="menu"
+      id={submenuToggleId}
+      onFocus={callEventHandlers(onFocusProp, eventHandler.onFocus)}
+      onKeyDown={callEventHandlers(onKeyDownProp, eventHandler.onKeyDown)}
+      onMouseEnter={callEventHandlers(onMouseEnterProp, eventHandler.onMouseEnter)}
+      onMouseLeave={callEventHandlers(onMouseLeaveProp, eventHandler.onMouseLeave)}
+      {...styleProps}
+      {...rest}
     >
       {children}
-    </Box>
+    </ButtonBase>
   );
 });
 
-SubmenuToggle.displayName = 'SubmenuToggle';
+SubmenuTrigger.displayName = 'SubmenuTrigger';
 
-export default SubmenuToggle;
+export default SubmenuTrigger;

--- a/packages/react/src/menu/SubmenuTrigger.js
+++ b/packages/react/src/menu/SubmenuTrigger.js
@@ -52,10 +52,9 @@ const SubmenuTrigger = forwardRef((inProps, ref) => {
   const mouseLeaveTimeoutRef = React.useRef();
 
   // Use button event handlers for click and Enter/Space key activation
-  // Unlike regular MenuItem, we don't close the parent menu when clicking the submenu trigger
   const { onClick, onKeyDown } = useButtonEventHandlers({
     disabled,
-    onActivate: () => {}, // No-op: submenu triggers don't close the parent menu
+    onActivate: () => closeOnSelect && ensureFunction(closeMenu)(),
   });
 
   const eventHandler = {};

--- a/packages/react/src/menu/__tests__/Submenu.test.js
+++ b/packages/react/src/menu/__tests__/Submenu.test.js
@@ -7,11 +7,13 @@ import {
   MenuDivider,
   MenuList,
   MenuItem,
+  Space,
   Submenu,
   SubmenuList,
   SubmenuTrigger,
   Text,
 } from '@tonic-ui/react/src';
+import { AngleRightIcon } from '@tonic-ui/react-icons';
 import React from 'react';
 
 describe('Submenu', () => {
@@ -29,6 +31,8 @@ describe('Submenu', () => {
             <Submenu>
               <SubmenuTrigger data-testid="submenu-trigger">
                 <Text>Submenu</Text>
+                <Space width="1x" />
+                <AngleRightIcon ml="auto" />
               </SubmenuTrigger>
               <SubmenuList data-testid="submenu-list">
                 <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
@@ -57,9 +61,9 @@ describe('Submenu', () => {
       await user.keyboard('[ArrowDown]'); // Focus menu-item-2
       await user.keyboard('[ArrowDown]'); // Focus submenu-trigger
 
-      const submenuToggle = screen.getByTestId('submenu-trigger');
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
       await waitFor(() => {
-        expect(submenuToggle).toHaveFocus();
+        expect(submenuTrigger).toHaveFocus();
       });
 
       // Press ArrowRight to open submenu
@@ -91,9 +95,9 @@ describe('Submenu', () => {
       await user.keyboard('[ArrowDown]');
       await user.keyboard('[ArrowDown]');
 
-      const submenuToggle = screen.getByTestId('submenu-trigger');
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
       await waitFor(() => {
-        expect(submenuToggle).toHaveFocus();
+        expect(submenuTrigger).toHaveFocus();
       });
 
       await user.keyboard('[ArrowRight]');
@@ -140,9 +144,9 @@ describe('Submenu', () => {
       await user.keyboard('[ArrowDown]');
       await user.keyboard('[ArrowDown]');
 
-      const submenuToggle = screen.getByTestId('submenu-trigger');
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
       await waitFor(() => {
-        expect(submenuToggle).toHaveFocus();
+        expect(submenuTrigger).toHaveFocus();
       });
 
       await user.keyboard('[ArrowRight]');
@@ -184,9 +188,9 @@ describe('Submenu', () => {
       await user.keyboard('[ArrowDown]');
       await user.keyboard('[ArrowDown]');
 
-      const submenuToggle = screen.getByTestId('submenu-trigger');
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
       await waitFor(() => {
-        expect(submenuToggle).toHaveFocus();
+        expect(submenuTrigger).toHaveFocus();
       });
 
       // Open the submenu
@@ -230,9 +234,9 @@ describe('Submenu', () => {
       await user.keyboard('[ArrowDown]');
       await user.keyboard('[ArrowDown]');
 
-      const submenuToggle = screen.getByTestId('submenu-trigger');
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
       await waitFor(() => {
-        expect(submenuToggle).toHaveFocus();
+        expect(submenuTrigger).toHaveFocus();
       });
 
       await user.keyboard('[ArrowRight]');
@@ -266,11 +270,11 @@ describe('Submenu', () => {
       expect(await screen.findByRole('menu')).toBeInTheDocument();
 
       // The submenu toggle should have role="menuitem"
-      const submenuToggle = screen.getByTestId('submenu-trigger');
-      expect(submenuToggle).toHaveAttribute('role', 'menuitem');
-      expect(submenuToggle).toHaveAttribute('aria-haspopup', 'menu');
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
+      expect(submenuTrigger).toHaveAttribute('role', 'menuitem');
+      expect(submenuTrigger).toHaveAttribute('aria-haspopup', 'menu');
       // aria-expanded is not present when false (ariaAttr returns undefined for false values)
-      expect(submenuToggle).not.toHaveAttribute('aria-expanded');
+      expect(submenuTrigger).not.toHaveAttribute('aria-expanded');
 
       // Open the submenu and check aria-expanded is now "true"
       await user.keyboard('[ArrowDown]');
@@ -279,13 +283,13 @@ describe('Submenu', () => {
 
       // Wait for submenu toggle to have focus before opening it
       await waitFor(() => {
-        expect(submenuToggle).toHaveFocus();
+        expect(submenuTrigger).toHaveFocus();
       });
 
       await user.keyboard('[ArrowRight]');
 
       await waitFor(() => {
-        expect(submenuToggle).toHaveAttribute('aria-expanded', 'true');
+        expect(submenuTrigger).toHaveAttribute('aria-expanded', 'true');
       });
     });
   });
@@ -316,6 +320,8 @@ describe('Submenu', () => {
               <Submenu>
                 <SubmenuTrigger data-testid="submenu-trigger">
                   <Text>Submenu</Text>
+                  <Space width="1x" />
+                  <AngleRightIcon ml="auto" />
                 </SubmenuTrigger>
                 <SubmenuList
                   data-testid="submenu-list"
@@ -347,8 +353,8 @@ describe('Submenu', () => {
       expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
 
       // Hover over the submenu toggle to open the submenu
-      const submenuToggle = screen.getByTestId('submenu-trigger');
-      await user.hover(submenuToggle);
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
+      await user.hover(submenuTrigger);
 
       // The submenu should be open
       await waitFor(() => {
@@ -388,6 +394,8 @@ describe('Submenu', () => {
               <Submenu>
                 <SubmenuTrigger data-testid="submenu-trigger">
                   <Text>Submenu</Text>
+                  <Space width="1x" />
+                  <AngleRightIcon ml="auto" />
                 </SubmenuTrigger>
                 <SubmenuList
                   data-testid="submenu-list"
@@ -417,8 +425,8 @@ describe('Submenu', () => {
       expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
 
       // Hover over the submenu toggle to open the submenu
-      const submenuToggle = screen.getByTestId('submenu-trigger');
-      await user.hover(submenuToggle);
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
+      await user.hover(submenuTrigger);
 
       // The submenu should be open
       await waitFor(() => {
@@ -461,6 +469,8 @@ describe('Submenu', () => {
               <Submenu>
                 <SubmenuTrigger data-testid="submenu-trigger">
                   <Text>Submenu</Text>
+                  <Space width="1x" />
+                  <AngleRightIcon ml="auto" />
                 </SubmenuTrigger>
                 <SubmenuList
                   data-testid="submenu-list"
@@ -487,8 +497,8 @@ describe('Submenu', () => {
       expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
 
       // Hover over the submenu toggle to open the submenu
-      const submenuToggle = screen.getByTestId('submenu-trigger');
-      await user.hover(submenuToggle);
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
+      await user.hover(submenuTrigger);
 
       // The submenu should be open
       await waitFor(() => {
@@ -529,7 +539,9 @@ describe('Submenu', () => {
               <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
               <Submenu>
                 <SubmenuTrigger data-testid="submenu-trigger">
-                  Submenu
+                  <Text>Submenu</Text>
+                  <Space width="1x" />
+                  <AngleRightIcon ml="auto" />
                 </SubmenuTrigger>
                 <SubmenuList data-testid="submenu-list">
                   <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
@@ -589,6 +601,8 @@ describe('Submenu', () => {
               <Submenu>
                 <SubmenuTrigger data-testid="submenu-trigger">
                   <Text>Simple Submenu</Text>
+                  <Space width="1x" />
+                  <AngleRightIcon ml="auto" />
                 </SubmenuTrigger>
                 <SubmenuList data-testid="submenu-list">
                   <MenuItem>Item 1</MenuItem>

--- a/packages/react/src/menu/__tests__/Submenu.test.js
+++ b/packages/react/src/menu/__tests__/Submenu.test.js
@@ -2,7 +2,6 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@tonic-ui/react/test-utils/render';
 import {
-  Flex,
   Menu,
   MenuButton,
   MenuDivider,
@@ -10,7 +9,6 @@ import {
   MenuItem,
   Submenu,
   SubmenuList,
-  SubmenuToggle,
   SubmenuTrigger,
   Text,
 } from '@tonic-ui/react/src';
@@ -18,8 +16,6 @@ import React from 'react';
 
 describe('Submenu', () => {
   describe('Submenu keyboard navigation', () => {
-    // Note: Use the render function pattern so MenuItem receives the props (role, tabIndex, aria attributes)
-    // This ensures focus-visible styling appears on MenuItem, not on a wrapper element
     const SubmenuKeyboardTestComponent = (props) => {
       return (
         <Menu {...props}>
@@ -31,15 +27,9 @@ describe('Submenu', () => {
             <MenuItem data-testid="menu-item-2">Menu item 2</MenuItem>
             <MenuDivider />
             <Submenu>
-              <SubmenuToggle>
-                {({ getSubmenuToggleProps }) => (
-                  <MenuItem data-testid="submenu-toggle" {...getSubmenuToggleProps()}>
-                    <Flex alignItems="center" justifyContent="space-between" width="100%">
-                      <Text>Submenu</Text>
-                    </Flex>
-                  </MenuItem>
-                )}
-              </SubmenuToggle>
+              <SubmenuTrigger data-testid="submenu-trigger">
+                <Text>Submenu</Text>
+              </SubmenuTrigger>
               <SubmenuList data-testid="submenu-list">
                 <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
                 <MenuItem data-testid="submenu-item-2">Submenu item 2</MenuItem>
@@ -65,9 +55,9 @@ describe('Submenu', () => {
       // Navigate to the submenu toggle using keyboard
       await user.keyboard('[ArrowDown]'); // Focus menu-item-1
       await user.keyboard('[ArrowDown]'); // Focus menu-item-2
-      await user.keyboard('[ArrowDown]'); // Focus submenu-toggle
+      await user.keyboard('[ArrowDown]'); // Focus submenu-trigger
 
-      const submenuToggle = screen.getByTestId('submenu-toggle');
+      const submenuToggle = screen.getByTestId('submenu-trigger');
       await waitFor(() => {
         expect(submenuToggle).toHaveFocus();
       });
@@ -101,7 +91,7 @@ describe('Submenu', () => {
       await user.keyboard('[ArrowDown]');
       await user.keyboard('[ArrowDown]');
 
-      const submenuToggle = screen.getByTestId('submenu-toggle');
+      const submenuToggle = screen.getByTestId('submenu-trigger');
       await waitFor(() => {
         expect(submenuToggle).toHaveFocus();
       });
@@ -128,7 +118,7 @@ describe('Submenu', () => {
 
       // The submenu toggle should be focused again
       await waitFor(() => {
-        expect(screen.getByTestId('submenu-toggle')).toHaveFocus();
+        expect(screen.getByTestId('submenu-trigger')).toHaveFocus();
       });
 
       // IMPORTANT: The parent menu should still be open
@@ -150,7 +140,7 @@ describe('Submenu', () => {
       await user.keyboard('[ArrowDown]');
       await user.keyboard('[ArrowDown]');
 
-      const submenuToggle = screen.getByTestId('submenu-toggle');
+      const submenuToggle = screen.getByTestId('submenu-trigger');
       await waitFor(() => {
         expect(submenuToggle).toHaveFocus();
       });
@@ -172,7 +162,7 @@ describe('Submenu', () => {
 
       // The submenu toggle should be focused again
       await waitFor(() => {
-        expect(screen.getByTestId('submenu-toggle')).toHaveFocus();
+        expect(screen.getByTestId('submenu-trigger')).toHaveFocus();
       });
 
       // IMPORTANT: The parent menu should still be open
@@ -194,7 +184,7 @@ describe('Submenu', () => {
       await user.keyboard('[ArrowDown]');
       await user.keyboard('[ArrowDown]');
 
-      const submenuToggle = screen.getByTestId('submenu-toggle');
+      const submenuToggle = screen.getByTestId('submenu-trigger');
       await waitFor(() => {
         expect(submenuToggle).toHaveFocus();
       });
@@ -240,7 +230,7 @@ describe('Submenu', () => {
       await user.keyboard('[ArrowDown]');
       await user.keyboard('[ArrowDown]');
 
-      const submenuToggle = screen.getByTestId('submenu-toggle');
+      const submenuToggle = screen.getByTestId('submenu-trigger');
       await waitFor(() => {
         expect(submenuToggle).toHaveFocus();
       });
@@ -276,7 +266,7 @@ describe('Submenu', () => {
       expect(await screen.findByRole('menu')).toBeInTheDocument();
 
       // The submenu toggle should have role="menuitem"
-      const submenuToggle = screen.getByTestId('submenu-toggle');
+      const submenuToggle = screen.getByTestId('submenu-trigger');
       expect(submenuToggle).toHaveAttribute('role', 'menuitem');
       expect(submenuToggle).toHaveAttribute('aria-haspopup', 'menu');
       // aria-expanded is not present when false (ariaAttr returns undefined for false values)
@@ -324,13 +314,9 @@ describe('Submenu', () => {
               <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
               <MenuDivider />
               <Submenu>
-                <SubmenuToggle data-testid="submenu-toggle">
-                  <MenuItem>
-                    <Flex alignItems="center" justifyContent="space-between" width="100%">
-                      <Text>Submenu</Text>
-                    </Flex>
-                  </MenuItem>
-                </SubmenuToggle>
+                <SubmenuTrigger data-testid="submenu-trigger">
+                  <Text>Submenu</Text>
+                </SubmenuTrigger>
                 <SubmenuList
                   data-testid="submenu-list"
                   PopperProps={{
@@ -361,7 +347,7 @@ describe('Submenu', () => {
       expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
 
       // Hover over the submenu toggle to open the submenu
-      const submenuToggle = screen.getByTestId('submenu-toggle');
+      const submenuToggle = screen.getByTestId('submenu-trigger');
       await user.hover(submenuToggle);
 
       // The submenu should be open
@@ -400,13 +386,9 @@ describe('Submenu', () => {
               <MenuItem value="2">Menu item 2</MenuItem>
               <MenuDivider />
               <Submenu>
-                <SubmenuToggle data-testid="submenu-toggle">
-                  <MenuItem>
-                    <Flex alignItems="center" justifyContent="space-between" width="100%">
-                      <Text>Submenu</Text>
-                    </Flex>
-                  </MenuItem>
-                </SubmenuToggle>
+                <SubmenuTrigger data-testid="submenu-trigger">
+                  <Text>Submenu</Text>
+                </SubmenuTrigger>
                 <SubmenuList
                   data-testid="submenu-list"
                   PopperProps={{
@@ -435,7 +417,7 @@ describe('Submenu', () => {
       expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
 
       // Hover over the submenu toggle to open the submenu
-      const submenuToggle = screen.getByTestId('submenu-toggle');
+      const submenuToggle = screen.getByTestId('submenu-trigger');
       await user.hover(submenuToggle);
 
       // The submenu should be open
@@ -477,13 +459,9 @@ describe('Submenu', () => {
               <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
               <MenuDivider />
               <Submenu>
-                <SubmenuToggle data-testid="submenu-toggle">
-                  <MenuItem>
-                    <Flex alignItems="center" justifyContent="space-between" width="100%">
-                      <Text>Submenu</Text>
-                    </Flex>
-                  </MenuItem>
-                </SubmenuToggle>
+                <SubmenuTrigger data-testid="submenu-trigger">
+                  <Text>Submenu</Text>
+                </SubmenuTrigger>
                 <SubmenuList
                   data-testid="submenu-list"
                   PopperProps={{
@@ -509,7 +487,7 @@ describe('Submenu', () => {
       expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
 
       // Hover over the submenu toggle to open the submenu
-      const submenuToggle = screen.getByTestId('submenu-toggle');
+      const submenuToggle = screen.getByTestId('submenu-trigger');
       await user.hover(submenuToggle);
 
       // The submenu should be open

--- a/packages/react/src/menu/__tests__/Submenu.test.js
+++ b/packages/react/src/menu/__tests__/Submenu.test.js
@@ -11,6 +11,7 @@ import {
   Submenu,
   SubmenuList,
   SubmenuToggle,
+  SubmenuTrigger,
   Text,
 } from '@tonic-ui/react/src';
 import React from 'react';
@@ -533,6 +534,101 @@ describe('Submenu', () => {
       await waitFor(() => {
         expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('SubmenuTrigger', () => {
+    it('should work as a combined MenuItem and submenu trigger', async () => {
+      const user = userEvent.setup();
+
+      const SubmenuTriggerTestComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList data-testid="menu-list">
+              <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
+              <Submenu>
+                <SubmenuTrigger data-testid="submenu-trigger">
+                  Submenu
+                </SubmenuTrigger>
+                <SubmenuList data-testid="submenu-list">
+                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                  <MenuItem data-testid="submenu-item-2">Submenu item 2</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(<SubmenuTriggerTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu trigger
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
+      await waitFor(() => {
+        expect(submenuTrigger).toHaveFocus();
+      });
+
+      // Verify it has the correct ARIA attributes
+      expect(submenuTrigger).toHaveAttribute('role', 'menuitem');
+      expect(submenuTrigger).toHaveAttribute('aria-haspopup', 'menu');
+
+      // Press ArrowRight to open submenu
+      await user.keyboard('[ArrowRight]');
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // The first submenu item should be focused
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+    });
+
+    it('should render children directly without requiring MenuItem wrapper', async () => {
+      const user = userEvent.setup();
+
+      const SubmenuTriggerSimpleComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList>
+              <Submenu>
+                <SubmenuTrigger data-testid="submenu-trigger">
+                  <Text>Simple Submenu</Text>
+                </SubmenuTrigger>
+                <SubmenuList data-testid="submenu-list">
+                  <MenuItem>Item 1</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(<SubmenuTriggerSimpleComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+      await user.click(menuButton);
+
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
+      expect(submenuTrigger).toBeInTheDocument();
+      expect(submenuTrigger.textContent).toBe('Simple Submenu');
     });
   });
 });

--- a/packages/react/src/menu/__tests__/Submenu.test.js
+++ b/packages/react/src/menu/__tests__/Submenu.test.js
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@tonic-ui/react/test-utils/render';
 import {
@@ -621,6 +621,210 @@ describe('Submenu', () => {
       const submenuTrigger = screen.getByTestId('submenu-trigger');
       expect(submenuTrigger).toBeInTheDocument();
       expect(submenuTrigger.textContent).toBe('Simple Submenu');
+    });
+
+    it('should not respond to mouse events when disabled', async () => {
+      const user = userEvent.setup();
+
+      const DisabledSubmenuTriggerComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList data-testid="menu-list">
+              <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
+              <Submenu>
+                <SubmenuTrigger disabled data-testid="submenu-trigger">
+                  <Text>Disabled Submenu</Text>
+                  <Space width="1x" />
+                  <AngleRightIcon ml="auto" />
+                </SubmenuTrigger>
+                <SubmenuList data-testid="submenu-list">
+                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(<DisabledSubmenuTriggerComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Use fireEvent to directly trigger mouse events on disabled element
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
+      fireEvent.mouseEnter(submenuTrigger);
+
+      // The submenu should NOT open because the trigger is disabled
+      expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
+
+      // Also test mouseLeave on disabled element
+      fireEvent.mouseLeave(submenuTrigger);
+
+      // Verify the trigger has aria-disabled attribute
+      expect(submenuTrigger).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('should not respond to keyboard events when disabled', async () => {
+      const user = userEvent.setup();
+
+      const DisabledSubmenuTriggerComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList data-testid="menu-list">
+              <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
+              <Submenu>
+                <SubmenuTrigger disabled data-testid="submenu-trigger">
+                  <Text>Disabled Submenu</Text>
+                  <Space width="1x" />
+                  <AngleRightIcon ml="auto" />
+                </SubmenuTrigger>
+                <SubmenuList data-testid="submenu-list">
+                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(<DisabledSubmenuTriggerComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Use fireEvent to directly trigger keyboard event on disabled element
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
+      fireEvent.keyDown(submenuTrigger, { key: 'ArrowRight' });
+
+      // The submenu should NOT open because the trigger is disabled
+      expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
+    });
+
+    it('should close submenu with ArrowLeft when trigger is focused and submenu is open', async () => {
+      const user = userEvent.setup();
+
+      const SubmenuTriggerTestComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList data-testid="menu-list">
+              <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
+              <Submenu>
+                <SubmenuTrigger data-testid="submenu-trigger">
+                  <Text>Submenu</Text>
+                  <Space width="1x" />
+                  <AngleRightIcon ml="auto" />
+                </SubmenuTrigger>
+                <SubmenuList data-testid="submenu-list">
+                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                  <MenuItem data-testid="submenu-item-2">Submenu item 2</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(<SubmenuTriggerTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu trigger
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
+      await waitFor(() => {
+        expect(submenuTrigger).toHaveFocus();
+      });
+
+      // Open the submenu via mouse hover (keeps focus on trigger)
+      fireEvent.mouseEnter(submenuTrigger);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // The trigger should still have focus
+      expect(submenuTrigger).toHaveFocus();
+
+      // Close with ArrowLeft while trigger is focused and submenu is open
+      fireEvent.keyDown(submenuTrigger, { key: 'ArrowLeft' });
+
+      // The submenu should close
+      await waitFor(() => {
+        expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should close submenu with Escape when trigger is focused', async () => {
+      const user = userEvent.setup();
+
+      const SubmenuTriggerTestComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList data-testid="menu-list">
+              <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
+              <Submenu>
+                <SubmenuTrigger data-testid="submenu-trigger">
+                  <Text>Submenu</Text>
+                  <Space width="1x" />
+                  <AngleRightIcon ml="auto" />
+                </SubmenuTrigger>
+                <SubmenuList data-testid="submenu-list">
+                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(<SubmenuTriggerTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu trigger
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuTrigger = screen.getByTestId('submenu-trigger');
+      await waitFor(() => {
+        expect(submenuTrigger).toHaveFocus();
+      });
+
+      // Open the submenu via mouse hover
+      fireEvent.mouseEnter(submenuTrigger);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // Close with Escape while trigger is focused
+      fireEvent.keyDown(submenuTrigger, { key: 'Escape' });
+
+      // The submenu should close
+      await waitFor(() => {
+        expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/packages/react/src/menu/deprecated/SubmenuToggle.js
+++ b/packages/react/src/menu/deprecated/SubmenuToggle.js
@@ -2,12 +2,12 @@ import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { ariaAttr, callEventHandlers, getAllFocusable } from '@tonic-ui/utils';
 import { ensureFunction } from 'ensure-type';
 import React, { forwardRef, useRef } from 'react';
-import { Box } from '../box';
-import { useDefaultProps } from '../default-props';
+import { Box } from '../../box';
+import { useDefaultProps } from '../../default-props';
+import useSubmenu from '../useSubmenu';
 import {
   useSubmenuToggleStyle,
 } from './styles';
-import useSubmenu from './useSubmenu';
 
 /**
  * @deprecated SubmenuToggle is deprecated and will be removed in a future version.
@@ -37,14 +37,14 @@ const SubmenuToggle = forwardRef((inProps, ref) => {
   const {
     focusOnFirstItem,
     isHoveringSubmenuContentRef,
-    isHoveringSubmenuToggleRef,
+    isHoveringSubmenuTriggerRef: isHoveringSubmenuToggleRef,
     isOpen,
     onClose: closeSubmenu,
     onOpen: openSubmenu,
     placement,
     submenuId,
-    submenuToggleId,
-    submenuToggleRef,
+    submenuTriggerId: submenuToggleId,
+    submenuTriggerRef: submenuToggleRef,
   } = { ...submenuContext };
   const combinedRef = useMergeRefs(submenuToggleRef, ref);
   const styleProps = useSubmenuToggleStyle();

--- a/packages/react/src/menu/deprecated/__tests__/SubmenuToggle.test.js
+++ b/packages/react/src/menu/deprecated/__tests__/SubmenuToggle.test.js
@@ -1,0 +1,609 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@tonic-ui/react/test-utils/render';
+import {
+  Flex,
+  Menu,
+  MenuButton,
+  MenuDivider,
+  MenuList,
+  MenuItem,
+  Submenu,
+  SubmenuList,
+  Text,
+} from '@tonic-ui/react/src';
+import React from 'react';
+import SubmenuToggle from '../SubmenuToggle';
+
+describe('SubmenuToggle', () => {
+  describe('SubmenuToggle keyboard navigation', () => {
+    // Note: Use the render function pattern so MenuItem receives the props (role, tabIndex, aria attributes)
+    // This ensures focus-visible styling appears on MenuItem, not on a wrapper element
+    const SubmenuKeyboardTestComponent = (props) => {
+      return (
+        <Menu {...props}>
+          <MenuButton data-testid="menu-button">
+            Options
+          </MenuButton>
+          <MenuList data-testid="menu-list">
+            <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
+            <MenuItem data-testid="menu-item-2">Menu item 2</MenuItem>
+            <MenuDivider />
+            <Submenu>
+              <SubmenuToggle>
+                {({ getSubmenuToggleProps }) => (
+                  <MenuItem data-testid="submenu-toggle" {...getSubmenuToggleProps()}>
+                    <Flex alignItems="center" justifyContent="space-between" width="100%">
+                      <Text>Submenu</Text>
+                    </Flex>
+                  </MenuItem>
+                )}
+              </SubmenuToggle>
+              <SubmenuList data-testid="submenu-list">
+                <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                <MenuItem data-testid="submenu-item-2">Submenu item 2</MenuItem>
+                <MenuItem data-testid="submenu-item-3">Submenu item 3</MenuItem>
+              </SubmenuList>
+            </Submenu>
+            <MenuItem data-testid="menu-item-3">Menu item 3</MenuItem>
+          </MenuList>
+        </Menu>
+      );
+    };
+
+    it('should open submenu with ArrowRight and focus first item', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu toggle using keyboard
+      await user.keyboard('[ArrowDown]'); // Focus menu-item-1
+      await user.keyboard('[ArrowDown]'); // Focus menu-item-2
+      await user.keyboard('[ArrowDown]'); // Focus submenu-toggle
+
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      // Press ArrowRight to open submenu
+      await user.keyboard('[ArrowRight]');
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // The first submenu item should be focused
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+    });
+
+    it('should close submenu with ArrowLeft and return focus to toggle', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu toggle and open it
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      await user.keyboard('[ArrowRight]');
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // The first submenu item should be focused
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+
+      // Press ArrowLeft to close submenu and return to toggle
+      await user.keyboard('[ArrowLeft]');
+
+      // The submenu should be closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
+      });
+
+      // The submenu toggle should be focused again
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-toggle')).toHaveFocus();
+      });
+
+      // IMPORTANT: The parent menu should still be open
+      expect(screen.getByTestId('menu-list')).toBeInTheDocument();
+    });
+
+    it('should close submenu with Escape and return focus to toggle', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu toggle and open it
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      await user.keyboard('[ArrowRight]');
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // Press Escape to close submenu
+      await user.keyboard('[Escape]');
+
+      // The submenu should be closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
+      });
+
+      // The submenu toggle should be focused again
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-toggle')).toHaveFocus();
+      });
+
+      // IMPORTANT: The parent menu should still be open
+      expect(screen.getByTestId('menu-list')).toBeInTheDocument();
+    });
+
+    it('should navigate within submenu with ArrowDown and ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu toggle
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      // Open the submenu
+      await user.keyboard('[ArrowRight]');
+
+      // Wait for submenu to open and first item to be focused
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+
+      // Navigate down in submenu
+      await user.keyboard('[ArrowDown]');
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-2')).toHaveFocus();
+      });
+
+      await user.keyboard('[ArrowDown]');
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-3')).toHaveFocus();
+      });
+
+      // Navigate up in submenu
+      await user.keyboard('[ArrowUp]');
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-2')).toHaveFocus();
+      });
+    });
+
+    it('should navigate to first/last submenu item with Home and End keys', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // Navigate to the submenu toggle and open it
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      await user.keyboard('[ArrowRight]');
+
+      // Wait for submenu to open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+
+      // Press End to go to last item
+      await user.keyboard('[End]');
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-3')).toHaveFocus();
+      });
+
+      // Press Home to go to first item
+      await user.keyboard('[Home]');
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-item-1')).toHaveFocus();
+      });
+    });
+
+    it('should have role="menuitem" on submenu toggle for accessibility', async () => {
+      const user = userEvent.setup();
+      render(<SubmenuKeyboardTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // The submenu toggle should have role="menuitem"
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      expect(submenuToggle).toHaveAttribute('role', 'menuitem');
+      expect(submenuToggle).toHaveAttribute('aria-haspopup', 'menu');
+      // aria-expanded is not present when false (ariaAttr returns undefined for false values)
+      expect(submenuToggle).not.toHaveAttribute('aria-expanded');
+
+      // Open the submenu and check aria-expanded is now "true"
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+      await user.keyboard('[ArrowDown]');
+
+      // Wait for submenu toggle to have focus before opening it
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      await user.keyboard('[ArrowRight]');
+
+      await waitFor(() => {
+        expect(submenuToggle).toHaveAttribute('aria-expanded', 'true');
+      });
+    });
+
+    it('should work with wrapper pattern and have role="presentation" on wrapper', async () => {
+      const user = userEvent.setup();
+
+      const WrapperPatternComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList data-testid="menu-list">
+              <Submenu>
+                <SubmenuToggle data-testid="submenu-toggle-wrapper">
+                  <MenuItem data-testid="submenu-toggle">
+                    <Flex alignItems="center" justifyContent="space-between" width="100%">
+                      <Text>Submenu</Text>
+                    </Flex>
+                  </MenuItem>
+                </SubmenuToggle>
+                <SubmenuList data-testid="submenu-list">
+                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(<WrapperPatternComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+      expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+      // The wrapper should have role="presentation"
+      const submenuToggleWrapper = screen.getByTestId('submenu-toggle-wrapper');
+      expect(submenuToggleWrapper).toHaveAttribute('role', 'presentation');
+      expect(submenuToggleWrapper).toHaveAttribute('aria-haspopup', 'menu');
+
+      // The inner MenuItem should have role="menuitem"
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      expect(submenuToggle).toHaveAttribute('role', 'menuitem');
+
+      // Navigate to the submenu toggle
+      await user.keyboard('[ArrowDown]');
+
+      await waitFor(() => {
+        expect(submenuToggle).toHaveFocus();
+      });
+
+      // Press ArrowRight to open submenu
+      await user.keyboard('[ArrowRight]');
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // The wrapper should have aria-expanded="true"
+      await waitFor(() => {
+        expect(submenuToggleWrapper).toHaveAttribute('aria-expanded', 'true');
+      });
+    });
+  });
+
+  describe('SubmenuToggle with portal', () => {
+    // NOTE: Test that uses fake timers must run last to avoid test isolation issues
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should close the menu when clicking outside both menu and submenu content', async () => {
+      const user = userEvent.setup();
+
+      const SubmenuTestComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList
+              data-testid="menu-list"
+              PopperProps={{
+                usePortal: true,
+              }}
+            >
+              <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
+              <MenuDivider />
+              <Submenu>
+                <SubmenuToggle>
+                  {({ getSubmenuToggleProps }) => (
+                    <MenuItem data-testid="submenu-toggle" {...getSubmenuToggleProps()}>
+                      <Flex alignItems="center" justifyContent="space-between" width="100%">
+                        <Text>Submenu</Text>
+                      </Flex>
+                    </MenuItem>
+                  )}
+                </SubmenuToggle>
+                <SubmenuList
+                  data-testid="submenu-list"
+                  PopperProps={{
+                    usePortal: true,
+                  }}
+                >
+                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(
+        <>
+          <SubmenuTestComponent />
+          <button data-testid="outside-button">Outside</button>
+        </>
+      );
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+
+      // The menu should be open
+      expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
+
+      // Hover over the submenu toggle to open the submenu
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await user.hover(submenuToggle);
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // Click outside the menu and submenu
+      const outsideButton = screen.getByTestId('outside-button');
+      await user.click(outsideButton);
+
+      // The menu should be closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('menu-list')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should receive click events when clicking submenu items rendered in a portal', async () => {
+      const user = userEvent.setup();
+      const handleMenuListClick = jest.fn();
+
+      const SubmenuTestComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList
+              data-testid="menu-list"
+              onClick={handleMenuListClick}
+              PopperProps={{
+                usePortal: true,
+              }}
+            >
+              <MenuItem value="1">Menu item 1</MenuItem>
+              <MenuItem value="2">Menu item 2</MenuItem>
+              <MenuDivider />
+              <Submenu>
+                <SubmenuToggle>
+                  {({ getSubmenuToggleProps }) => (
+                    <MenuItem data-testid="submenu-toggle" {...getSubmenuToggleProps()}>
+                      <Flex alignItems="center" justifyContent="space-between" width="100%">
+                        <Text>Submenu</Text>
+                      </Flex>
+                    </MenuItem>
+                  )}
+                </SubmenuToggle>
+                <SubmenuList
+                  data-testid="submenu-list"
+                  PopperProps={{
+                    usePortal: true,
+                  }}
+                >
+                  <MenuItem data-testid="submenu-item-1" value="3">
+                    Submenu item 1
+                  </MenuItem>
+                  <MenuItem value="4">Submenu item 2</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(<SubmenuTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+
+      // The menu should be open
+      expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
+
+      // Hover over the submenu toggle to open the submenu
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await user.hover(submenuToggle);
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // Click on a submenu item
+      const submenuItem = screen.getByTestId('submenu-item-1');
+      await user.click(submenuItem);
+
+      // Verify the onClick event was received by the menu list
+      expect(handleMenuListClick).toHaveBeenCalledTimes(1);
+
+      // Verify the event target has the correct value
+      const clickEvent = handleMenuListClick.mock.calls[0][0];
+      expect(clickEvent.target.getAttribute('value')).toBe('3');
+
+      // The menu should still be open (not closed by the click on submenu item)
+      expect(screen.getByTestId('menu-list')).toBeInTheDocument();
+    });
+
+    it('should close submenu when mouse leaves both toggle and content', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      const SubmenuTestComponent = () => {
+        return (
+          <Menu>
+            <MenuButton data-testid="menu-button">
+              Options
+            </MenuButton>
+            <MenuList
+              data-testid="menu-list"
+              PopperProps={{
+                usePortal: true,
+              }}
+            >
+              <MenuItem data-testid="menu-item-1">Menu item 1</MenuItem>
+              <MenuDivider />
+              <Submenu>
+                <SubmenuToggle>
+                  {({ getSubmenuToggleProps }) => (
+                    <MenuItem data-testid="submenu-toggle" {...getSubmenuToggleProps()}>
+                      <Flex alignItems="center" justifyContent="space-between" width="100%">
+                        <Text>Submenu</Text>
+                      </Flex>
+                    </MenuItem>
+                  )}
+                </SubmenuToggle>
+                <SubmenuList
+                  data-testid="submenu-list"
+                  PopperProps={{
+                    usePortal: true,
+                  }}
+                >
+                  <MenuItem data-testid="submenu-item-1">Submenu item 1</MenuItem>
+                </SubmenuList>
+              </Submenu>
+            </MenuList>
+          </Menu>
+        );
+      };
+
+      render(<SubmenuTestComponent />);
+
+      const menuButton = screen.getByTestId('menu-button');
+
+      // Open the menu
+      await user.click(menuButton);
+
+      // The menu should be open
+      expect(await screen.findByTestId('menu-list')).toBeInTheDocument();
+
+      // Hover over the submenu toggle to open the submenu
+      const submenuToggle = screen.getByTestId('submenu-toggle');
+      await user.hover(submenuToggle);
+
+      // The submenu should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+      });
+
+      // Move to submenu content
+      const submenuList = screen.getByTestId('submenu-list');
+      await user.hover(submenuList);
+
+      // The submenu should still be open
+      expect(screen.getByTestId('submenu-list')).toBeInTheDocument();
+
+      // Move mouse away from submenu
+      await user.unhover(submenuList);
+
+      // Advance timers to trigger the close timeout
+      jest.advanceTimersByTime(150);
+
+      // The submenu should be closed after the timeout
+      await waitFor(() => {
+        expect(screen.queryByTestId('submenu-list')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/packages/react/src/menu/deprecated/styles.js
+++ b/packages/react/src/menu/deprecated/styles.js
@@ -1,0 +1,10 @@
+const useSubmenuToggleStyle = () => {
+  return {
+    cursor: 'pointer',
+    display: 'inline-flex',
+  };
+};
+
+export {
+  useSubmenuToggleStyle,
+};

--- a/packages/react/src/menu/index.js
+++ b/packages/react/src/menu/index.js
@@ -11,6 +11,7 @@ import Submenu from './Submenu';
 import SubmenuContent from './SubmenuContent';
 import SubmenuList from './SubmenuList';
 import SubmenuToggle from './SubmenuToggle';
+import SubmenuTrigger from './SubmenuTrigger';
 import useMenu from './useMenu';
 import useSubmenu from './useSubmenu';
 
@@ -25,7 +26,8 @@ Menu.Toggle.Icon = MenuToggleIcon;
 
 Submenu.Content = SubmenuContent;
 Submenu.List = SubmenuList;
-Submenu.Toggle = SubmenuToggle;
+Submenu.Toggle = SubmenuToggle; // deprecated - Use Submenu.Trigger instead
+Submenu.Trigger = SubmenuTrigger;
 
 export {
   Menu,
@@ -40,7 +42,8 @@ export {
   Submenu,
   SubmenuContent,
   SubmenuList,
-  SubmenuToggle,
+  SubmenuToggle, // deprecated - Use SubmenuTrigger instead
+  SubmenuTrigger,
   useMenu,
   useSubmenu,
 };

--- a/packages/react/src/menu/index.js
+++ b/packages/react/src/menu/index.js
@@ -10,10 +10,11 @@ import MenuToggleIcon from './MenuToggleIcon';
 import Submenu from './Submenu';
 import SubmenuContent from './SubmenuContent';
 import SubmenuList from './SubmenuList';
-import SubmenuToggle from './SubmenuToggle';
 import SubmenuTrigger from './SubmenuTrigger';
 import useMenu from './useMenu';
 import useSubmenu from './useSubmenu';
+
+import SubmenuToggle from './deprecated/SubmenuToggle'; // deprecated
 
 Menu.Button = MenuButton;
 Menu.Content = MenuContent;
@@ -26,7 +27,7 @@ Menu.Toggle.Icon = MenuToggleIcon;
 
 Submenu.Content = SubmenuContent;
 Submenu.List = SubmenuList;
-Submenu.Toggle = SubmenuToggle; // deprecated - Use Submenu.Trigger instead
+Submenu.Toggle = SubmenuToggle; // deprecated
 Submenu.Trigger = SubmenuTrigger;
 
 export {
@@ -42,7 +43,7 @@ export {
   Submenu,
   SubmenuContent,
   SubmenuList,
-  SubmenuToggle, // deprecated - Use SubmenuTrigger instead
+  SubmenuToggle, // deprecated
   SubmenuTrigger,
   useMenu,
   useSubmenu,

--- a/packages/react/src/menu/styles.js
+++ b/packages/react/src/menu/styles.js
@@ -239,13 +239,11 @@ const useSubmenuListStyle = ({
   };
 };
 
-const useSubmenuTriggerStyle = useMenuItemStyle;
+const useSubmenuTriggerStyle = ({ tabIndex }) => {
+  const menuItemStyle = useMenuItemStyle({ tabIndex });
 
-// deprecated
-const useSubmenuToggleStyle = () => {
   return {
-    cursor: 'pointer',
-    display: 'inline-flex',
+    ...menuItemStyle,
   };
 };
 
@@ -264,7 +262,4 @@ export {
   useSubmenuContentStyle,
   useSubmenuListStyle,
   useSubmenuTriggerStyle,
-
-  // deprecated
-  useSubmenuToggleStyle,
 };

--- a/packages/react/src/menu/styles.js
+++ b/packages/react/src/menu/styles.js
@@ -239,6 +239,9 @@ const useSubmenuListStyle = ({
   };
 };
 
+const useSubmenuTriggerStyle = useMenuItemStyle;
+
+// deprecated
 const useSubmenuToggleStyle = () => {
   return {
     cursor: 'pointer',
@@ -260,5 +263,8 @@ export {
   useSubmenuStyle,
   useSubmenuContentStyle,
   useSubmenuListStyle,
+  useSubmenuTriggerStyle,
+
+  // deprecated
   useSubmenuToggleStyle,
 };

--- a/packages/react/src/table/deprecated/TableHeaderCell.js
+++ b/packages/react/src/table/deprecated/TableHeaderCell.js
@@ -1,9 +1,9 @@
 import React, { forwardRef } from 'react';
-import { Box } from '../box';
-import { useDefaultProps } from '../default-props';
-import { GROUP_VARIANT_HEADER, LAYOUT_TABLE } from './constants';
-import { useTableCellStyle } from './styles';
-import useTable from './useTable';
+import { Box } from '../../box';
+import { useDefaultProps } from '../../default-props';
+import { GROUP_VARIANT_HEADER, LAYOUT_TABLE } from '../constants';
+import { useTableCellStyle } from '../styles';
+import useTable from '../useTable';
 
 const TableHeaderCell = forwardRef((inProps, ref) => {
   const {

--- a/packages/react/src/table/deprecated/TableHeaderRow.js
+++ b/packages/react/src/table/deprecated/TableHeaderRow.js
@@ -1,9 +1,9 @@
 import React, { forwardRef } from 'react';
-import { Box } from '../box';
-import { useDefaultProps } from '../default-props';
-import { GROUP_VARIANT_HEADER, LAYOUT_TABLE } from './constants';
-import { useTableRowStyle } from './styles';
-import useTable from './useTable';
+import { Box } from '../../box';
+import { useDefaultProps } from '../../default-props';
+import { GROUP_VARIANT_HEADER, LAYOUT_TABLE } from '../constants';
+import { useTableRowStyle } from '../styles';
+import useTable from '../useTable';
 
 const TableHeaderRow = forwardRef((inProps, ref) => {
   const {

--- a/packages/react/src/table/index.js
+++ b/packages/react/src/table/index.js
@@ -1,13 +1,14 @@
 import { ResizeHandle as TableColumnResizeHandle } from '../resize-handle';
 import Table from './Table';
 import TableHeader from './TableHeader';
-import TableHeaderRow from './TableHeaderRow'; // deprecated
-import TableHeaderCell from './TableHeaderCell'; // deprecated
 import TableBody from './TableBody';
 import TableFooter from './TableFooter';
 import TableRow from './TableRow';
 import TableCell from './TableCell';
 import TableScrollbar from './TableScrollbar';
+
+import TableHeaderRow from './deprecated/TableHeaderRow'; // deprecated
+import TableHeaderCell from './deprecated/TableHeaderCell'; // deprecated
 
 Table.Header = TableHeader;
 Table.HeaderRow = TableHeaderRow; // deprecated


### PR DESCRIPTION
## Summary

Closes #1090

This PR introduces `SubmenuTrigger`, a new component that combines MenuItem functionality with submenu trigger behavior, significantly improving the developer experience and aligning with industry standards.

Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-1091/components/menu/

## Motivation

The current `SubmenuToggle` component requires verbose nesting of a MenuItem inside it, leading to:
- Excessive boilerplate code (3 levels of nesting)
- Poor developer experience
- Inconsistency with industry naming standards (Radix UI, React Aria, Chakra UI all use "Trigger")

## Changes

### New Component: `SubmenuTrigger`

- **Combined functionality**: Acts as both MenuItem and submenu trigger
- **Cleaner API**: Direct children without MenuItem wrapper
- **Event handling**: Integrates `useButtonEventHandlers` for click/Enter/Space support
- **closeOnSelect support**: Inherits MenuItem's close-on-select behavior
- **Keyboard navigation**: Arrow keys for opening/closing submenus
- **Full accessibility**: Proper ARIA attributes maintained

### Deprecated: `SubmenuToggle`

- Marked with `@deprecated` JSDoc annotation
- Includes clear migration guide in code comments
- Maintains backward compatibility
- Will be removed in next major version

### Migration

**Before (verbose):**
```jsx
<SubmenuToggle>
  <MenuItem>
    <Flex alignItems="center" justifyContent="space-between" width="100%">
      <Text>Submenu</Text>
      <AngleRightIcon />
    </Flex>
  </MenuItem>
</SubmenuToggle>
```

After (clean):
```jsx
<SubmenuTrigger>
  <Text>Submenu</Text>
  <Space width="1x" />
  <AngleRightIcon ml="auto" />
</SubmenuTrigger>
```