### PR TITLE
feat(react): replace `getMemoizedState` with `useShallowMemo` hook

### DIFF
--- a/.changeset/tonic-ui-pr-1120.md
+++ b/.changeset/tonic-ui-pr-1120.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": patch
+---
+
+feat(react): replace `getMemoizedState` with `useShallowMemo` hook

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -15,9 +15,18 @@ module.exports = {
   ],
   rules: {
     'camelcase': ['error', { 'allow': ['^DEPRECATED_'] }],
+    'max-lines-per-function': ['warn', { 'max': 500, 'skipComments': true }],
     'react/jsx-no-bind': 2,
     'react/prop-types': 0,
     'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
     'react-hooks/exhaustive-deps': 'error', // Checks effect dependencies
   },
+  'overrides': [
+    {
+      'files': ['**/__tests__/**/*.{js,ts,jsx,tsx}', '**/*.test.{js,ts,jsx,tsx}'],
+      'rules': {
+        'max-lines-per-function': 'off',
+      }
+    }
+  ]
 };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,7 @@
     "@tonic-ui/utils": "^2.2.0",
     "date-fns": "2.x",
     "ensure-type": "^1.5.1",
-    "micro-memoize": "4.x",
+    "micro-memoize": "5.x",
     "react-focus-lock": "2.x",
     "react-is": "^16.14.0 || ^17 || ^18 || ^19",
     "react-transition-group": "4.x"

