### PR TITLE
chore: add Claude Code skill files for repo conventions

### DIFF
--- a/.claude/skills/tonic-ui-patterns/SKILL.md
+++ b/.claude/skills/tonic-ui-patterns/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: tonic-ui-patterns
+description: Coding patterns extracted from tonic-ui repository
+version: 1.0.0
+source: local-git-analysis
+analyzed_commits: 200
+---
+
+# Tonic UI Patterns
+
+## Commit Conventions
+
+This project uses **conventional commits** with scope:
+
+| Type | Usage | Frequency |
+|------|-------|-----------|
+| `chore` | Releases, deps, tooling | ~36% |
+| `feat` | New features | ~23% |
+| `docs` | Documentation | ~18% |
+| `ci` | CI/CD workflows | ~12% |
+| `fix` | Bug fixes | ~7% |
+| `test` | Test additions | ~2% |
+| `refactor` | Code restructuring | ~1% |
+
+**Scope format:** `type(package/component)` — e.g., `feat(react/menu)`, `fix(react/Checkbox)`, `chore(deps-dev)`
+
+Common scopes:
+- `react` / `react/<component>` — Main component package
+- `react-hooks` — Hooks package
+- `react-icons` — Icons package
+- `mcp` — MCP server package
+- `deps` / `deps-dev` — Dependency bumps
+- `release` — Version releases
+- `changesets` — Changeset config
+
+**PR references:** Commit messages include `(#<number>)` at the end.
+
+## Monorepo Structure
+
+```
+packages/
+├── changelog-github/   # Custom changelog generator
+├── codemod/            # Code migration tools
+├── mcp/                # MCP server (TypeScript)
+├── react/              # Main component library (JavaScript)
+├── react-base/         # Base primitives (Box)
+├── react-docs/         # Next.js documentation site
+├── react-hooks/        # Shared hooks
+├── react-icons/        # SVG icon components
+├── styled-system/      # Styled System utilities
+├── theme/              # Design tokens
+└── utils/              # Shared utilities
+```
+
+**Key:** `packages/react` is the most frequently modified package (~38 commits in last 200).
+
+## Component Architecture
+
+### File Structure Pattern
+
+Each component lives in `packages/react/src/<component-name>/`:
+
+```
+<component-name>/
+├── ComponentName.js        # Main component (forwardRef + Box base)
+├── index.js                # Barrel exports
+├── styles.js               # Style hooks (useComponentNameStyle)
+├── context.js              # React context (if compound component)
+├── useComponentName.js     # Context consumer hook
+├── withComponentName.js    # HOC for context injection (optional)
+├── constants.js            # Constants (variants, sizes)
+└── __tests__/
+    ├── ComponentName.test.js
+    └── __snapshots__/
+        └── ComponentName.test.js.snap
+```
+
+### Component Pattern
+
+Components use `forwardRef` with `useDefaultProps`:
+
+```javascript
+import React, { forwardRef } from 'react';
+import { useDefaultProps } from '../default-props';
+import { useComponentStyle } from './styles';
+
+const Component = forwardRef((inProps, ref) => {
+  const {
+    prop1,
+    prop2,
+    ...rest
+  } = useDefaultProps({ props: inProps, name: 'Component' });
+
+  const styleProps = useComponentStyle({ prop1 });
+
+  return (
+    <Box ref={ref} {...styleProps} {...rest} />
+  );
+});
+
+Component.displayName = 'Component';
+
+export default Component;
+```
+
+### Compound Component Pattern
+
+For related component groups (Menu, FormControl, Accordion):
+
+1. **Context file** (`context.js`) — `createContext()`
+2. **Provider component** — wraps children with context
+3. **Consumer hook** (`useComponentName.js`) — `useContext(ComponentContext)`
+4. **HOC** (`withComponentName.js`) — injects context props (optional)
+5. **Barrel exports** (`index.js`) — named exports for all sub-components
+
+### Style Pattern
+
+Styles use hooks that return style objects using Styled System tokens:
+
+```javascript
+import { useColorStyle } from '../color-style';
+
+const useComponentStyle = ({ variant }) => {
+  const [colorStyle] = useColorStyle();
+
+  return {
+    color: colorStyle.color.primary,
+    fontSize: 'sm',
+    px: '2x',
+    py: '1x',
+  };
+};
+```
+
+**Token formats:** `'1x'`, `'2x'`, `'sm'`, `'md'`, `'lg'` (Styled System spacing/sizing).
+
+## Adding a New Component
+
+Based on recent features (Highlight, Mark, FormControl), the workflow is:
+
+### 1. Create component source files
+
+```
+packages/react/src/<component-name>/
+├── ComponentName.js
+├── index.js
+├── styles.js
+└── __tests__/
+    └── ComponentName.test.js
+```
+
+### 2. Register in package index
+
+Add to `packages/react/src/index.js`:
+```javascript
+export { ComponentName } from './<component-name>';
+```
+
+### 3. Update package export test
+
+Add to `packages/react/__tests__/index.test.js` to verify the export exists.
+
+### 4. Create documentation pages
+
+Add to `packages/react-docs/pages/components/<component-name>/`:
+- `index.page.mdx` — Main doc page
+- Individual example files (`.js`) for each usage pattern
+
+### 5. Register in sidebar
+
+Add route to `packages/react-docs/config/sidebar-routes.js`.
+
+### 6. Create changeset
+
+Add `.changeset/<changeset-name>.md`:
+```markdown
+---
+"@tonic-ui/react": minor
+---
+
+feat: Add `ComponentName` component
+```
+
+## Files That Co-Change
+
+These files typically change together:
+- `packages/react/src/index.js` + `packages/react/__tests__/index.test.js` (new exports)
+- `packages/react-docs/config/sidebar-routes.js` + `packages/react-docs/pages/components/*/index.page.mdx` (new docs)
+- `packages/react/package.json` + `packages/react/CHANGELOG.md` + `.changeset/*.md` (releases)
+
+## Testing Patterns
+
+- **Framework:** Jest with React Testing Library
+- **Location:** `__tests__/` directories co-located with source
+- **Naming:** `ComponentName.test.js`
+- **Snapshots:** Used extensively for visual regression (`__snapshots__/`)
+- **Accessibility:** Tests use `@tonic-ui/react-base/test-utils/accessibility` utilities
+- **Test command:** `yarn test`
+
+## Changesets & Releases
+
+- Uses `@changesets/cli` for versioning
+- Base branch: `v2`
+- Changelog: Custom `@tonic-ui/changelog-github` generator
+- Access: `public` (npm)
+- Changeset files go in `.changeset/` with descriptive names (e.g., `tonic-ui-pr-1085.md`)
+
+## Key Conventions
+
+1. **JavaScript only** — No TypeScript for components; `.d.ts` files for type definitions
+2. **forwardRef everywhere** — All components forward refs
+3. **Styled System props** — Style via props (`px`, `py`, `color`, `bg`), not CSS classes
+4. **Color tokens** — Use `colorStyle.color.primary`, `colorStyle.color.secondary`, `colorStyle.color.error`
+5. **useDefaultProps** — Components use this for default prop values
+6. **displayName** — Always set on components
+7. **Named exports** — Barrel files use named `export { X } from './X'` pattern

