### PR TITLE
feat: skip deprecation and removal warnings in production

### DIFF
--- a/.changeset/tonic-ui-pr-1157md
+++ b/.changeset/tonic-ui-pr-1157md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/utils": minor
+---
+
+feat(utils): skip deprecation and removed prop warnings in production

--- a/packages/utils/src/__tests__/shared.test.js
+++ b/packages/utils/src/__tests__/shared.test.js
@@ -599,6 +599,16 @@ describe('warnDeprecatedProps', () => {
     });
     expect(fn).toHaveBeenCalledWith('TestComponent: \'isDisabled\' is deprecated and will be removed in the next major release. Use \'disabled\' instead.');
   });
+  it('should not warn in production', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const fn = jest.spyOn(console, 'error').mockImplementation(() => {});
+    warnDeprecatedProps('isDisabled', {
+      prefix: 'TestComponent:',
+    });
+    expect(fn).not.toHaveBeenCalled();
+    process.env.NODE_ENV = originalNodeEnv;
+  });
 });
 
 describe('warnRemovedProps', () => {
@@ -616,5 +626,15 @@ describe('warnRemovedProps', () => {
       alternative: 'disabled',
     });
     expect(fn).toHaveBeenCalledWith('TestComponent: \'isDisabled\' is removed. Use \'disabled\' instead.');
+  });
+  it('should not warn in production', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const fn = jest.spyOn(console, 'error').mockImplementation(() => {});
+    warnRemovedProps('isDisabled', {
+      prefix: 'TestComponent:',
+    });
+    expect(fn).not.toHaveBeenCalled();
+    process.env.NODE_ENV = originalNodeEnv;
   });
 });

--- a/packages/utils/src/shared.js
+++ b/packages/utils/src/shared.js
@@ -176,6 +176,9 @@ export const runIfFn = (valueOrFn, ...args) => {
 };
 
 export const warnDeprecatedProps = (props, options) => {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
   const prefix = options?.prefix ?? 'Warning:';
   const alternative = ensureArray(options?.alternative);
   const willRemove = ensureBoolean(options?.willRemove);
@@ -207,6 +210,9 @@ export const warnDeprecatedProps = (props, options) => {
 };
 
 export const warnRemovedProps = (props, options) => {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
   const prefix = options?.prefix ?? 'Warning:';
   const alternative = ensureArray(options?.alternative);
   const message = ensureString(options?.message);


### PR DESCRIPTION
## Summary

- `warnDeprecatedProps` and `warnRemovedProps` now early-return when `process.env.NODE_ENV === 'production'`, skipping unnecessary console output and string-building work in production builds.
- Added tests verifying that neither function calls `console.error` in production.

## Test plan

- [x] `warnDeprecatedProps` does not warn when `NODE_ENV` is `production`
- [x] `warnRemovedProps` does not warn when `NODE_ENV` is `production`
- [ ] Existing non-production warning behavior remains unchanged