--- a/packages/react/src/accordion/Accordion.js
+++ b/packages/react/src/accordion/Accordion.js
@@ -1,19 +1,20 @@
 import { runIfFn } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { AccordionContext } from './context';
 import { useAccordionStyle } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const Accordion = forwardRef((inProps, ref) => {
   const {
     children,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Accordion' });
-  const context = getMemoizedState({
+  const shallowMemo = useShallowMemo();
+
+  const context = shallowMemo({
     // TODO
   });
   const styleProps = useAccordionStyle();

--- a/packages/react/src/accordion/Accordion.js
+++ b/packages/react/src/accordion/Accordion.js
@@ -6,7 +6,6 @@ import useShallowMemo from '../utils/useShallowMemo';
 import { AccordionContext } from './context';
 import { useAccordionStyle } from './styles';
 
-
 const Accordion = forwardRef((inProps, ref) => {
   const {
     children,

--- a/packages/react/src/accordion/AccordionItem.js
+++ b/packages/react/src/accordion/AccordionItem.js
@@ -1,15 +1,14 @@
 import { useId } from '@tonic-ui/react-hooks';
 import { runIfFn } from '@tonic-ui/utils';
 import { ensureFunction } from 'ensure-type';
-import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useState } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import config from '../shared/config';
 import { AccordionItemContext } from './context';
 import useAccordion from './useAccordion';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const AccordionItem = forwardRef((inProps, ref) => {
   const {
@@ -20,6 +19,7 @@ const AccordionItem = forwardRef((inProps, ref) => {
     onToggle: onToggleProp,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'AccordionItem' });
+  const shallowMemo = useShallowMemo();
   const accordionContext = useAccordion();
   const defaultId = useId();
   const accordionToggleId = `${config.name}:AccordionToggle-${defaultId}`;
@@ -44,7 +44,7 @@ const AccordionItem = forwardRef((inProps, ref) => {
     });
   }, [isExpanded, isExpandedProp, onToggleProp]);
 
-  const context = getMemoizedState({
+  const context = shallowMemo({
     accordionToggleId,
     accordionContentId,
     disabled,

--- a/packages/react/src/accordion/AccordionItem.js
+++ b/packages/react/src/accordion/AccordionItem.js
@@ -9,7 +9,6 @@ import config from '../shared/config';
 import { AccordionItemContext } from './context';
 import useAccordion from './useAccordion';
 
-
 const AccordionItem = forwardRef((inProps, ref) => {
   const {
     children,

--- a/packages/react/src/alert/Alert.js
+++ b/packages/react/src/alert/Alert.js
@@ -15,7 +15,6 @@ import {
   useAlertStyle,
 } from './styles';
 
-
 const Alert = forwardRef((inProps, ref) => {
   const {
     isClosable = false,

--- a/packages/react/src/alert/Alert.js
+++ b/packages/react/src/alert/Alert.js
@@ -1,8 +1,8 @@
 import { runIfFn } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import AlertCloseButton from './AlertCloseButton';
 import AlertIcon from './AlertIcon';
 import AlertMessage from './AlertMessage';
@@ -15,7 +15,6 @@ import {
   useAlertStyle,
 } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const Alert = forwardRef((inProps, ref) => {
   const {
@@ -27,7 +26,9 @@ const Alert = forwardRef((inProps, ref) => {
     children,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Alert' });
-  const context = getMemoizedState({
+  const shallowMemo = useShallowMemo();
+
+  const context = shallowMemo({
     icon,
     isClosable,
     onClose,

--- a/packages/react/src/button/ButtonGroup.js
+++ b/packages/react/src/button/ButtonGroup.js
@@ -6,7 +6,6 @@ import useShallowMemo from '../utils/useShallowMemo';
 import { ButtonGroupContext } from './context';
 import { useButtonGroupStyle } from './styles';
 
-
 const defaultOrientation = 'horizontal';
 const defaultSize = 'md';
 const defaultVariant = 'default';

--- a/packages/react/src/button/ButtonGroup.js
+++ b/packages/react/src/button/ButtonGroup.js
@@ -1,12 +1,11 @@
 import { runIfFn } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { ButtonGroupContext } from './context';
 import { useButtonGroupStyle } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const defaultOrientation = 'horizontal';
 const defaultSize = 'md';
@@ -21,8 +20,10 @@ const ButtonGroup = forwardRef((inProps, ref) => {
     variant = defaultVariant,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'ButtonGroup' });
+  const shallowMemo = useShallowMemo();
   const styleProps = useButtonGroupStyle({ orientation });
-  const context = getMemoizedState({
+
+  const context = shallowMemo({
     disabled,
     orientation,
     size,

--- a/packages/react/src/checkbox/CheckboxGroup.js
+++ b/packages/react/src/checkbox/CheckboxGroup.js
@@ -1,13 +1,12 @@
 import { useId } from '@tonic-ui/react-hooks';
 import { runIfFn } from '@tonic-ui/utils';
 import { ensureArray } from 'ensure-type';
-import memoize from 'micro-memoize';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import config from '../shared/config';
 import { CheckboxGroupContext } from './context';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const CheckboxGroup = (inProps) => {
   const {
@@ -20,6 +19,7 @@ const CheckboxGroup = (inProps) => {
     value: valueProp,
     variantColor,
   } = useDefaultProps({ props: inProps, name: 'CheckboxGroup' });
+  const shallowMemo = useShallowMemo();
   const defaultId = useId();
   const name = nameProp ?? `${config.name}:CheckboxGroup-${defaultId}`;
 
@@ -50,7 +50,7 @@ const CheckboxGroup = (inProps) => {
     }
   }, [onChangeProp, state.value, valueProp]);
 
-  const context = getMemoizedState({
+  const context = shallowMemo({
     disabled,
     name,
     onChange,

--- a/packages/react/src/checkbox/CheckboxGroup.js
+++ b/packages/react/src/checkbox/CheckboxGroup.js
@@ -7,7 +7,6 @@ import useShallowMemo from '../utils/useShallowMemo';
 import config from '../shared/config';
 import { CheckboxGroupContext } from './context';
 
-
 const CheckboxGroup = (inProps) => {
   const {
     children,

--- a/packages/react/src/color-mode/ColorModeProvider.js
+++ b/packages/react/src/color-mode/ColorModeProvider.js
@@ -1,7 +1,7 @@
 import { canUseDOM, noop } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { useCallback, useEffect, useReducer } from 'react';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { ColorModeContext } from './context';
 import { getColorScheme, colorSchemeQuery } from './utils';
 
@@ -9,7 +9,6 @@ const ensureColorMode = (colorMode) => {
   return colorMode === 'dark' ? 'dark' : 'light';
 };
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const colorModeReducer = (state, nextValue) => {
   if (nextValue === undefined) {
@@ -27,6 +26,7 @@ const ColorModeProvider = (inProps) => {
     onChange: onChangeProp,
     useSystemColorMode,
   } = useDefaultProps({ props: inProps, name: 'ColorModeProvider' });
+  const shallowMemo = useShallowMemo();
   const defaultColorMode = (defaultValueProp === 'dark') ? 'dark' : 'light';
   const [colorMode, setColorMode] = useReducer(colorModeReducer, ensureColorMode(valueProp ?? defaultColorMode));
 
@@ -72,7 +72,7 @@ const ColorModeProvider = (inProps) => {
     };
   }, [defaultValueProp, valueProp, useSystemColorMode, defaultColorMode, onChange]);
 
-  const colorModeState = getMemoizedState({
+  const colorModeState = shallowMemo({
     colorMode,
     onChange,
   });

--- a/packages/react/src/color-mode/ColorModeProvider.js
+++ b/packages/react/src/color-mode/ColorModeProvider.js
@@ -9,7 +9,6 @@ const ensureColorMode = (colorMode) => {
   return colorMode === 'dark' ? 'dark' : 'light';
 };
 
-
 const colorModeReducer = (state, nextValue) => {
   if (nextValue === undefined) {
     const colorMode = state;

--- a/packages/react/src/color-style/ColorStyleProvider.js
+++ b/packages/react/src/color-style/ColorStyleProvider.js
@@ -1,7 +1,7 @@
 import { ensurePlainObject } from 'ensure-type';
-import memoize from 'micro-memoize';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import defaultColorStyle from './color-style';
 import { ColorStyleContext } from './context';
 
@@ -9,7 +9,6 @@ const ensureColorStyle = (colorStyle) => {
   return ensurePlainObject(colorStyle);
 };
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const ColorStyleProvider = (inProps) => {
   const {
@@ -18,6 +17,7 @@ const ColorStyleProvider = (inProps) => {
     value: valueProp,
     onChange: onChangeProp,
   } = useDefaultProps({ props: inProps, name: 'ColorStyleProvider' });
+  const shallowMemo = useShallowMemo();
   const [colorStyle, setColorStyle] = useState(ensureColorStyle(valueProp ?? (defaultValueProp ?? defaultColorStyle)));
 
   useEffect(() => {
@@ -37,7 +37,7 @@ const ColorStyleProvider = (inProps) => {
     }
   }, [valueProp, onChangeProp]);
 
-  const colorStyleState = getMemoizedState({
+  const colorStyleState = shallowMemo({
     colorStyle,
     onChange,
   });

--- a/packages/react/src/color-style/ColorStyleProvider.js
+++ b/packages/react/src/color-style/ColorStyleProvider.js
@@ -9,7 +9,6 @@ const ensureColorStyle = (colorStyle) => {
   return ensurePlainObject(colorStyle);
 };
 
-
 const ColorStyleProvider = (inProps) => {
   const {
     children,

--- a/packages/react/src/date-pickers/DateCalendar/DateCalendar.js
+++ b/packages/react/src/date-pickers/DateCalendar/DateCalendar.js
@@ -21,17 +21,16 @@ import startOfDay from 'date-fns/startOfDay';
 import startOfMonth from 'date-fns/startOfMonth';
 import startOfWeek from 'date-fns/startOfWeek';
 import subMonths from 'date-fns/subMonths';
-import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../../box';
 import { useDefaultProps } from '../../default-props';
+import useShallowMemo from '../../utils/useShallowMemo';
 import { validateDate } from '../validation';
 import { DateCalendarProvider } from './context';
 import MonthDate from './MonthDate';
 import YearMonthPicker from './YearMonthPicker';
 import { useDateCalendarStyle } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const mapValueToDate = (value) => {
   if (isNullOrUndefined(value)) {
@@ -68,6 +67,7 @@ const DateCalendar = forwardRef((inProps, ref) => {
     value: valueProp,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'DateCalendar' });
+  const shallowMemo = useShallowMemo();
 
   { // deprecation warning
     const prefix = `${DateCalendar.displayName}:`;
@@ -448,7 +448,7 @@ const DateCalendar = forwardRef((inProps, ref) => {
     }
   }, [date, firstDayOfWeek]);
 
-  const context = getMemoizedState({
+  const context = shallowMemo({
     activeDate,
     date,
     firstDayOfWeek,

--- a/packages/react/src/date-pickers/DateCalendar/DateCalendar.js
+++ b/packages/react/src/date-pickers/DateCalendar/DateCalendar.js
@@ -31,7 +31,6 @@ import MonthDate from './MonthDate';
 import YearMonthPicker from './YearMonthPicker';
 import { useDateCalendarStyle } from './styles';
 
-
 const mapValueToDate = (value) => {
   if (isNullOrUndefined(value)) {
     return null;

--- a/packages/react/src/date-pickers/DatePicker/DatePicker.js
+++ b/packages/react/src/date-pickers/DatePicker/DatePicker.js
@@ -6,10 +6,10 @@ import isDate from 'date-fns/isDate';
 import isValid from 'date-fns/isValid';
 import parse from 'date-fns/parse';
 import startOfDay from 'date-fns/startOfDay';
-import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../../box';
 import { useDefaultProps } from '../../default-props';
+import useShallowMemo from '../../utils/useShallowMemo';
 import config from '../../shared/config';
 import DateCalendar from '../DateCalendar';
 import { validateDate } from '../validation';
@@ -18,7 +18,6 @@ import DatePickerToggle from './DatePickerToggle';
 import { DatePickerProvider } from './context';
 import { useDatePickerStyle } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 /**
  * Convert a value to a Date object in accordance with the format string.
@@ -84,6 +83,7 @@ const DatePicker = forwardRef((inProps, ref) => {
     value: valueProp,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'DatePicker' });
+  const shallowMemo = useShallowMemo();
   const datePickerContentRef = useRef(null);
   const datePickerToggleRef = useRef(null);
   const initialValue = useConst(() => {
@@ -224,7 +224,8 @@ const DatePicker = forwardRef((inProps, ref) => {
   const defaultId = useId();
   const datePickerContentId = `${config.name}:DatePickerContent-${defaultId}`;
   const datePickerToggleId = `${config.name}:DatePickerToggle-${defaultId}`;
-  const context = getMemoizedState({
+
+  const context = shallowMemo({
     isOpen,
     offset,
     onClose,

--- a/packages/react/src/date-pickers/DatePicker/DatePicker.js
+++ b/packages/react/src/date-pickers/DatePicker/DatePicker.js
@@ -18,7 +18,6 @@ import DatePickerToggle from './DatePickerToggle';
 import { DatePickerProvider } from './context';
 import { useDatePickerStyle } from './styles';
 
-
 /**
  * Convert a value to a Date object in accordance with the format string.
  */

--- a/packages/react/src/drawer/Drawer.js
+++ b/packages/react/src/drawer/Drawer.js
@@ -1,15 +1,14 @@
 import { useOnceWhen } from '@tonic-ui/react-hooks';
 import { getAllFocusable, runIfFn, warnDeprecatedProps } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import FocusLock from 'react-focus-lock/dist/cjs';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { Portal } from '../portal';
 import { AnimatePresence } from '../utils/animate-presence';
 import DrawerContainer from './DrawerContainer';
 import { DrawerContext } from './context';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const defaultPlacement = 'right';
 const defaultSize = 'auto';
@@ -36,6 +35,7 @@ const Drawer = forwardRef((inProps, ref) => {
     size = defaultSize,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Drawer' });
+  const shallowMemo = useShallowMemo();
 
   { // deprecation warning
     const prefix = `${Drawer.displayName}:`;
@@ -57,7 +57,8 @@ const Drawer = forwardRef((inProps, ref) => {
   const [isMounted, setIsMounted] = useState(isOpen);
   const containerRef = useRef();
   const contentRef = useRef(null);
-  const context = getMemoizedState({
+
+  const context = shallowMemo({
     autoFocus,
     backdrop,
     closeOnEsc,

--- a/packages/react/src/drawer/Drawer.js
+++ b/packages/react/src/drawer/Drawer.js
@@ -9,7 +9,6 @@ import { AnimatePresence } from '../utils/animate-presence';
 import DrawerContainer from './DrawerContainer';
 import { DrawerContext } from './context';
 
-
 const defaultPlacement = 'right';
 const defaultSize = 'auto';
 

--- a/packages/react/src/form-control/FormCharacterCount.js
+++ b/packages/react/src/form-control/FormCharacterCount.js
@@ -19,7 +19,12 @@ const FormCharacterCount = forwardRef(
     const styleProps = useFormCharacterCountStyle();
 
     return (
-      <Flex ref={ref} id={id} {...styleProps} {...rest}>
+      <Flex
+        ref={ref}
+        id={id}
+        {...styleProps}
+        {...rest}
+      >
         <Text color={lengthColor}>{count}</Text>
         <Text color={maxColor}>/{maxCount}</Text>
       </Flex>

--- a/packages/react/src/form-control/FormErrorMessage.js
+++ b/packages/react/src/form-control/FormErrorMessage.js
@@ -29,13 +29,19 @@ const FormErrorMessage = forwardRef(({ errors = [], ...rest }, ref) => {
   const isSingleError = normalizedErrors.length === 1;
 
   return (
-    <Text ref={ref} id={id} role="alert" {...styleProps} {...rest}>
+    <Text
+      ref={ref}
+      id={id}
+      role="alert"
+      {...styleProps}
+      {...rest}
+    >
       {isSingleError ? (
         normalizedErrors[0]
       ) : (
         <Box as="ul" {...listStyleProps}>
           {normalizedErrors.map((error, index) => (
-            <Box as="li" key={index}>
+            <Box as="li" key={`error_${index}`}>
               {error}
             </Box>
           ))}

--- a/packages/react/src/form-control/FormHelperText.js
+++ b/packages/react/src/form-control/FormHelperText.js
@@ -11,7 +11,13 @@ const FormHelperText = forwardRef(({ children, ...rest }, ref) => {
   const styleProps = useFormHelperTextStyle();
 
   return (
-    <Text ref={ref} id={id} role="note" {...styleProps} {...rest}>
+    <Text
+      ref={ref}
+      id={id}
+      role="note"
+      {...styleProps}
+      {...rest}
+    >
       {children}
     </Text>
   );

--- a/packages/react/src/input/InputGroup.js
+++ b/packages/react/src/input/InputGroup.js
@@ -6,7 +6,6 @@ import useShallowMemo from '../utils/useShallowMemo';
 import { InputGroupContext } from './context';
 import { useInputGroupStyle } from './styles';
 
-
 const InputGroup = forwardRef((inProps, ref) => {
   const {
     children,

--- a/packages/react/src/input/InputGroup.js
+++ b/packages/react/src/input/InputGroup.js
@@ -1,12 +1,11 @@
 import { runIfFn } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { InputGroupContext } from './context';
 import { useInputGroupStyle } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const InputGroup = forwardRef((inProps, ref) => {
   const {
@@ -15,7 +14,9 @@ const InputGroup = forwardRef((inProps, ref) => {
     variant = 'outline',
     ...rest
   } = useDefaultProps({ props: inProps, name: 'InputGroup' });
-  const context = getMemoizedState({ size, variant });
+  const shallowMemo = useShallowMemo();
+
+  const context = shallowMemo({ size, variant });
   const styleProps = useInputGroupStyle();
 
   return (

--- a/packages/react/src/menu/Menu.js
+++ b/packages/react/src/menu/Menu.js
@@ -9,7 +9,6 @@ import config from '../shared/config';
 import { MenuContext } from './context';
 import { useMenuStyle } from './styles';
 
-
 const mapPlacementToDirection = (placement) => {
   const p0 = ensureString(placement).split('-')[0];
   const direction = {

--- a/packages/react/src/menu/Menu.js
+++ b/packages/react/src/menu/Menu.js
@@ -1,15 +1,14 @@
 import { useId, usePrevious } from '@tonic-ui/react-hooks';
 import { getAllFocusable, runIfFn } from '@tonic-ui/utils';
 import { ensureString } from 'ensure-type';
-import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import config from '../shared/config';
 import { MenuContext } from './context';
 import { useMenuStyle } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const mapPlacementToDirection = (placement) => {
   const p0 = ensureString(placement).split('-')[0];
@@ -38,6 +37,7 @@ const Menu = forwardRef((inProps, ref) => {
     returnFocusOnClose = true,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Menu' });
+  const shallowMemo = useShallowMemo();
   const menuContentRef = useRef(null);
   const menuToggleRef = useRef(null);
   // The `submenuContentRefs` is used to store refs of submenu contents for detecting clicks outside the menu and its submenus
@@ -181,7 +181,8 @@ const Menu = forwardRef((inProps, ref) => {
   const menuId = `${config.name}:Menu-${defaultId}`;
   const menuToggleId = `${config.name}:MenuToggle-${defaultId}`;
   const direction = mapPlacementToDirection(placement);
-  const context = getMemoizedState({
+
+  const context = shallowMemo({
     autoSelect,
     closeOnBlur,
     closeOnSelect,

--- a/packages/react/src/menu/Submenu.js
+++ b/packages/react/src/menu/Submenu.js
@@ -8,7 +8,6 @@ import config from '../shared/config';
 import { SubmenuContext } from './context';
 import { useSubmenuStyle } from './styles';
 
-
 const Submenu = forwardRef((inProps, ref) => {
   const {
     children,

--- a/packages/react/src/menu/Submenu.js
+++ b/packages/react/src/menu/Submenu.js
@@ -1,14 +1,13 @@
 import { useId } from '@tonic-ui/react-hooks';
 import { getAllFocusable, runIfFn } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import config from '../shared/config';
 import { SubmenuContext } from './context';
 import { useSubmenuStyle } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const Submenu = forwardRef((inProps, ref) => {
   const {
@@ -21,6 +20,7 @@ const Submenu = forwardRef((inProps, ref) => {
     placement = 'right-start', // One of: 'right-start', 'right-end', 'left-start', 'left-end'
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Submenu' });
+  const shallowMemo = useShallowMemo();
   const submenuContentRef = useRef(null);
   const submenuTriggerRef = useRef(null);
   const isHoveringSubmenuContentRef = useRef();
@@ -132,7 +132,7 @@ const Submenu = forwardRef((inProps, ref) => {
   const submenuTriggerId = `${config.name}:SubmenuTrigger-${defaultId}`;
   const styleProps = useSubmenuStyle();
 
-  const context = getMemoizedState({
+  const context = shallowMemo({
     focusOnFirstItem,
     focusOnLastItem,
     focusOnNextItem,

--- a/packages/react/src/modal/Modal.js
+++ b/packages/react/src/modal/Modal.js
@@ -1,15 +1,14 @@
 import { useOnceWhen } from '@tonic-ui/react-hooks';
 import { getAllFocusable, runIfFn, warnDeprecatedProps } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import FocusLock from 'react-focus-lock/dist/cjs';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { Portal } from '../portal';
 import { AnimatePresence } from '../utils/animate-presence';
 import ModalContainer from './ModalContainer';
 import { ModalContext } from './context';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const defaultScrollBehavior = 'inside';
 const defaultSize = 'auto';
@@ -35,6 +34,7 @@ const Modal = forwardRef((inProps, ref) => {
     size = defaultSize,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Modal' });
+  const shallowMemo = useShallowMemo();
 
   { // deprecation warning
     const prefix = `${Modal.displayName}:`;
@@ -56,7 +56,8 @@ const Modal = forwardRef((inProps, ref) => {
   const [isMounted, setIsMounted] = useState(isOpen);
   const containerRef = useRef();
   const contentRef = useRef();
-  const context = getMemoizedState({
+
+  const context = shallowMemo({
     autoFocus,
     closeOnEsc,
     closeOnInteractOutside,

--- a/packages/react/src/modal/Modal.js
+++ b/packages/react/src/modal/Modal.js
@@ -9,7 +9,6 @@ import { AnimatePresence } from '../utils/animate-presence';
 import ModalContainer from './ModalContainer';
 import { ModalContext } from './context';
 
-
 const defaultScrollBehavior = 'inside';
 const defaultSize = 'auto';
 

--- a/packages/react/src/popover/Popover.js
+++ b/packages/react/src/popover/Popover.js
@@ -1,12 +1,11 @@
 import { useId, useOnceWhen, usePrevious } from '@tonic-ui/react-hooks';
 import { runIfFn } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import config from '../shared/config';
 import { PopoverContext } from './context';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const defaultPlacement = 'bottom';
 
@@ -31,6 +30,7 @@ const Popover = (inProps) => {
     returnFocusOnClose = true,
     trigger = 'click',
   } = useDefaultProps({ props: inProps, name: 'Popover' });
+  const shallowMemo = useShallowMemo();
 
   { // validation warnings
     const prefix = `${Popover.displayName}:`;
@@ -167,7 +167,8 @@ const Popover = (inProps) => {
   const defaultId = useId();
   const popoverId = `${config.name}:Popover-${defaultId}`;
   const popoverTriggerId = `${config.name}:PopoverTrigger-${defaultId}`;
-  const context = getMemoizedState({
+
+  const context = shallowMemo({
     closeOnBlur,
     closeOnEsc,
     disabled,

--- a/packages/react/src/popover/Popover.js
+++ b/packages/react/src/popover/Popover.js
@@ -6,7 +6,6 @@ import useShallowMemo from '../utils/useShallowMemo';
 import config from '../shared/config';
 import { PopoverContext } from './context';
 
-
 const defaultPlacement = 'bottom';
 
 const Popover = (inProps) => {

--- a/packages/react/src/portal/PortalManager.js
+++ b/packages/react/src/portal/PortalManager.js
@@ -1,6 +1,6 @@
-import memoize from 'micro-memoize';
 import React, { useCallback, useState } from 'react';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import Portal from './Portal';
 import { PortalManagerContext } from './context';
 
@@ -12,13 +12,13 @@ const uniqueId = (() => {
   };
 })();
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const PortalManager = (inProps) => {
   const {
     children,
     containerRef: containerRefProp,
   } = useDefaultProps({ props: inProps, name: 'PortalManager' });
+  const shallowMemo = useShallowMemo();
   const [portals, setPortals] = useState([]);
   const add = useCallback((render, options) => {
     const id = options?.id ?? uniqueId();
@@ -33,7 +33,8 @@ const PortalManager = (inProps) => {
   const remove = useCallback(id => {
     setPortals(portals => portals.filter(portal => portal.id !== id));
   }, []);
-  const context = getMemoizedState({ add, remove });
+
+  const context = shallowMemo({ add, remove });
 
   return (
     <PortalManagerContext.Provider value={context}>

--- a/packages/react/src/portal/PortalManager.js
+++ b/packages/react/src/portal/PortalManager.js
@@ -12,7 +12,6 @@ const uniqueId = (() => {
   };
 })();
 
-
 const PortalManager = (inProps) => {
   const {
     children,

--- a/packages/react/src/radio/RadioGroup.js
+++ b/packages/react/src/radio/RadioGroup.js
@@ -6,7 +6,6 @@ import useShallowMemo from '../utils/useShallowMemo';
 import config from '../shared/config';
 import { RadioGroupContext } from './context';
 
-
 const RadioGroup = (inProps) => {
   const {
     children,

--- a/packages/react/src/radio/RadioGroup.js
+++ b/packages/react/src/radio/RadioGroup.js
@@ -1,12 +1,11 @@
 import { useId } from '@tonic-ui/react-hooks';
 import { runIfFn } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import config from '../shared/config';
 import { RadioGroupContext } from './context';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const RadioGroup = (inProps) => {
   const {
@@ -19,6 +18,7 @@ const RadioGroup = (inProps) => {
     value: valueProp,
     variantColor,
   } = useDefaultProps({ props: inProps, name: 'RadioGroup' });
+  const shallowMemo = useShallowMemo();
   const defaultId = useId();
   const name = nameProp ?? `${config.name}:RadioGroup-${defaultId}`;
 
@@ -47,7 +47,7 @@ const RadioGroup = (inProps) => {
     }
   }, [onChangeProp, valueProp]);
 
-  const context = getMemoizedState({
+  const context = shallowMemo({
     disabled,
     name,
     onChange,

--- a/packages/react/src/table/Table.js
+++ b/packages/react/src/table/Table.js
@@ -6,7 +6,6 @@ import { LAYOUT_FLEXBOX, LAYOUT_TABLE, SIZE_MEDIUM, VARIANT_DEFAULT } from './co
 import { TableContext } from './context';
 import { useTableStyle } from './styles';
 
-
 const Table = forwardRef((inProps, ref) => {
   const {
     layout = LAYOUT_FLEXBOX,

--- a/packages/react/src/table/Table.js
+++ b/packages/react/src/table/Table.js
@@ -14,9 +14,9 @@ const Table = forwardRef((inProps, ref) => {
     variant = VARIANT_DEFAULT,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Table' });
+  const shallowMemo = useShallowMemo();
   const as = layout === LAYOUT_TABLE ? 'table' : undefined;
   const role = roleProp ?? 'table';
-  const shallowMemo = useShallowMemo();
 
   const context = shallowMemo({
     layout,

--- a/packages/react/src/table/Table.js
+++ b/packages/react/src/table/Table.js
@@ -1,12 +1,11 @@
-import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { LAYOUT_FLEXBOX, LAYOUT_TABLE, SIZE_MEDIUM, VARIANT_DEFAULT } from './constants';
 import { TableContext } from './context';
 import { useTableStyle } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const Table = forwardRef((inProps, ref) => {
   const {
@@ -18,7 +17,9 @@ const Table = forwardRef((inProps, ref) => {
   } = useDefaultProps({ props: inProps, name: 'Table' });
   const as = layout === LAYOUT_TABLE ? 'table' : undefined;
   const role = roleProp ?? 'table';
-  const context = getMemoizedState({
+  const shallowMemo = useShallowMemo();
+
+  const context = shallowMemo({
     layout,
     size,
     variant,

--- a/packages/react/src/table/TableBody.js
+++ b/packages/react/src/table/TableBody.js
@@ -1,13 +1,12 @@
-import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { GROUP_VARIANT_BODY, LAYOUT_TABLE } from './constants';
 import { TableGroupContext } from './context';
 import { useTableBodyStyle } from './styles';
 import useTable from './useTable';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const TableBody = forwardRef((inProps, ref) => {
   const {
@@ -18,7 +17,9 @@ const TableBody = forwardRef((inProps, ref) => {
   const as = layout === LAYOUT_TABLE ? 'tbody' : undefined;
   const role = roleProp ?? 'rowgroup';
   const groupVariant = GROUP_VARIANT_BODY;
-  const context = getMemoizedState({
+  const shallowMemo = useShallowMemo();
+
+  const context = shallowMemo({
     groupVariant,
   });
   const styleProps = useTableBodyStyle({ layout });

--- a/packages/react/src/table/TableBody.js
+++ b/packages/react/src/table/TableBody.js
@@ -12,11 +12,11 @@ const TableBody = forwardRef((inProps, ref) => {
     role: roleProp,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'TableBody' });
+  const shallowMemo = useShallowMemo();
   const { layout } = useTable();
   const as = layout === LAYOUT_TABLE ? 'tbody' : undefined;
   const role = roleProp ?? 'rowgroup';
   const groupVariant = GROUP_VARIANT_BODY;
-  const shallowMemo = useShallowMemo();
 
   const context = shallowMemo({
     groupVariant,

--- a/packages/react/src/table/TableBody.js
+++ b/packages/react/src/table/TableBody.js
@@ -7,7 +7,6 @@ import { TableGroupContext } from './context';
 import { useTableBodyStyle } from './styles';
 import useTable from './useTable';
 
-
 const TableBody = forwardRef((inProps, ref) => {
   const {
     role: roleProp,

--- a/packages/react/src/table/TableFooter.js
+++ b/packages/react/src/table/TableFooter.js
@@ -7,7 +7,6 @@ import { TableGroupContext } from './context';
 import { useTableFooterStyle } from './styles';
 import useTable from './useTable';
 
-
 const TableFooter = forwardRef((inProps, ref) => {
   const {
     role: roleProp,

--- a/packages/react/src/table/TableFooter.js
+++ b/packages/react/src/table/TableFooter.js
@@ -12,11 +12,11 @@ const TableFooter = forwardRef((inProps, ref) => {
     role: roleProp,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'TableFooter' });
+  const shallowMemo = useShallowMemo();
   const { layout } = useTable();
   const as = layout === LAYOUT_TABLE ? 'tfoot' : undefined;
   const role = roleProp ?? 'rowgroup';
   const groupVariant = GROUP_VARIANT_FOOTER;
-  const shallowMemo = useShallowMemo();
 
   const context = shallowMemo({
     groupVariant,

--- a/packages/react/src/table/TableFooter.js
+++ b/packages/react/src/table/TableFooter.js
@@ -1,13 +1,12 @@
-import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { GROUP_VARIANT_FOOTER, LAYOUT_TABLE } from './constants';
 import { TableGroupContext } from './context';
 import { useTableFooterStyle } from './styles';
 import useTable from './useTable';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const TableFooter = forwardRef((inProps, ref) => {
   const {
@@ -18,7 +17,9 @@ const TableFooter = forwardRef((inProps, ref) => {
   const as = layout === LAYOUT_TABLE ? 'tfoot' : undefined;
   const role = roleProp ?? 'rowgroup';
   const groupVariant = GROUP_VARIANT_FOOTER;
-  const context = getMemoizedState({
+  const shallowMemo = useShallowMemo();
+
+  const context = shallowMemo({
     groupVariant,
   });
   const styleProps = useTableFooterStyle({ layout });

--- a/packages/react/src/table/TableHeader.js
+++ b/packages/react/src/table/TableHeader.js
@@ -12,11 +12,11 @@ const TableHeader = forwardRef((inProps, ref) => {
     role: roleProp,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'TableHeader' });
+  const shallowMemo = useShallowMemo();
   const { layout } = useTable();
   const as = layout === LAYOUT_TABLE ? 'thead' : undefined;
   const role = roleProp ?? 'rowgroup';
   const groupVariant = GROUP_VARIANT_HEADER;
-  const shallowMemo = useShallowMemo();
 
   const context = shallowMemo({
     groupVariant,

--- a/packages/react/src/table/TableHeader.js
+++ b/packages/react/src/table/TableHeader.js
@@ -1,13 +1,12 @@
-import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { GROUP_VARIANT_HEADER, LAYOUT_TABLE } from './constants';
 import { TableGroupContext } from './context';
 import { useTableHeaderStyle } from './styles';
 import useTable from './useTable';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const TableHeader = forwardRef((inProps, ref) => {
   const {
@@ -18,7 +17,9 @@ const TableHeader = forwardRef((inProps, ref) => {
   const as = layout === LAYOUT_TABLE ? 'thead' : undefined;
   const role = roleProp ?? 'rowgroup';
   const groupVariant = GROUP_VARIANT_HEADER;
-  const context = getMemoizedState({
+  const shallowMemo = useShallowMemo();
+
+  const context = shallowMemo({
     groupVariant,
   });
   const styleProps = useTableHeaderStyle({ layout });

--- a/packages/react/src/table/TableHeader.js
+++ b/packages/react/src/table/TableHeader.js
@@ -7,7 +7,6 @@ import { TableGroupContext } from './context';
 import { useTableHeaderStyle } from './styles';
 import useTable from './useTable';
 
-
 const TableHeader = forwardRef((inProps, ref) => {
   const {
     role: roleProp,

--- a/packages/react/src/tabs/Tabs.js
+++ b/packages/react/src/tabs/Tabs.js
@@ -1,14 +1,13 @@
 import { useConst } from '@tonic-ui/react-hooks';
 import { isNullOrUndefined, runIfFn } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { forwardRef, useEffect, useReducer } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { defaultOrientation, defaultVariant } from './constants';
 import { TabsContext } from './context';
 import { useTabsStyle } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const stateReducer = (prevState, nextState) => ({
   ...prevState,
@@ -26,6 +25,7 @@ const Tabs = forwardRef((inProps, ref) => {
     variant = defaultVariant,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Tabs' });
+  const shallowMemo = useShallowMemo();
   const tabMap = useConst(() => new Map());
   const tabPanelMap = useConst(() => new Map());
   const [state, setState] = useReducer(stateReducer, {
@@ -70,7 +70,8 @@ const Tabs = forwardRef((inProps, ref) => {
     return tabPanelMap.delete(index);
   };
 
-  const context = getMemoizedState({
+
+  const context = shallowMemo({
     disabled,
     index: state.index,
     onChange: handleChange,

--- a/packages/react/src/tabs/Tabs.js
+++ b/packages/react/src/tabs/Tabs.js
@@ -8,7 +8,6 @@ import { defaultOrientation, defaultVariant } from './constants';
 import { TabsContext } from './context';
 import { useTabsStyle } from './styles';
 
-
 const stateReducer = (prevState, nextState) => ({
   ...prevState,
   ...(typeof nextState === 'function' ? nextState(prevState) : nextState),
@@ -69,7 +68,6 @@ const Tabs = forwardRef((inProps, ref) => {
   const unregisterTabPanel = (index) => {
     return tabPanelMap.delete(index);
   };
-
 
   const context = shallowMemo({
     disabled,

--- a/packages/react/src/tag/Tag.js
+++ b/packages/react/src/tag/Tag.js
@@ -1,13 +1,12 @@
 import { ariaAttr, runIfFn } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { useTagStyle } from './styles';
 import TagCloseButton from './TagCloseButton';
 import { TagContext } from './context';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const Tag = forwardRef((inProps, ref) => {
   const {
@@ -20,11 +19,13 @@ const Tag = forwardRef((inProps, ref) => {
     variant = 'solid',
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Tag' });
+  const shallowMemo = useShallowMemo();
   const ariaProps = {
     'aria-disabled': ariaAttr(disabled),
     'aria-invalid': ariaAttr(error),
   };
-  const context = getMemoizedState({
+
+  const context = shallowMemo({
     disabled,
     error,
     isClosable,

--- a/packages/react/src/tag/Tag.js
+++ b/packages/react/src/tag/Tag.js
@@ -7,7 +7,6 @@ import { useTagStyle } from './styles';
 import TagCloseButton from './TagCloseButton';
 import { TagContext } from './context';
 
-
 const Tag = forwardRef((inProps, ref) => {
   const {
     children,

--- a/packages/react/src/toast/Toast.js
+++ b/packages/react/src/toast/Toast.js
@@ -14,7 +14,6 @@ import {
   useToastStyle,
 } from './styles';
 
-
 const Toast = forwardRef((inProps, ref) => {
   const {
     appearance = defaultAppearance,

--- a/packages/react/src/toast/Toast.js
+++ b/packages/react/src/toast/Toast.js
@@ -1,8 +1,8 @@
 import { runIfFn } from '@tonic-ui/utils';
-import memoize from 'micro-memoize';
 import React, { forwardRef } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import ToastCloseButton from './ToastCloseButton';
 import ToastIcon from './ToastIcon';
 import ToastMessage from './ToastMessage';
@@ -14,7 +14,6 @@ import {
   useToastStyle,
 } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const Toast = forwardRef((inProps, ref) => {
   const {
@@ -25,7 +24,9 @@ const Toast = forwardRef((inProps, ref) => {
     children,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Toast' });
-  const context = getMemoizedState({
+  const shallowMemo = useShallowMemo();
+
+  const context = shallowMemo({
     appearance,
     icon,
     isClosable,

--- a/packages/react/src/toast/ToastManager.js
+++ b/packages/react/src/toast/ToastManager.js
@@ -1,9 +1,9 @@
 import { useHydrated } from '@tonic-ui/react-hooks';
 import { isNullish, runIfFn } from '@tonic-ui/utils';
 import { ensureArray, ensureString } from 'ensure-type';
-import memoize from 'micro-memoize';
 import React, { useCallback, useState } from 'react';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { Portal } from '../portal';
 import isValidComponent from '../utils/isValidComponent';
 import ToastContainer from './ToastContainer';
@@ -20,7 +20,6 @@ const uniqueId = (() => {
   };
 })();
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const defaultPlacement = 'bottom-right';
 const placements = [
@@ -55,6 +54,7 @@ const ToastManager = (inProps) => {
     containerRef,
     placement: placementProp = defaultPlacement,
   } = useDefaultProps({ props: inProps, name: 'ToastManager' });
+  const shallowMemo = useShallowMemo();
   const isHydrated = useHydrated();
   const [state, setState] = useState(() => (
     placements.reduce((acc, placement) => {
@@ -199,7 +199,7 @@ const ToastManager = (inProps) => {
     return toast.id;
   }, [placementProp]);
 
-  const context = getMemoizedState({
+  const context = shallowMemo({
     // Methods
     close,
     closeAll,

--- a/packages/react/src/toast/ToastManager.js
+++ b/packages/react/src/toast/ToastManager.js
@@ -20,7 +20,6 @@ const uniqueId = (() => {
   };
 })();
 
-
 const defaultPlacement = 'bottom-right';
 const placements = [
   'bottom',

--- a/packages/react/src/tooltip/Tooltip.js
+++ b/packages/react/src/tooltip/Tooltip.js
@@ -10,7 +10,6 @@ import TooltipContent from './TooltipContent';
 import TooltipTrigger from './TooltipTrigger';
 import { TooltipContext } from './context';
 
-
 const defaultPlacement = 'bottom';
 
 const Tooltip = forwardRef((inProps, ref) => {

--- a/packages/react/src/tooltip/Tooltip.js
+++ b/packages/react/src/tooltip/Tooltip.js
@@ -1,7 +1,7 @@
 import { useId } from '@tonic-ui/react-hooks';
-import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { Popper } from '../popper';
 import config from '../shared/config';
 import { Grow } from '../transitions';
@@ -10,7 +10,6 @@ import TooltipContent from './TooltipContent';
 import TooltipTrigger from './TooltipTrigger';
 import { TooltipContext } from './context';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const defaultPlacement = 'bottom';
 
@@ -48,6 +47,7 @@ const Tooltip = forwardRef((inProps, ref) => {
     placement = defaultPlacement,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Tooltip' });
+  const shallowMemo = useShallowMemo();
   const tooltipContentRef = useRef(null);
   const tooltipTriggerRef = useRef(null);
   const [mousePageX, setMousePageX] = useState(0);
@@ -138,7 +138,8 @@ const Tooltip = forwardRef((inProps, ref) => {
   const defaultId = useId();
   const tooltipId = `${config.name}:Tooltip-${defaultId}`;
   const tooltipTriggerId = `${config.name}:TooltipTrigger-${defaultId}`;
-  const context = getMemoizedState({
+
+  const context = shallowMemo({
     arrow: (followCursor || nextToCursor) ? false : arrow,
     closeOnClick,
     closeOnEsc,

--- a/packages/react/src/tree/Tree.js
+++ b/packages/react/src/tree/Tree.js
@@ -1,15 +1,14 @@
 import { useConst, useId } from '@tonic-ui/react-hooks';
 import { ariaAttr, callEventHandlers, isNullish } from '@tonic-ui/utils';
 import { ensureArray } from 'ensure-type';
-import memoize from 'micro-memoize';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { Descendant } from '../utils/descendant';
 import { TreeContext } from './context';
 import { useTreeStyle } from './styles';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const Tree = forwardRef((inProps, ref) => {
   const {
@@ -29,6 +28,7 @@ const Tree = forwardRef((inProps, ref) => {
     selected: selectedProp,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'Tree' });
+  const shallowMemo = useShallowMemo();
   const defaultId = useId();
   const treeId = idProp ?? defaultId;
   const [focusedNodeId, setFocusedNodeId] = useState(null);
@@ -705,7 +705,8 @@ const Tree = forwardRef((inProps, ref) => {
    * Context
    */
 
-  const context = getMemoizedState({
+
+  const context = shallowMemo({
     focusNode,
     getIsNodeDisabled,
     getIsNodeExpandable,

--- a/packages/react/src/tree/Tree.js
+++ b/packages/react/src/tree/Tree.js
@@ -9,7 +9,6 @@ import { Descendant } from '../utils/descendant';
 import { TreeContext } from './context';
 import { useTreeStyle } from './styles';
 
-
 const Tree = forwardRef((inProps, ref) => {
   const {
     defaultExpanded = [],
@@ -704,7 +703,6 @@ const Tree = forwardRef((inProps, ref) => {
   /**
    * Context
    */
-
 
   const context = shallowMemo({
     focusNode,

--- a/packages/react/src/tree/TreeItem.js
+++ b/packages/react/src/tree/TreeItem.js
@@ -1,17 +1,16 @@
 import { useMergeRefs } from '@tonic-ui/react-hooks';
 import { ariaAttr, isNullish, runIfFn } from '@tonic-ui/utils';
 import { ensureFiniteNumber } from 'ensure-type';
-import memoize from 'micro-memoize';
 import React, { forwardRef, isValidElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box } from '../box';
 import { useDefaultProps } from '../default-props';
+import useShallowMemo from '../utils/useShallowMemo';
 import { Collapse } from '../transitions';
 import { Descendant, useDescendant } from '../utils/descendant';
 import { TreeItemContext } from './context';
 import { useTreeItemStyle } from './styles';
 import useTree from './useTree';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const TreeItem = forwardRef((inProps, ref) => {
   const {
@@ -24,6 +23,7 @@ const TreeItem = forwardRef((inProps, ref) => {
     render,
     ...rest
   } = useDefaultProps({ props: inProps, name: 'TreeItem' });
+  const shallowMemo = useShallowMemo();
   const {
     focusNode,
     getIsNodeDisabled,
@@ -149,7 +149,8 @@ const TreeItem = forwardRef((inProps, ref) => {
   }, [nodeId, getIsNodeDisabled, getIsNodeFocused, focusNode, toggleSelection]);
 
   const styleProps = useTreeItemStyle();
-  const context = getMemoizedState({
+
+  const context = shallowMemo({
     contentRef, // internal use only
     isDisabled,
     isExpandable,

--- a/packages/react/src/tree/TreeItem.js
+++ b/packages/react/src/tree/TreeItem.js
@@ -11,7 +11,6 @@ import { TreeItemContext } from './context';
 import { useTreeItemStyle } from './styles';
 import useTree from './useTree';
 
-
 const TreeItem = forwardRef((inProps, ref) => {
   const {
     TransitionComponent = Collapse,

--- a/packages/react/src/utils/__tests__/useShallowMemo.test.js
+++ b/packages/react/src/utils/__tests__/useShallowMemo.test.js
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react';
+import useShallowMemo from '../useShallowMemo';
+
+describe('useShallowMemo', () => {
+  test('returns the same memoized function across re-renders', () => {
+    const { result, rerender } = renderHook(() => useShallowMemo());
+    const fn = result.current;
+    rerender();
+    expect(result.current).toBe(fn);
+  });
+
+  test('each hook instance has its own independent cache', () => {
+    const { result: { current: firstShallowMemo } } = renderHook(() => useShallowMemo());
+    const { result: { current: secondShallowMemo } } = renderHook(() => useShallowMemo());
+
+    const a = firstShallowMemo({ color: 'red' });
+    const b = secondShallowMemo({ color: 'blue' });
+
+    // calling secondShallowMemo with different values should not affect firstShallowMemo's cache
+    const a2 = firstShallowMemo({ color: 'red' });
+
+    expect(a).toBe(a2);
+    expect(a).not.toBe(b);
+  });
+
+  test('returns the same reference when inputs are shallowly equal, and a new reference when a value changes', () => {
+    const { result } = renderHook(() => useShallowMemo());
+    const shallowMemo = result.current;
+    const state = { color: 'red', size: 'md' };
+
+    const a = shallowMemo(state);
+    const b = shallowMemo({ color: 'red', size: 'md' });
+    const c = shallowMemo({ ...state });
+    const d = shallowMemo({ ...state, color: 'blue' });
+
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(c).not.toBe(d);
+  });
+
+  test('returns a new reference when a function callback changes', () => {
+    const { result } = renderHook(() => useShallowMemo());
+    const shallowMemo = result.current;
+    const onChangeA = jest.fn();
+    const onChangeB = jest.fn();
+
+    const a = shallowMemo({ onChange: onChangeA });
+    const b = shallowMemo({ onChange: onChangeB });
+
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/react/src/utils/descendant/Descendant.js
+++ b/packages/react/src/utils/descendant/Descendant.js
@@ -1,11 +1,10 @@
 /**
  * Credit: https://github.com/reach/reach-ui/tree/dev/packages/descendants
  */
-import memoize from 'micro-memoize';
 import React, { useCallback, useState } from 'react';
 import { DescendantContext } from './context';
+import useShallowMemo from '../useShallowMemo';
 
-const getMemoizedState = memoize(state => ({ ...state }));
 
 const binaryFindElement = (array, element) => {
   let start = 0;
@@ -94,7 +93,10 @@ const Descendant = ({
     });
   }, []);
 
-  const context = getMemoizedState({
+  const shallowMemo = useShallowMemo();
+
+
+  const context = shallowMemo({
     descendants,
     depth,
     id,

--- a/packages/react/src/utils/descendant/Descendant.js
+++ b/packages/react/src/utils/descendant/Descendant.js
@@ -5,7 +5,6 @@ import React, { useCallback, useState } from 'react';
 import { DescendantContext } from './context';
 import useShallowMemo from '../useShallowMemo';
 
-
 const binaryFindElement = (array, element) => {
   let start = 0;
   let end = array.length - 1;
@@ -94,7 +93,6 @@ const Descendant = ({
   }, []);
 
   const shallowMemo = useShallowMemo();
-
 
   const context = shallowMemo({
     descendants,

--- a/packages/react/src/utils/useShallowMemo.js
+++ b/packages/react/src/utils/useShallowMemo.js
@@ -1,0 +1,8 @@
+import { memoize } from 'micro-memoize';
+import { useRef } from 'react';
+
+const useShallowMemo = () => {
+  return useRef(memoize(v => v, { isKeyItemEqual: 'shallow' })).current;
+};
+
+export default useShallowMemo;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5539,7 +5539,7 @@ __metadata:
     jest-axe: ^8.0.0
     jest-environment-jsdom: ^29.0.0
     jest-extended: ^4.0.0
-    micro-memoize: 4.x
+    micro-memoize: 5.x
     react: ^16.14.0 || ^17 || ^18 || ^19
     react-dom: ^16.14.0 || ^17 || ^18 || ^19
     react-focus-lock: 2.x
@@ -10002,6 +10002,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-equals@npm:^5.3.3":
+  version: 5.4.0
+  resolution: "fast-equals@npm:5.4.0"
+  checksum: c6661f8b606ba3cb99c42aa23e3367c2ef9843c5564c81e79f1fcba5d299978feeed335fce16ea8a1e3fe609ca4caa1f7624eb808d6e01061a36011f07186ab2
+  languageName: node
+  linkType: hard
+
 "fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0, fast-glob@npm:^3.3.1":
   version: 3.3.2
   resolution: "fast-glob@npm:3.3.2"
@@ -10039,6 +10046,13 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 92cfec0a8dfafd9c7a15fba8f2cc29cd0b62b85f056d99ce448bbcd9f708e18ab2764bda4dd5158364f4145a7c72788538994f0d1787b956ef0d1062b0f7c24c
+  languageName: node
+  linkType: hard
+
+"fast-stringify@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "fast-stringify@npm:4.0.0"
+  checksum: 14476c22602a6afc27f7faf301ec098fec5546a2291caa57d4373d0d8232a0be4a3429c9517bd1c7e821d47fdd157088a1e9ae69ade37cd8e099e5b66ebf745d
   languageName: node
   linkType: hard
 
@@ -14136,10 +14150,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micro-memoize@npm:4.x":
-  version: 4.1.2
-  resolution: "micro-memoize@npm:4.1.2"
-  checksum: 4b02750622d44b5ab31573c629b5d91927dd0c2727743ff75e790c223ab6cd02c48cc3bddea69da0dffb688091a0a71a17944947dd165f8ba9e03728bc30a76d
+"micro-memoize@npm:5.x":
+  version: 5.1.1
+  resolution: "micro-memoize@npm:5.1.1"
+  dependencies:
+    fast-equals: ^5.3.3
+    fast-stringify: ^4.0.0
+  checksum: 6fea5c00f59df98bf01eed256fcd11f54929188082300ae130fd41739c4fabeff1dc1cfe231c4497f59b170ab19d9d532ff6b5e260af34c8cb6b781a28231cee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Introduce `useShallowMemo`, a per-instance memoization hook backed by `micro-memoize` v5 with `isKeyItemEqual: 'shallow'`, replacing the module-level `getMemoizedState` pattern across 29 components
- The old approach shared a single cache across all component instances (maxSize 1), causing cross-instance cache eviction; the new hook creates an independent memoized function per instance via `useRef`, ensuring stable context object references
- Bump `micro-memoize` from `4.x` to `5.x` and update imports to the v5 named export (`import { memoize } from 'micro-memoize'`)
- `useShallowMemo` is called immediately after `useDefaultProps` in every component, following the established pattern from Tonic One

## Test plan

- [ ] New `useShallowMemo.test.js` covers: stable function reference across re-renders, per-instance cache isolation, shallow equality returning same reference, and new reference on value change
- [ ] Run `yarn test` in `packages/react` to verify all tests pass
- [ ] Verify context objects remain stable across re-renders in components that consume the context (no unnecessary child re-renders)