--- a/.claude/skills/tonic-ui-pr/SKILL.md
+++ b/.claude/skills/tonic-ui-pr/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: tonic-ui-pr
+description: Generate PR descriptions and changeset entries. Use when the user mentions "PR", "pull request", "PR description", "changeset", provides a diff or describes code changes, or asks to draft a merge request. Also trigger for conventional commit message generation.
+---
+
+# PR Description Generator
+
+Generate well-structured PR descriptions following conventional commits and tonic-ui project conventions. Based on analysis of 885 commits and 721 PRs.
+
+## Pre-Work Checklist
+
+**CRITICAL: Always complete these steps BEFORE writing PR descriptions**
+
+- [ ] **Run git commands to understand changes** — Never write PR descriptions without seeing the actual changes
+- [ ] **Check commit history** — Review recent commits to match repository style
+- [ ] **Identify changed files and scope** — Determine which packages/components are affected
+
+**Run these commands in parallel:**
+```bash
+git status              # See all changed files
+git diff HEAD           # See all changes
+git log --oneline -10   # See recent commit message style
+```
+
+**For efficiency:** Make all three Bash tool calls in a single message since they're independent.
+
+## Scope Rules
+
+| Allowed | NOT Allowed |
+|---------|------------|
+| Generate PR titles and descriptions | Modify source code |
+| Create changeset files for monorepos | Create changesets for non-monorepo projects |
+| Draft commit messages | Automatically commit or push changes |
+| Review and summarize diffs | Add features or fix bugs |
+
+**If asked to create a changeset for a non-monorepo project**, explain that changesets are only used in Tonic UI and Tonic One monorepos.
+
+## PR Title Format
+
+Follow conventional commits:
+
+```
+<type>(<scope>): <short description>
+```
+
+**Formatting rules:**
+- Lowercase first letter after type/scope (87% convention)
+- Under 72 characters
+- No period at end
+- Wrap component/prop/package names in backticks (34% of PRs do this)
+
+**Types (by frequency in this repo):**
+
+| Type | Usage | % |
+|------|-------|---|
+| `feat` | New features, components, props | 38% |
+| `docs` | Documentation changes | 16% |
+| `fix` | Bug fixes | 15% |
+| `chore` | Dependencies, releases, tooling | 14% |
+| `refactor` | Code restructuring, no behavior change | 5% |
+| `ci` | CI/CD changes | 2% |
+| `breaking` | Breaking changes (repo-specific type) | 2% |
+| `test` | Test additions/changes | <1% |
+| `build` | Build system changes | <1% |
+| `style` | Formatting, whitespace | <1% |
+| `revert` | Reverting previous changes | <1% |
+
+**Important — `breaking` as a type:** This repo historically uses `breaking:` as a standalone type prefix (15 PRs), NOT the conventional `feat!:` notation. Only 1 PR uses the `!` marker.
+```
+breaking: deprecate the rarely used FlatButton component
+breaking: deprecate the second argument of CheckboxGroup onChange callback
+feat(react/date-pickers)!: deprecate Calendar and replace it with DateCalendar  ← only 1 uses !
+```
+
+**Scope conventions:**
+
+| Format | Example | Notes |
+|--------|---------|-------|
+| `package/component` | `react/menu`, `react/scrollbar`, `react/tag` | Current convention (recent trend) |
+| Package name | `react`, `styled-system`, `utils`, `react-hooks` | For package-wide changes |
+| No scope | `feat: add X component` | Acceptable for cross-cutting changes |
+
+**Common scopes:** `react/menu`, `react/table`, `react/scrollbar`, `react/checkbox`, `react/toast`, `react/date-pickers`, `styled-system`, `utils`, `react-hooks`, `react-icons`, `theme`
+
+**Cross-repo references:** When porting changes from/to Tonic One, include `[tonic-one-pr-NNN]` in the title.
+
+**Examples:**
+```
+feat(react/scrollbar): add `scrollViewProps` to enable passing custom props
+fix(react/menu): correct focus management on keyboard navigation
+refactor(styled-system): migrate to semantic color tokens
+docs: update `Table` component examples
+chore(deps): bump webpack from 5.88.0 to 5.89.0
+breaking: deprecate the `FlatButton` component
+revert(react/InputGroup): restore pseudo-class styling
+```
+
+## PR Body Template
+
+Based on the actual patterns used in recent PRs (not a generic template):
+
+```markdown
+## Summary
+
+Closes #ISSUE_NUMBER (if applicable)
+
+Brief 1-3 sentence description of the change.
+
+Demo: https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-{PR_NUMBER}/components/{COMPONENT}/
+
+## Changes
+
+- **Component/File**: Description of change
+- **Component/File**: Description of change
+
+## Motivation
+
+Why this change was needed. (Optional — include for non-trivial changes)
+
+## Migration
+
+Before/after code examples showing migration path. (Only for breaking changes)
+```
+
+**Section usage guide:**
+- `## Summary` — Always include. 1-3 sentences + optional demo link + optional `Closes #NNN`
+- `## Changes` — Always include for multi-file changes. Bullet list of what changed where.
+- `## Motivation` — Include when the "why" isn't obvious from the summary
+- `## Migration` — Only for breaking changes. Show before/after code examples.
+
+**Demo links:** ~48% of PRs include a demo link. Format:
+```
+https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-{PR_NUMBER}/components/{COMPONENT}/
+https://trendmicro-frontend.github.io/tonic-ui-demo/react/pr-{PR_NUMBER}/hooks/{HOOK_NAME}/
+```
+
+**Issue references:**
+- `Closes #NNN` or `Close #NNN` — for GitHub issues (~10% of PRs)
+- `Related PR: #NNN` or `Depends on: #NNN` — for PR dependencies (~2% of PRs)
+
+**What NOT to include:**
+- `## Testing` section — never used in this repo
+- Jira ticket references (`TVO-XXXX`, `V1E-XXXX`) — not used in this repo
+- Figma links — only ~4% of PRs, include only if the user provides one
+
+## Changeset Entries
+
+When the change affects a publishable package, generate a changeset file.
+
+### File Naming Convention
+
+```
+.changeset/tonic-ui-pr-{PR_NUMBER}.md
+```
+
+For multiple changesets on the same PR, use suffixes:
+```
+.changeset/tonic-ui-pr-943a.md
+.changeset/tonic-ui-pr-943b.md
+```
+Or descriptive suffixes:
+```
+.changeset/tonic-ui-pr-987-modal-regression.md
+.changeset/tonic-ui-pr-987-react-hooks.md
+```
+
+### Changeset Format
+
+```markdown
+---
+"@tonic-ui/react": minor
+---
+
+feat(react/scrollbar): add `scrollViewProps` to enable passing custom props to the `ScrollView`
+```
+
+**Description rules:**
+- Always single line
+- Use conventional commit format matching the PR title
+- Wrap component/prop names in backticks
+- ~75 characters average length
+- This description becomes the changelog entry
+
+### Bump Rules
+
+| Bump | When | Frequency |
+|------|------|-----------|
+| `patch` | Bug fixes, refactoring, styling corrections, internal improvements | 56% |
+| `minor` | New components, new props, new hooks, new features | 42% |
+| `major` | Breaking API changes (extremely rare) | 2% |
+
+### Package Names (by frequency)
+
+| Package | Changeset Frequency |
+|---------|-------------------|
+| `@tonic-ui/react` | 66% (most common) |
+| `@tonic-ui/styled-system` | 6% |
+| `@tonic-ui/react-hooks` | 6% |
+| `@tonic-ui/utils` | 5% |
+| `@tonic-ui/react-icons` | 5% |
+| `@tonic-ui/react-base` | 5% |
+| `@tonic-ui/theme` | 2% |
+
+**Tonic One packages:** `@tonic-one/react`, `@tonic-one/react-icons`, `@tonic-one/react-hooks`, `@tonic-one/react-data-grid`
+
+**Never create changesets for:** `codemod`, `changelog-github`, `react-docs` (internal/dev packages)
+
+### Single vs Multi-Package
+
+- **Single-package changesets** are the norm (86%)
+- **Multi-package** only when the change genuinely spans package boundaries:
+  - Cross-cutting infrastructure (e.g., React 19 compat across `react`, `react-base`, `react-hooks`)
+  - Feature with utility dependency (e.g., component + `utils`)
+  - Bug fix spanning hook + component (e.g., `react-hooks` + `react`)
+
+### Changeset Configuration
+
+- **Config**: `.changeset/config.json`
+- **Base branch**: `v2` (not `master`)
+- **Release PR title**: `chore(release): version packages`
+- **Release workflow**: Automated via `.github/workflows/changesets-release.yml` on push to `v2`
+
+## Workflow: Diff → PR Description
+
+### Step 1: Analyze Changes (Use parallel tool calls)
+
+```bash
+# Make all three Bash tool calls in one message:
+git status
+git diff HEAD
+git log --oneline -10
+```
+
+### Step 2: Classify the Change
+
+Identify:
+- **Type**: feat/fix/refactor/docs/chore/ci/breaking/test/build/style/revert
+- **Scope**: From file paths (e.g., `react/button`, `react-hooks/useColorMode`, `theme`)
+- **Breaking changes**: API changes, removed features, behavior changes
+- **Affected packages**: Which packages in the monorepo are impacted
+
+### Step 3: Write PR Content
+
+Generate:
+1. **PR Title** — Following conventional commits format
+2. **PR Body** — Using the template above
+3. **Changeset** — With correct file name, package, bump type, and description
+
+### Step 4: Verify Quality
+
+**Post-Generation Checklist:**
+- [ ] PR title follows `<type>(<scope>): <description>` format
+- [ ] Title is under 72 characters with lowercase first letter
+- [ ] Body uses `## Summary` / `## Changes` sections (not `## What Changed`)
+- [ ] Demo link included if applicable
+- [ ] `## Migration` section included if breaking change
+- [ ] Changeset file named `tonic-ui-pr-{NUMBER}.md`
+- [ ] Changeset bump type correct (patch/minor/major)
+- [ ] Changeset package names accurate
+- [ ] Changeset description is single-line conventional commit format
+
+## Common Mistakes to Avoid
+
+**Vague PR titles:**
+```
+fix: fix bug                          ← too vague
+feat: add feature                     ← too vague
+fix: fix the issue with the component ← redundant "fix: fix"
+```
+
+**Specific PR titles:**
+```
+fix(react/scrollbar): prevent scroll jump on content update
+feat(react/table): add sticky header support with `stickyHeader` prop
+```
+
+**Wrong PR body template:**
+```markdown
+## What Changed    ← wrong, use "## Summary"
+## Why             ← wrong, use "## Motivation"
+## How             ← wrong, use "## Changes"
+## Testing         ← not used in this repo
+## Related
+- Jira: TVO-XXXX  ← not used in this repo
+```
+
+**Wrong changeset file name:**
+```
+.changeset/fuzzy-pots-clap.md         ← auto-generated name, don't use
+.changeset/tonic-ui-943.md            ← old convention
+.changeset/tonic-ui-pr-943.md         ← correct current convention
+```
+
+## Label Conventions
+
+PRs in this repo use labels with the following conventions:
+
+| Label | Usage |
+|-------|-------|
+| `feature (enhancement)` | New features |
+| `bug` | Bug fixes |
+| `documentation` | Docs changes |
+| `refactor (improvement)` | Refactoring |
+| `breaking change` | Breaking changes |
+| `build (ci/cd)` | CI/CD changes |
+| `dependencies` | Dependency updates |
+| `work in progress` | Draft/WIP PRs |
+| `review required` | Ready for review |
+| `Review effort [1-5]: N` | Review complexity rating |

