### PR TITLE
chore(deps): upgrade @testing-library/react from v14 to v15

### DIFF
--- a/packages/react-base/package.json
+++ b/packages/react-base/package.json
@@ -40,7 +40,7 @@
     "@rollup/plugin-babel": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@testing-library/jest-dom": "^6.0.0",
-    "@testing-library/react": "^14.0.0",
+    "@testing-library/react": "^15.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@trendmicro/babel-config": "^1.0.2",
     "cross-env": "^7.0.3",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -36,7 +36,7 @@
     "@rollup/plugin-babel": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@testing-library/jest-dom": "^6.0.0",
-    "@testing-library/react": "^14.0.0",
+    "@testing-library/react": "^15.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@trendmicro/babel-config": "^1.0.2",
     "cross-env": "^7.0.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -50,7 +50,7 @@
     "@rollup/plugin-babel": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@testing-library/jest-dom": "^6.0.0",
-    "@testing-library/react": "^14.0.0",
+    "@testing-library/react": "^15.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@trendmicro/babel-config": "^1.0.2",
     "cross-env": "^7.0.3",

--- a/packages/react/src/menu/__tests__/Menu.test.js
+++ b/packages/react/src/menu/__tests__/Menu.test.js
@@ -8,7 +8,7 @@ import {
   MenuList,
   MenuItem,
 } from '@tonic-ui/react/src';
