### PR TITLE
feat(react-docs/experiments): improve event handling and menu list sizing in `DropdownBase`

### DIFF
--- a/packages/react-docs/experiments/dropdown/DropdownBase.js
+++ b/packages/react-docs/experiments/dropdown/DropdownBase.js
@@ -10,7 +10,7 @@ import {
   SubmenuList,
   useTheme,
 } from '@tonic-ui/react';
-import { isPlainObject, runIfFn } from '@tonic-ui/utils';
+import { callEventHandlers, isPlainObject, runIfFn } from '@tonic-ui/utils';
 import { ensureArray } from 'ensure-type';
 import React, { Fragment, forwardRef, useCallback } from 'react';
 
@@ -40,9 +40,15 @@ const DropdownBase = forwardRef((
 ) => {
   const theme = useTheme();
   const handleClickBy = useCallback((item) => (event) => {
+    if (event.defaultPrevented) {
+      return;
+    }
     onSelect?.(item);
   }, [onSelect]);
   const handleKeyDownBy = useCallback((item) => (event) => {
+    if (event.defaultPrevented) {
+      return;
+    }
     if ((event.key === ' ' || event.key === 'Enter') && !event.repeat) {
       onSelect?.(item);
     }
@@ -103,12 +109,14 @@ const DropdownBase = forwardRef((
         );
       }
 
+      const { onClick: onClickProp, onKeyDown: onKeyDownProp, ...restItemProps } = { ...item.props };
+
       return (
         <MenuItem
           key={key}
-          onClick={handleClickBy(item)}
-          onKeyDown={handleKeyDownBy(item)}
-          {...item.props}
+          onClick={callEventHandlers(onClickProp, handleClickBy(item))}
+          onKeyDown={callEventHandlers(onKeyDownProp, handleKeyDownBy(item))}
+          {...restItemProps}
         >
           {renderItem?.(item)}
         </MenuItem>
@@ -122,19 +130,15 @@ const DropdownBase = forwardRef((
       {...rest}
     >
       {({ menuToggleRef }) => {
-        const menuListProps = portalled
-          ? {
-              PopperProps: {
-                usePortal: true,
-              },
-              minWidth: menuToggleRef.current?.offsetWidth,
-              zIndex: theme?.zIndices?.modal + 1,
-            }
-          : {
-              // Set the minimum width to fit the menu's content while occupying full width
-              minWidth: 'max-content',
-              width: '100%',
-            };
+        const { fitToggleWidth, ...restContentProps } = { ...slotProps?.content };
+        const toggleWidth = menuToggleRef.current?.offsetWidth;
+        const menuListStyle = {
+          ...(fitToggleWidth
+            ? { width: toggleWidth }
+            : { minWidth: toggleWidth, width: 'max-content', maxWidth: 640 }
+          ),
+          ...(portalled && { zIndex: theme?.zIndices?.modal + 1 }),
+        };
 
         return (
           <>
@@ -155,8 +159,12 @@ const DropdownBase = forwardRef((
               }}
             </MenuToggle>
             <MenuList
-              {...menuListProps}
-              {...slotProps?.content}
+              {...menuListStyle}
+              {...restContentProps}
+              PopperProps={{
+                usePortal: portalled,
+                ...restContentProps?.PopperProps,
+              }}
             >
               {(typeof renderContent === 'function')
                 ? renderContent({ items, renderItem, renderItems })

--- a/packages/react-docs/pages/experiments/dropdown-base/index.page.mdx
+++ b/packages/react-docs/pages/experiments/dropdown-base/index.page.mdx
@@ -26,9 +26,8 @@ Here's the simplest configuration to get started with the `DropdownBase` compone
     toggle: CustomDropdownToggle,
   }}
   slotProps={{
-    toggle: {
-      // Additional props to pass to the toggle component
-    },
+    toggle: {}, // additional toggle props
+    content: {}, // additional content props
   }}
 >
   {value}

--- a/packages/react-docs/pages/experiments/dropdown-base/index.page.mdx
+++ b/packages/react-docs/pages/experiments/dropdown-base/index.page.mdx
@@ -137,6 +137,14 @@ export interface DropdownBaseProps {
    */
   slotProps?: {
     toggle?: Record<string, any>;
+    content?: {
+      /**
+       * If `true`, the dropdown menu width will match the toggle width exactly.
+       * If `false` or omitted, the dropdown menu will use `min-width` equal to the toggle width,
+       * `width` set to `max-content`, and `max-width` of 640px.
+       */
+      fitToggleWidth?: boolean;
+    } & Record<string, any>;
   };
 }
 
@@ -221,7 +229,7 @@ Each dropdown item is an object that may include the following fields:
 | renderItem | `(item: DropdownItem) => ReactNode` | `defaultRenderItem` <sub>[2]</sub> | Optional custom render function for rendering dropdown items. |
 | renderContent | `(args: { items: DropdownItem[], renderItem: (item: DropdownItem) => ReactNode, renderItems: (items: DropdownItem[], prefix?: string) => ReactNode[] }) => ReactNode` | | Optional custom function to render the entire dropdown's content. Provides access to `items`, `renderItem`, and `renderItems`. Use this to fully customize the dropdown content beyond the default rendering behavior. |
 | slots	<sub>[1]</sub> | `{ toggle?: React.ComponentType<any> }` | \{\} |	The components used for each slot inside the `DropdownBase`. Either a string to use a HTML element or a component. |
-| slotProps	| `{ toggle?: Record<string, any> }` | \{\} | The props used for each slot inside the `DropdownBase`. |
+| slotProps	| `{ toggle?: Record<string, any>, content?: { fitToggleWidth?: boolean } & Record<string, any> }` | \{\} | The props used for each slot inside the `DropdownBase`. See the **slotProps** section below for details. |
 
 Notes:
 1. If `slots.toggle` is a valid React component, it wraps the `children`. Otherwise, it executes the `children` function, passing in `getToggleProps`. This allows for full customization of the toggle's appearance and behavior.
@@ -247,6 +255,38 @@ Notes:
     ```js
     const defaultRenderItem = (item) => isPlainObject(item) ? item.label : item;
     ```
+
+#### slotProps
+
+**slotProps.toggle**
+
+Props passed directly to the `MenuToggle` component.
+
+**slotProps.content**
+
+Props passed to the `MenuList` component that renders the dropdown content. In addition to standard `MenuList` props, the following custom props are supported:
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| fitToggleWidth | boolean | false | If `true`, the dropdown menu width will match the toggle width exactly. If `false` or omitted, the dropdown menu will use `min-width` equal to the toggle width, `width` set to `max-content`, and `max-width` of `640px`. |
+
+**Example:**
+```jsx
+<DropdownBase
+  items={items}
+  onSelect={handleSelect}
+  slots={{
+    toggle: MenuButtonToggle,
+  }}
+  slotProps={{
+    content: {
+      fitToggleWidth: true, // Dropdown content width matches toggle width
+    },
+  }}
+>
+  {value}
+</DropdownBase>
+```
 
 ## Source code
 

--- a/packages/react-docs/pages/experiments/dropdown-base/usage.js
+++ b/packages/react-docs/pages/experiments/dropdown-base/usage.js
@@ -69,7 +69,8 @@ const App = () => {
         toggle: MenuButtonToggle,
       }}
       slotProps={{
-        // Additional props to pass to the toggle component
+        toggle: {}, // additional toggle props
+        content: {}, // additional content props
       }}
       width={200}
     >

--- a/packages/react-docs/pages/experiments/dropdown/index.page.mdx
+++ b/packages/react-docs/pages/experiments/dropdown/index.page.mdx
@@ -51,9 +51,8 @@ By default, the dropdown uses a `MenuButton` as its toggle. To customize the tog
     toggle: CustomDropdownToggle,
   }}
   slotProps={{
-    toggle: {
-      // Additional props to pass to the toggle component
-    },
+    toggle: {}, // additional toggle props
+    content: {}, // additional content props
   }}
 >
   {selectedItem.label}

--- a/packages/react-docs/pages/experiments/dropdown/usage.js
+++ b/packages/react-docs/pages/experiments/dropdown/usage.js
@@ -53,6 +53,9 @@ const App = () => {
   const setToggleProps = (updater) => {
     setTogglePropsMap((prevState) => produce(prevState, draft => updater(draft[toggle])));
   };
+  const [contentProps, setContentProps] = useState({
+    fitToggleWidth: false,
+  });
   const [value, setValue] = useState('all');
   const items = useConst(() => [
     { value: 'all', label: 'All' },
@@ -178,6 +181,26 @@ const App = () => {
           )}
         </Stack>
       </FormGroup>
+      <FormGroup>
+        <Stack spacing="2x" shouldWrapChildren>
+          <MutedText>
+            Dropdown content props:
+          </MutedText>
+          <Checkbox
+            checked={contentProps.fitToggleWidth}
+            onChange={() => {
+              setContentProps(prevState => {
+                return {
+                  ...prevState,
+                  fitToggleWidth: !prevState.fitToggleWidth,
+                };
+              });
+            }}
+          >
+            <MutedText fontFamily="mono" whiteSpace="nowrap">fitToggleWidth</MutedText>
+          </Checkbox>
+        </Stack>
+      </FormGroup>
       <Divider my="4x" />
       <Dropdown
         items={items}
@@ -196,8 +219,8 @@ const App = () => {
           toggle: ToggleComponent,
         }}
         slotProps={{
-          // Additional props to pass to the toggle component
           toggle: toggleProps,
+          content: contentProps,
         }}
         width={width}
       >


### PR DESCRIPTION
## Summary

Improves the `DropdownBase` experiment component with better event handler composition, `defaultPrevented` guards, and a unified menu list sizing strategy with a new `fitToggleWidth` slot prop.

## Changes

- **Event handling**: Guard `onSelect` calls behind `event.defaultPrevented` checks in both `handleClickBy` and `handleKeyDownBy`, so consumers can cancel selection by calling `event.preventDefault()` in their own handlers
- **Event composition**: Use `callEventHandlers` to chain item-level `onClick`/`onKeyDown` props with internal handlers, instead of overriding them via spread order — fixing a bug where `item.props.onClick` was silently ignored
- **Menu sizing**: Replace the branched `portalled`/non-portalled `menuListProps` logic with a unified `menuListStyle` object; add a `fitToggleWidth` slot prop on `slotProps.content` to force the menu width to match the toggle button width
- **Popper portal**: Always pass `PopperProps.usePortal` explicitly (driven by the `portalled` prop), while still allowing consumer overrides via `restContentProps.PopperProps`