--- a/.claude/skills/tonic-ui-types/SKILL.md
+++ b/.claude/skills/tonic-ui-types/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: tonic-ui-types
+description: Use this skill when adding JSDoc type definitions to React components in Tonic UI. Triggers include "add type definitions", "add JSDoc types", "document component props", or when creating new components that need type annotations.
+---
+
+# Add Type Definitions to React Components
+
+This skill provides guidelines for adding JSDoc type definitions to React components in the Tonic UI design system.
+
+## Overview
+
+Tonic UI uses JSDoc annotations (`@typedef` and `@type`) to provide type information for React components. This enables better IDE support, documentation generation, and type checking.
+
+## Prerequisites
+
+Before adding type definitions:
+
+1. **Read the component documentation** (required) - Check `packages/react-docs/pages/components/[component-name]/index.page.mdx`
+   - Locate the Props table in the `## Props` section
+   - Document all prop names, types, defaults, and descriptions
+   - Use exact descriptions from the documentation
+   - If no documentation exists, analyze the component implementation
+2. **Read the component file** to understand its implementation
+3. **Verify the component pattern** (forwardRef vs functional component)
+4. **Identify the HTML element type** that the component renders
+
+## Required Workflow
+
+### Step 1: Identify the Component Pattern
+
+Determine which pattern the component uses:
+
+**ForwardRef Component (most common):**
+```javascript
+const Component = forwardRef((inProps, ref) => { ... });
+```
+
+**Functional Component (no ref):**
+```javascript
+const Component = (inProps) => { ... };
+```
+
+### Step 2: Add the @typedef Block
+
+Add a JSDoc `@typedef` block before the component declaration. Include all custom props with their types and descriptions.
+
+**Format:**
+```javascript
+/**
+ * @typedef {Object} ComponentNameProps
+ * @property {type} [propName] - Description of the property.
+ * @property {type} [propName=default] - Description with default value.
+ */
+```
+
+**Property Type Examples:**
+- `{React.ReactNode}` - React children or renderable content
+- `{boolean}` - Boolean flags
+- `{string}` - String values
+- `{number}` - Numeric values
+- `{function}` - Callback functions
+- `{'option1' | 'option2'}` - String enums
+- `{'sm' | 'md' | 'lg'}` - Size variants
+- `{React.ReactNode | React.ReactNode[]}` - Single or array
+- `{React.RefObject<HTMLElement>}` - Ref objects
+
+### Step 3: Add the @type Annotation
+
+Add a `@type` annotation immediately before the component declaration.
+
+**For ForwardRef Components (simple — no prop conflicts):**
+```javascript
+/**
+ * @type {React.ForwardRefExoticComponent<StyleProps & React.ComponentPropsWithoutRef<'element'> & ComponentNameProps & React.RefAttributes<HTMLElement>>}
+ */
+const Component = forwardRef((inProps, ref) => {
+```
+
+**For ForwardRef Components (with prop conflicts — use `Omit`):**
+
+When the component defines custom props that conflict with native HTML element props (e.g., `onChange`, `onBlur`, `children`, `size`), use `Omit<>` to exclude the conflicting native props:
+
+```javascript
+/**
+ * @type {React.ForwardRefExoticComponent<StyleProps & Omit<React.ComponentPropsWithoutRef<'element'>, 'conflictingProp1' | 'conflictingProp2'> & ComponentNameProps & React.RefAttributes<HTMLElement>>}
+ */
+const Component = forwardRef((inProps, ref) => {
+```
+
+Common conflicts to `Omit`:
+| Custom prop | Conflicts with native | Example components |
+|-------------|----------------------|-------------------|
+| `children` (render prop) | `React.ReactNode` children | Accordion, Modal |
+| `onChange` (custom signature) | `HTMLElement.onChange` | Checkbox, Switch, Tabs |
+| `onBlur`, `onFocus`, `onClick` | Native event handlers | Checkbox, Switch |
+| `size` (string enum) | `HTMLInputElement.size` (number) | Input |
+
+**For Functional Components:**
+```javascript
+/**
+ * @type {React.FC<StyleProps & ComponentNameProps>}
+ */
+const Component = (inProps) => {
+```
+
+### Step 4: Choose the Correct HTML Element
+
+Match the element type to what the component renders:
+
+| Component renders | Use element | Ref type |
+|-------------------|-------------|----------|
+| `<button>` | `'button'` | `HTMLButtonElement` |
+| `<input>` | `'input'` | `HTMLInputElement` |
+| `<a>` | `'a'` | `HTMLAnchorElement` |
+| `<label>` | `'label'` | `HTMLLabelElement` |
+| `<div>` (default) | `'div'` | `HTMLDivElement` |
+| `<span>` | `'span'` | `HTMLSpanElement` |
+
+### Step 4.5: Add Type Test File
+
+Create a type test file at `packages/react/__type-tests__/components/{component-name}.test-d.tsx` to verify the type definitions compile correctly.
+
+**Format:**
+```tsx
+import React, { createRef } from 'react';
+import { ComponentName } from '@tonic-ui/react';
+
+// Basic usage
+<ComponentName>content</ComponentName>;
+
+// With custom props
+<ComponentName propName="value" />;
+
+// With ref
+const ref = createRef<HTMLDivElement>();
+<ComponentName ref={ref} />;
+
+// With style props
+<ComponentName mt={2} px="4x" />;
+```
+
+The type tests are compiled with `tsconfig.json` in the `__type-tests__/` directory using `strict: true` and `noEmit: true` — they only need to compile without errors.
+
+## Implementation Rules
+
+1. **Copy descriptions exactly** - Use the exact wording from the Props table in the documentation
+2. **Always include `StyleProps`** - All Tonic UI components support style props
+3. **Use brackets for optional props** - `[propName]` indicates optional
+4. **Document defaults** - Use `[propName=default]` syntax
+5. **Match documentation exactly** - Props, types, defaults, and descriptions must match the docs table
+6. **Use proper React types** - `React.ReactNode`, `React.RefObject`, etc.
+7. **Check for prop conflicts** - If a custom prop name collides with a native HTML prop, use `Omit<>` in the `@type` annotation
+8. **Align with `useDefaultProps`** - Verify that default values in `@typedef` match the defaults provided by `useDefaultProps`
+
+## Examples
+
+### Example 1: Simple Component with Few Props
+
+```javascript
+/**
+ * @typedef {Object} LinkProps
+ * @property {React.ReactNode} [children] -
+ * @property {boolean} [disabled] - The link will be disabled.
+ * @property {function} [onClick] - A callback called when the link is clicked.
+ * @property {string} [variant='default'] - The visual style of the link.
+ */
+
+/**
+ * @type {React.ForwardRefExoticComponent<StyleProps & React.ComponentPropsWithoutRef<'a'> & LinkProps & React.RefAttributes<HTMLAnchorElement>>}
+ */
+const Link = forwardRef((inProps, ref) => {
+```
+
+### Example 2: Component with Enum Props
+
+```javascript
+/**
+ * @typedef {Object} ButtonProps
+ * @property {React.ReactNode} [children] -
+ * @property {boolean} [disabled] - Disables the button.
+ * @property {'sm' | 'md' | 'lg'} [size='md'] - The size of the button.
+ * @property {'emphasis' | 'primary' | 'default' | 'secondary' | 'ghost'} [variant='default'] - The variant style.
+ */
+
+/**
+ * @type {React.ForwardRefExoticComponent<StyleProps & React.ComponentPropsWithoutRef<'button'> & ButtonProps & React.RefAttributes<HTMLButtonElement>>}
+ */
+const Button = forwardRef((inProps, ref) => {
+```
+
+### Example 3: Component with Prop Conflicts (Omit pattern)
+
+```javascript
+/**
+ * @typedef {Object} CheckboxProps
+ * @property {React.ReactNode} [children] -
+ * @property {boolean} [checked] - If `true`, the checkbox is checked.
+ * @property {boolean} [disabled] - If `true`, the checkbox is disabled.
+ * @property {function} [onChange] - A callback called when the state is changed.
+ */
+
+/**
+ * @type {React.ForwardRefExoticComponent<StyleProps & Omit<React.ComponentPropsWithoutRef<'label'>, 'onBlur' | 'onChange' | 'onClick' | 'onFocus'> & CheckboxProps & React.RefAttributes<HTMLLabelElement>>}
+ */
+const Checkbox = forwardRef((inProps, ref) => {
+```
+
+### Example 4: Component with Complex Props
+
+```javascript
+/**
+ * @typedef {Object} ModalProps
+ * @property {React.ReactNode | ((context: object) => React.ReactNode)} [children] -
+ * @property {boolean} [isOpen=false] - Controls the visibility of the modal.
+ * @property {function} [onClose] - Callback when the modal closes.
+ * @property {React.RefObject<HTMLElement>} [initialFocusRef] - Element to focus on open.
+ * @property {'auto' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full'} [size='auto'] - The size of the modal.
+ */
+
+/**
+ * @type {React.ForwardRefExoticComponent<StyleProps & React.ComponentPropsWithoutRef<'div'> & ModalProps & React.RefAttributes<HTMLDivElement>>}
+ */
+const Modal = forwardRef((inProps, ref) => {
+```
+
+## Reference Files
+
+Well-documented components to use as reference:
+- `packages/react/src/link/Link.js` - Simple component, no `Omit` needed
+- `packages/react/src/button/Button.js` - Basic component with size/variant
+- `packages/react/src/input/Input.js` - Uses `Omit<..., 'size'>` for prop conflict
+- `packages/react/src/checkbox/Checkbox.js` - Uses `Omit<..., 'onBlur' | 'onChange' | 'onClick' | 'onFocus'>`
+- `packages/react/src/accordion/Accordion.js` - Uses `Omit<..., 'children'>` for render prop
+- `packages/react/src/tabs/Tabs.js` - Uses `Omit<..., 'onChange'>` for custom handler
+
+## Best Practices
+
+1. **Follow existing patterns** - Match the style of nearby components
+2. **Test in IDE** - Verify that autocomplete works after adding types
+3. **Keep in sync** - Update types when props change
+4. **Document all public props** - Even if the description is just `-`
+
+## Common Issues and Solutions
+
+**Issue:** IDE doesn't recognize custom props
+**Solution:** Ensure the `@typedef` is directly above the `@type` annotation
+
+**Issue:** Native HTML props not showing
+**Solution:** Add `React.ComponentPropsWithoutRef<'element'>` to the type union
+
+**Issue:** Ref type mismatch
+**Solution:** Match `React.RefAttributes<HTMLElement>` to the actual DOM element type


### PR DESCRIPTION
## Summary

Add three Claude Code skill files to help Claude understand and follow tonic-ui project conventions:

- **tonic-ui-patterns** — Coding patterns extracted from repo analysis (commit conventions, monorepo structure, component architecture, testing patterns)
- **tonic-ui-types** — Guidelines for adding JSDoc type definitions to React components (forwardRef patterns, @typedef/@type annotations, type test files)
- **tonic-ui-pr** — PR description and changeset generation conventions (based on analysis of 885 commits and 721 PRs)

## Changes

- Add `.claude/skills/tonic-ui-patterns/SKILL.md`
- Add `.claude/skills/tonic-ui-types/SKILL.md`
- Add `.claude/skills/tonic-ui-pr/SKILL.md`