### PR TITLE
ci(changesets): enable `onlyUpdatePeerDependentsWhenOutOfRange` option

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "v2",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }


### PR DESCRIPTION
# Summary

Configure Changesets to only bump peer dependents when the version change puts them out of their declared range. This prevents unnecessary major version bumps when the existing peer dependency range still covers the new version.

See https://github.com/changesets/changesets/blob/main/docs/experimental-options.md

### What This Will Do
With this setting enabled, Changesets will now:

* Only bump dependents to major when the peer dependency change puts them out of range
* Skip unnecessary major bumps when the existing peer dependency range still covers the new version