-import React from 'react';
+import React, { act } from 'react';
 
 describe('Menu', () => {
   const TestComponent = (props) => {
@@ -60,6 +60,15 @@ describe('Menu', () => {
 
     // The menu should be in the document
     expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+    // Wait for focus and Collapse transition to stabilize
+    await waitFor(() => {
+      const firstMenuItem = screen.getByText('Menu item 1');
+      expect(firstMenuItem).toBeInTheDocument();
+    });
+
+    // Wait for the Collapse transition to complete (entering → entered)
+    await act(() => new Promise((resolve) => setTimeout(resolve, 300)));
 
     expect(container).toMatchSnapshot();
 

--- a/packages/react/src/menu/__tests__/Menu.test.js
+++ b/packages/react/src/menu/__tests__/Menu.test.js
@@ -68,7 +68,9 @@ describe('Menu', () => {
     });
 
     // Wait for the Collapse transition to complete (entering → entered)
-    await act(() => new Promise((resolve) => setTimeout(resolve, 300)));
+    await act(() => new Promise((resolve) => {
+      setTimeout(resolve, 300);
+    }));
 
     expect(container).toMatchSnapshot();
 

--- a/packages/react/src/menu/__tests__/Submenu.test.js
+++ b/packages/react/src/menu/__tests__/Submenu.test.js
@@ -68,7 +68,9 @@ describe('Submenu', () => {
 
       // Press ArrowRight to open submenu
       await user.keyboard('[ArrowRight]');
-      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
+      await act(() => new Promise(resolve => {
+        requestAnimationFrame(resolve);
+      }));
 
       // The submenu should be open
       await waitFor(() => {
@@ -102,7 +104,9 @@ describe('Submenu', () => {
       });
 
       await user.keyboard('[ArrowRight]');
-      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
+      await act(() => new Promise(resolve => {
+        requestAnimationFrame(resolve);
+      }));
 
       // The submenu should be open
       await waitFor(() => {
@@ -152,7 +156,9 @@ describe('Submenu', () => {
       });
 
       await user.keyboard('[ArrowRight]');
-      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
+      await act(() => new Promise(resolve => {
+        requestAnimationFrame(resolve);
+      }));
 
       // The submenu should be open
       await waitFor(() => {
@@ -198,7 +204,9 @@ describe('Submenu', () => {
 
       // Open the submenu
       await user.keyboard('[ArrowRight]');
-      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
+      await act(() => new Promise(resolve => {
+        requestAnimationFrame(resolve);
+      }));
 
       // Wait for submenu to open and first item to be focused
       await waitFor(() => {
@@ -244,7 +252,9 @@ describe('Submenu', () => {
       });
 
       await user.keyboard('[ArrowRight]');
-      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
+      await act(() => new Promise(resolve => {
+        requestAnimationFrame(resolve);
+      }));
 
       // Wait for submenu to open
       await waitFor(() => {
@@ -292,7 +302,9 @@ describe('Submenu', () => {
       });
 
       await user.keyboard('[ArrowRight]');
-      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
+      await act(() => new Promise(resolve => {
+        requestAnimationFrame(resolve);
+      }));
 
       await waitFor(() => {
         expect(submenuTrigger).toHaveAttribute('aria-expanded', 'true');
@@ -584,7 +596,9 @@ describe('Submenu', () => {
 
       // Press ArrowRight to open submenu
       await user.keyboard('[ArrowRight]');
-      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
+      await act(() => new Promise(resolve => {
+        requestAnimationFrame(resolve);
+      }));
 
       // The submenu should be open
       await waitFor(() => {

--- a/packages/react/src/menu/__tests__/Submenu.test.js
+++ b/packages/react/src/menu/__tests__/Submenu.test.js
@@ -14,7 +14,7 @@ import {
   Text,
 } from '@tonic-ui/react/src';
 import { AngleRightIcon } from '@tonic-ui/react-icons';
-import React from 'react';
+import React, { act } from 'react';
 
 describe('Submenu', () => {
   describe('Submenu keyboard navigation', () => {
@@ -68,6 +68,7 @@ describe('Submenu', () => {
 
       // Press ArrowRight to open submenu
       await user.keyboard('[ArrowRight]');
+      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
 
       // The submenu should be open
       await waitFor(() => {
@@ -101,6 +102,7 @@ describe('Submenu', () => {
       });
 
       await user.keyboard('[ArrowRight]');
+      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
 
       // The submenu should be open
       await waitFor(() => {
@@ -150,6 +152,7 @@ describe('Submenu', () => {
       });
 
       await user.keyboard('[ArrowRight]');
+      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
 
       // The submenu should be open
       await waitFor(() => {
@@ -195,6 +198,7 @@ describe('Submenu', () => {
 
       // Open the submenu
       await user.keyboard('[ArrowRight]');
+      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
 
       // Wait for submenu to open and first item to be focused
       await waitFor(() => {
@@ -240,6 +244,7 @@ describe('Submenu', () => {
       });
 
       await user.keyboard('[ArrowRight]');
+      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
 
       // Wait for submenu to open
       await waitFor(() => {
@@ -287,6 +292,7 @@ describe('Submenu', () => {
       });
 
       await user.keyboard('[ArrowRight]');
+      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
 
       await waitFor(() => {
         expect(submenuTrigger).toHaveAttribute('aria-expanded', 'true');
@@ -516,7 +522,9 @@ describe('Submenu', () => {
       await user.unhover(submenuList);
 
       // Advance timers to trigger the close timeout
-      jest.advanceTimersByTime(150);
+      await act(() => {
+        jest.advanceTimersByTime(150);
+      });
 
       // The submenu should be closed after the timeout
       await waitFor(() => {
@@ -576,6 +584,7 @@ describe('Submenu', () => {
 
       // Press ArrowRight to open submenu
       await user.keyboard('[ArrowRight]');
+      await act(() => new Promise(resolve => requestAnimationFrame(resolve)));
 
       // The submenu should be open
       await waitFor(() => {

--- a/packages/react/src/menu/__tests__/__snapshots__/Menu.test.js.snap
+++ b/packages/react/src/menu/__tests__/__snapshots__/Menu.test.js.snap
@@ -151,9 +151,8 @@ exports[`Menu should render correctly 1`] = `
 }
 
 .emotion-12 {
-  height: 0;
+  height: auto;
   opacity: 1;
-  overflow: hidden;
   -webkit-transition: height 133ms linear,opacity 133ms linear;
   transition: height 133ms linear,opacity 133ms linear;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5111,19 +5111,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^9.0.0":
-  version: 9.3.4
-  resolution: "@testing-library/dom@npm:9.3.4"
+"@testing-library/dom@npm:^10.0.0":
+  version: 10.4.1
+  resolution: "@testing-library/dom@npm:10.4.1"
   dependencies:
     "@babel/code-frame": ^7.10.4
     "@babel/runtime": ^7.12.5
     "@types/aria-query": ^5.0.1
-    aria-query: 5.1.3
-    chalk: ^4.1.0
+    aria-query: 5.3.0
     dom-accessibility-api: ^0.5.9
     lz-string: ^1.5.0
+    picocolors: 1.1.1
     pretty-format: ^27.0.2
-  checksum: dfd6fb0d6c7b4dd716ba3c47309bc9541b4a55772cb61758b4f396b3785efe2dbc75dc63423545c039078c7ffcc5e4b8c67c2db1b6af4799580466036f70026f
+  checksum: 3887fe95594b6d9467a804e2cc82e719c57f4d55d7d9459b72a949b3a8189db40375b89034637326d4be559f115abc6b6bcfcc6fec0591c4a4d4cdde96751a6c
   languageName: node
   linkType: hard
 
@@ -5160,17 +5160,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:^14.0.0":
-  version: 14.2.2
-  resolution: "@testing-library/react@npm:14.2.2"
+"@testing-library/react@npm:^15.0.0":
+  version: 15.0.7
+  resolution: "@testing-library/react@npm:15.0.7"
   dependencies:
     "@babel/runtime": ^7.12.5
-    "@testing-library/dom": ^9.0.0
+    "@testing-library/dom": ^10.0.0
     "@types/react-dom": ^18.0.0
   peerDependencies:
+    "@types/react": ^18.0.0
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: cb73df588592d9101429f057eaa6f320fc12524d5eb2acc8a16002c1ee2d9422a49e44841003bba42974c9ae1ced6b134f0d647826eca42ab8f19e4592971b16
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: eb33fd82eb811bb8612aa154e430a2c1c251d5ed45a477ef57fe20095db494ea7dcfa6b1e1e2bffb0c7ee10c86e408745d95a879be8ca8fbe301bb91e5f2e5db
   languageName: node
   linkType: hard
 
@@ -5305,7 +5309,7 @@ __metadata:
     "@rollup/plugin-babel": ^6.0.0
     "@rollup/plugin-node-resolve": ^15.0.0
     "@testing-library/jest-dom": ^6.0.0
-    "@testing-library/react": ^14.0.0
+    "@testing-library/react": ^15.0.0
     "@testing-library/user-event": ^14.4.3
     "@tonic-ui/styled-system": ^2.2.1
     "@trendmicro/babel-config": ^1.0.2
@@ -5437,7 +5441,7 @@ __metadata:
     "@rollup/plugin-babel": ^6.0.0
     "@rollup/plugin-node-resolve": ^15.0.0
     "@testing-library/jest-dom": ^6.0.0
-    "@testing-library/react": ^14.0.0
+    "@testing-library/react": ^15.0.0
     "@testing-library/user-event": ^14.4.3
     "@tonic-ui/utils": ^2.2.0
     "@trendmicro/babel-config": ^1.0.2
@@ -5511,7 +5515,7 @@ __metadata:
     "@rollup/plugin-babel": ^6.0.0
     "@rollup/plugin-node-resolve": ^15.0.0
     "@testing-library/jest-dom": ^6.0.0
-    "@testing-library/react": ^14.0.0
+    "@testing-library/react": ^15.0.0
     "@testing-library/user-event": ^14.4.3
     "@tonic-ui/react-base": ^2.0.4
     "@tonic-ui/react-hooks": ^2.2.1
@@ -6721,16 +6725,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:5.1.3":
-  version: 5.1.3
-  resolution: "aria-query@npm:5.1.3"
-  dependencies:
-    deep-equal: ^2.0.5
-  checksum: 929ff95f02857b650fb4cbcd2f41072eee2f46159a6605ea03bf63aa572e35ffdff43d69e815ddc462e16e07de8faba3978afc2813650b4448ee18c9895d982b
-  languageName: node
-  linkType: hard
-
-"aria-query@npm:^5.0.0, aria-query@npm:^5.3.0":
+"aria-query@npm:5.3.0, aria-query@npm:^5.0.0, aria-query@npm:^5.3.0":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
   dependencies:
@@ -6739,7 +6734,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-buffer-byte-length@npm:^1.0.0, array-buffer-byte-length@npm:^1.0.1":
+"array-buffer-byte-length@npm:^1.0.1":
   version: 1.0.1
   resolution: "array-buffer-byte-length@npm:1.0.1"
   dependencies:
@@ -8525,32 +8520,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-equal@npm:^2.0.5":
-  version: 2.2.3
-  resolution: "deep-equal@npm:2.2.3"
-  dependencies:
-    array-buffer-byte-length: ^1.0.0
-    call-bind: ^1.0.5
-    es-get-iterator: ^1.1.3
-    get-intrinsic: ^1.2.2
-    is-arguments: ^1.1.1
-    is-array-buffer: ^3.0.2
-    is-date-object: ^1.0.5
-    is-regex: ^1.1.4
-    is-shared-array-buffer: ^1.0.2
-    isarray: ^2.0.5
-    object-is: ^1.1.5
-    object-keys: ^1.1.1
-    object.assign: ^4.1.4
-    regexp.prototype.flags: ^1.5.1
-    side-channel: ^1.0.4
-    which-boxed-primitive: ^1.0.2
-    which-collection: ^1.0.1
-    which-typed-array: ^1.1.13
-  checksum: ee8852f23e4d20a5626c13b02f415ba443a1b30b4b3d39eaf366d59c4a85e6545d7ec917db44d476a85ae5a86064f7e5f7af7479f38f113995ba869f3a1ddc53
-  languageName: node
-  linkType: hard
-
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
@@ -9187,23 +9156,6 @@ __metadata:
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: ec1414527a0ccacd7f15f4a3bc66e215f04f595ba23ca75cdae0927af099b5ec865f9f4d33e9d7e86f512f252876ac77d4281a7871531a50678132429b1271b5
-  languageName: node
-  linkType: hard
-
-"es-get-iterator@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "es-get-iterator@npm:1.1.3"
-  dependencies:
-    call-bind: ^1.0.2
-    get-intrinsic: ^1.1.3
-    has-symbols: ^1.0.3
-    is-arguments: ^1.1.1
-    is-map: ^2.0.2
-    is-set: ^2.0.2
-    is-string: ^1.0.7
-    isarray: ^2.0.5
-    stop-iteration-iterator: ^1.0.0
-  checksum: 8fa118da42667a01a7c7529f8a8cca514feeff243feec1ce0bb73baaa3514560bd09d2b3438873cf8a5aaec5d52da248131de153b28e2638a061b6e4df13267d
   languageName: node
   linkType: hard
 
@@ -10537,7 +10489,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.1, get-intrinsic@npm:^1.2.2, get-intrinsic@npm:^1.2.3, get-intrinsic@npm:^1.2.4":
+"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.1, get-intrinsic@npm:^1.2.3, get-intrinsic@npm:^1.2.4":
   version: 1.2.4
   resolution: "get-intrinsic@npm:1.2.4"
   dependencies:
@@ -11568,7 +11520,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"internal-slot@npm:^1.0.4, internal-slot@npm:^1.0.7":
+"internal-slot@npm:^1.0.7":
   version: 1.0.7
   resolution: "internal-slot@npm:1.0.7"
   dependencies:
@@ -11620,17 +11572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-arguments@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "is-arguments@npm:1.1.1"
-  dependencies:
-    call-bind: ^1.0.2
-    has-tostringtag: ^1.0.0
-  checksum: 7f02700ec2171b691ef3e4d0e3e6c0ba408e8434368504bb593d0d7c891c0dbfda6d19d30808b904a6cb1929bca648c061ba438c39f296c2a8ca083229c49f27
-  languageName: node
-  linkType: hard
-
-"is-array-buffer@npm:^3.0.2, is-array-buffer@npm:^3.0.4":
+"is-array-buffer@npm:^3.0.4":
   version: 3.0.4
   resolution: "is-array-buffer@npm:3.0.4"
   dependencies:
@@ -11839,7 +11781,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-map@npm:^2.0.2, is-map@npm:^2.0.3":
+"is-map@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-map@npm:2.0.3"
   checksum: e6ce5f6380f32b141b3153e6ba9074892bbbbd655e92e7ba5ff195239777e767a976dcd4e22f864accaf30e53ebf961ab1995424aef91af68788f0591b7396cc
@@ -11967,7 +11909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-set@npm:^2.0.2, is-set@npm:^2.0.3":
+"is-set@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-set@npm:2.0.3"
   checksum: 36e3f8c44bdbe9496c9689762cc4110f6a6a12b767c5d74c0398176aa2678d4467e3bf07595556f2dba897751bde1422480212b97d973c7b08a343100b0c0dfe
@@ -15924,16 +15866,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-is@npm:^1.1.5":
-  version: 1.1.6
-  resolution: "object-is@npm:1.1.6"
-  dependencies:
-    call-bind: ^1.0.7
-    define-properties: ^1.2.1
-  checksum: 3ea22759967e6f2380a2cbbd0f737b42dc9ddb2dfefdb159a1b927fea57335e1b058b564bfa94417db8ad58cddab33621a035de6f5e5ad56d89f2dd03e66c6a1
-  languageName: node
-  linkType: hard
-
 "object-keys@npm:^1.1.1":
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
@@ -16535,17 +16467,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picocolors@npm:1.1.1, picocolors@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0":
   version: 1.0.0
   resolution: "picocolors@npm:1.0.0"
   checksum: a2e8092dd86c8396bdba9f2b5481032848525b3dc295ce9b57896f931e63fc16f79805144321f72976383fc249584672a75cc18d6777c6b757603f372f745981
-  languageName: node
-  linkType: hard
-
-"picocolors@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "picocolors@npm:1.1.1"
-  checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
   languageName: node
   linkType: hard
 
@@ -17462,7 +17394,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp.prototype.flags@npm:^1.5.1, regexp.prototype.flags@npm:^1.5.2":
+"regexp.prototype.flags@npm:^1.5.2":
   version: 1.5.2
   resolution: "regexp.prototype.flags@npm:1.5.2"
   dependencies:
@@ -18652,15 +18584,6 @@ __metadata:
   version: 2.0.2
   resolution: "statuses@npm:2.0.2"
   checksum: 6927feb50c2a75b2a4caab2c565491f7a93ad3d8dbad7b1398d52359e9243a20e2ebe35e33726dee945125ef7a515e9097d8a1b910ba2bbd818265a2f6c39879
-  languageName: node
-  linkType: hard
-
-"stop-iteration-iterator@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "stop-iteration-iterator@npm:1.0.0"
-  dependencies:
-    internal-slot: ^1.0.4
-  checksum: d04173690b2efa40e24ab70e5e51a3ff31d56d699550cfad084104ab3381390daccb36652b25755e420245f3b0737de66c1879eaa2a8d4fc0a78f9bf892fcb42
   languageName: node
   linkType: hard
 
@@ -20239,7 +20162,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-typed-array@npm:^1.1.13, which-typed-array@npm:^1.1.14, which-typed-array@npm:^1.1.15, which-typed-array@npm:^1.1.9":
+"which-typed-array@npm:^1.1.14, which-typed-array@npm:^1.1.15, which-typed-array@npm:^1.1.9":
   version: 1.1.15
   resolution: "which-typed-array@npm:1.1.15"
   dependencies:


### PR DESCRIPTION
## Summary

- Upgrades `@testing-library/react` from `^14.0.0` to `^15.0.0` in `packages/react`, `packages/react-base`, and `packages/react-hooks`
- v15 imports `act` from `react` directly instead of the deprecated `react-dom/test-utils`, eliminating the deprecation warning when running tests
- Fixes `jest.advanceTimersByTime` in `Submenu.test.js` by wrapping it in `act()` to properly flush React state updates triggered by fake timers
- Adds transition stabilization wait in `Menu.test.js` before snapshotting, and updates the snapshot to reflect the completed Collapse transition state (`height: auto`)

## Test plan

- [ ] Run `yarn test` in `packages/react` — all Menu and Submenu tests pass with no `act(...)` warnings
- [ ] Run `yarn test` in `packages/react-base` and `packages/react-hooks` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)