### PR TITLE
chore(react): upgrade `date-fns` from v2 to v4

### DIFF
--- a/.changeset/fiery-jeans-laugh.md
+++ b/.changeset/fiery-jeans-laugh.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": patch
+---
+
+chore(react): upgrade `date-fns` from v2 to v4

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -45,7 +45,7 @@
     "boolean": "^3.2.0",
     "chance": "^1.1.12",
     "cross-env": "^7.0.3",
-    "date-fns": "2.x",
+    "date-fns": "^4.4.0",
     "del-cli": "^5.0.0",
     "dotenv-flow": "^3.2.0",
     "ensure-type": "^1.5.1",

--- a/packages/react-docs/pages/components/date-pickers/date-calendar/usage.js
+++ b/packages/react-docs/pages/components/date-pickers/date-calendar/usage.js
@@ -163,7 +163,7 @@ const App = () => {
           You can use the <Code>formatDate</Code> prop to return a formatted date string in the given format and locale.
         </TextLabel>
         <PreformattedText>
-          {'// format\nimport format from \'date-fns/format\';\n\n// locale\nimport enLocale from \'date-fns/locale/en-US\'; // English (United States)\nimport deLocale from \'date-fns/locale/de\'; // Deutsch\nimport esLocale from \'date-fns/locale/es\'; // Español\nimport frLocale from \'date-fns/locale/fr\'; // Français\nimport itLocale from \'date-fns/locale/it\'; // Italiano\nimport jaLocale from \'date-fns/locale/ja\'; // 日本語\nimport koLocale from \'date-fns/locale/ko\'; // 한국어\nimport zhCNLocale from \'date-fns/locale/zh-CN\'; // 简体中文\nimport zhTWLocale from \'date-fns/locale/zh-TW\'; // 繁體中文'}
+          {'// format\nimport { format } from \'date-fns\';\n\n// locale\nimport { enUS as enLocale } from \'date-fns/locale\'; // English (United States)\nimport { de as deLocale } from \'date-fns/locale\'; // Deutsch\nimport { es as esLocale } from \'date-fns/locale\'; // Español\nimport { fr as frLocale } from \'date-fns/locale\'; // Français\nimport { it as itLocale } from \'date-fns/locale\'; // Italiano\nimport { ja as jaLocale } from \'date-fns/locale\'; // 日本語\nimport { ko as koLocale } from \'date-fns/locale\'; // 한국어\nimport { zhCN as zhCNLocale } from \'date-fns/locale\'; // 简体中文\nimport { zhTW as zhTWLocale } from \'date-fns/locale\'; // 繁體中文'}
         </PreformattedText>
         <PreformattedText>
           {'// DateCalendar component\nformatDate={(date, format, options) => {\n  return format(date, format, { locale: enLocale });\n}}'}

--- a/packages/react-docs/pages/components/date-pickers/date-picker/usage.js
+++ b/packages/react-docs/pages/components/date-pickers/date-picker/usage.js
@@ -215,7 +215,7 @@ const App = () => {
           You can use the <Code>formatDate</Code> prop to return a formatted date string in the given format and locale.
         </TextLabel>
         <PreformattedText>
-          {'// format\nimport format from \'date-fns/format\';\n\n// locale\nimport enLocale from \'date-fns/locale/en-US\'; // English (United States)\nimport deLocale from \'date-fns/locale/de\'; // Deutsch\nimport esLocale from \'date-fns/locale/es\'; // Español\nimport frLocale from \'date-fns/locale/fr\'; // Français\nimport itLocale from \'date-fns/locale/it\'; // Italiano\nimport jaLocale from \'date-fns/locale/ja\'; // 日本語\nimport koLocale from \'date-fns/locale/ko\'; // 한국어\nimport zhCNLocale from \'date-fns/locale/zh-CN\'; // 简体中文\nimport zhTWLocale from \'date-fns/locale/zh-TW\'; // 繁體中文'}
+          {'// format\nimport { format } from \'date-fns\';\n\n// locale\nimport { enUS as enLocale } from \'date-fns/locale\'; // English (United States)\nimport { de as deLocale } from \'date-fns/locale\'; // Deutsch\nimport { es as esLocale } from \'date-fns/locale\'; // Español\nimport { fr as frLocale } from \'date-fns/locale\'; // Français\nimport { it as itLocale } from \'date-fns/locale\'; // Italiano\nimport { ja as jaLocale } from \'date-fns/locale\'; // 日本語\nimport { ko as koLocale } from \'date-fns/locale\'; // 한국어\nimport { zhCN as zhCNLocale } from \'date-fns/locale\'; // 简体中文\nimport { zhTW as zhTWLocale } from \'date-fns/locale\'; // 繁體中文'}
         </PreformattedText>
         <PreformattedText>
           {'// DatePicker component\nformatDate={(date, format, options) => {\n  return format(date, format, { locale: enLocale });\n}}'}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "@tonic-ui/styled-system": "^2.2.1",
     "@tonic-ui/theme": "^2.0.1",
     "@tonic-ui/utils": "^2.3.0",
-    "date-fns": "2.x",
+    "date-fns": "^4.4.0",
     "ensure-type": "^1.5.1",
     "micro-memoize": "5.x",
     "react-focus-lock": "2.x",

--- a/packages/react/src/date-pickers/DateCalendar/DateCalendar.js
+++ b/packages/react/src/date-pickers/DateCalendar/DateCalendar.js
@@ -9,18 +9,7 @@ import {
   isNullOrUndefined,
   warnDeprecatedProps,
 } from '@tonic-ui/utils';
-import differenceInCalendarDays from 'date-fns/differenceInCalendarDays';
-import addMonths from 'date-fns/addMonths';
-import endOfDay from 'date-fns/endOfDay';
-import format from 'date-fns/format';
-import isDate from 'date-fns/isDate';
-import isSameMonth from 'date-fns/isSameMonth';
-import isSameYear from 'date-fns/isSameYear';
-import isValid from 'date-fns/isValid';
-import startOfDay from 'date-fns/startOfDay';
-import startOfMonth from 'date-fns/startOfMonth';
-import startOfWeek from 'date-fns/startOfWeek';
-import subMonths from 'date-fns/subMonths';
+import { addMonths, differenceInCalendarDays, endOfDay, format, isDate, isSameMonth, isSameYear, isValid, startOfDay, startOfMonth, startOfWeek, subMonths } from 'date-fns';
 import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../../box';
 import { useDefaultProps } from '../../default-props';

--- a/packages/react/src/date-pickers/DateCalendar/MonthDate/Day.js
+++ b/packages/react/src/date-pickers/DateCalendar/MonthDate/Day.js
@@ -1,9 +1,5 @@
 import { callEventHandlers, dataAttr } from '@tonic-ui/utils';
-import formatISO from 'date-fns/formatISO';
-import isAfter from 'date-fns/isAfter';
-import isBefore from 'date-fns/isBefore';
-import isSameDay from 'date-fns/isSameDay';
-import isSameMonth from 'date-fns/isSameMonth';
+import { formatISO, isAfter, isBefore, isSameDay, isSameMonth } from 'date-fns';
 import { forwardRef } from 'react';
 import { Box } from '../../../box';
 import useButtonEventHandlers from '../../../utils/useButtonEventHandlers';

--- a/packages/react/src/date-pickers/DateCalendar/MonthDate/DaysOfWeek.js
+++ b/packages/react/src/date-pickers/DateCalendar/MonthDate/DaysOfWeek.js
@@ -1,5 +1,4 @@
-import addDays from 'date-fns/addDays';
-import startOfWeek from 'date-fns/startOfWeek';
+import { addDays, startOfWeek } from 'date-fns';
 import { forwardRef } from 'react';
 import { Box } from '../../../box';
 import { Grid } from '../../../grid';

--- a/packages/react/src/date-pickers/DateCalendar/MonthDate/Week.js
+++ b/packages/react/src/date-pickers/DateCalendar/MonthDate/Week.js
@@ -1,4 +1,4 @@
-import addDays from 'date-fns/addDays';
+import { addDays } from 'date-fns';
 import Day from './Day';
 
 const Week = ({

--- a/packages/react/src/date-pickers/DateCalendar/MonthDate/Weeks.js
+++ b/packages/react/src/date-pickers/DateCalendar/MonthDate/Weeks.js
@@ -1,8 +1,4 @@
-import addDays from 'date-fns/addDays';
-import addWeeks from 'date-fns/addWeeks';
-import isSameMonth from 'date-fns/isSameMonth';
-import startOfMonth from 'date-fns/startOfMonth';
-import startOfWeek from 'date-fns/startOfWeek';
+import { addDays, addWeeks, isSameMonth, startOfMonth, startOfWeek } from 'date-fns';
 import { forwardRef } from 'react';
 import { Grid } from '../../../grid';
 import useDateCalendar from '../useDateCalendar';

--- a/packages/react/src/date-pickers/DateCalendar/YearMonthPicker/YearMonthPicker.js
+++ b/packages/react/src/date-pickers/DateCalendar/YearMonthPicker/YearMonthPicker.js
@@ -6,10 +6,7 @@ import {
   AngleDownIcon,
 } from '@tonic-ui/react-icons';
 import { getAllFocusable } from '@tonic-ui/utils';
-import addMonths from 'date-fns/addMonths';
-import addYears from 'date-fns/addYears';
-import subMonths from 'date-fns/subMonths';
-import subYears from 'date-fns/subYears';
+import { addMonths, addYears, subMonths, subYears } from 'date-fns';
 import { forwardRef, useCallback, useRef } from 'react';
 import { Box } from '../../../box';
 import { Button } from '../../../button';

--- a/packages/react/src/date-pickers/DatePicker/DatePicker.js
+++ b/packages/react/src/date-pickers/DatePicker/DatePicker.js
@@ -1,11 +1,6 @@
 import { useClickOutside, useConst, useEventCallback, useId, useMergeRefs, usePrevious } from '@tonic-ui/react-hooks';
 import { callEventHandlers, isNullOrUndefined } from '@tonic-ui/utils';
-import format from 'date-fns/format';
-import endOfDay from 'date-fns/endOfDay';
-import isDate from 'date-fns/isDate';
-import isValid from 'date-fns/isValid';
-import parse from 'date-fns/parse';
-import startOfDay from 'date-fns/startOfDay';
+import { endOfDay, format, isDate, isValid, parse, startOfDay } from 'date-fns';
 import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Box } from '../../box';
 import { useDefaultProps } from '../../default-props';

--- a/packages/react/src/date-pickers/DatePicker/__tests__/DatePicker.test.js
+++ b/packages/react/src/date-pickers/DatePicker/__tests__/DatePicker.test.js
@@ -24,7 +24,7 @@ describe('DatePicker', () => {
     const inputError = false;
     const formatDate = useCallback((date, format) => {
       const options = {
-        locale: dateFnsLocale['en-US'],
+        locale: dateFnsLocale['enUS'],
       };
       return dateFns.format(date, format, options);
     }, []);

--- a/packages/react/src/date-pickers/validation.js
+++ b/packages/react/src/date-pickers/validation.js
@@ -1,7 +1,5 @@
 import { isNullOrUndefined } from '@tonic-ui/utils';
-import isAfter from 'date-fns/isAfter';
-import isBefore from 'date-fns/isBefore';
-import isValid from 'date-fns/isValid';
+import { isAfter, isBefore, isValid } from 'date-fns';
 
 const validateDate = (value, props) => {
   const { maxDate, minDate, shouldDisableDate } = { ...props };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,7 +2375,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.24.1
   resolution: "@babel/runtime@npm:7.24.1"
   dependencies:
@@ -6058,7 +6058,7 @@ __metadata:
     boolean: ^3.2.0
     chance: ^1.1.12
     cross-env: ^7.0.3
-    date-fns: 2.x
+    date-fns: ^4.4.0
     del-cli: ^5.0.0
     dotenv-flow: ^3.2.0
     ensure-type: ^1.5.1
@@ -6216,7 +6216,7 @@ __metadata:
     "@tonic-ui/utils": ^2.3.0
     "@trendmicro/babel-config": ^1.0.2
     cross-env: ^7.0.3
-    date-fns: 2.x
+    date-fns: ^4.4.0
     del-cli: ^5.0.0
     ensure-type: ^1.5.1
     eslint: ^9.26.0
@@ -9334,12 +9334,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:2.x":
-  version: 2.30.0
-  resolution: "date-fns@npm:2.30.0"
-  dependencies:
-    "@babel/runtime": ^7.21.0
-  checksum: f7be01523282e9bb06c0cd2693d34f245247a29098527d4420628966a2d9aad154bd0e90a6b1cf66d37adcb769cd108cf8a7bd49d76db0fb119af5cdd13644f4
+"date-fns@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "date-fns@npm:4.4.0"
+  checksum: 9a25020573f1aeaddfa0a41bb32411e8e1e8c81ddb870865a005c37f741778c737833baee350a90f275ae806dcd227e41bc4f26337dda189ebca796ce760ba11
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Upgrades `date-fns` from `2.x` to `^4.4.0` in `@tonic-ui/react` and `react-docs`. date-fns v4 removed default exports from subpaths, so all imports are migrated to named imports from the main package.

## Changes

| File | Change |
|---|---|
| `packages/react/package.json` | `"date-fns": "2.x"` → `"^4.4.0"` |
| `packages/react-docs/package.json` | `"date-fns": "2.x"` → `"^4.4.0"` |
| `src/date-pickers/validation.js` | 3 subpath defaults → `import { isAfter, isBefore, isValid } from 'date-fns'` |
| `DateCalendar/MonthDate/DaysOfWeek.js` | 2 → `import { addDays, startOfWeek } from 'date-fns'` |
| `DateCalendar/MonthDate/Week.js` | 1 → `import { addDays } from 'date-fns'` |
| `DateCalendar/MonthDate/Weeks.js` | 5 → `import { addDays, addWeeks, isSameMonth, startOfMonth, startOfWeek } from 'date-fns'` |
| `DateCalendar/MonthDate/Day.js` | 5 → `import { formatISO, isAfter, isBefore, isSameDay, isSameMonth } from 'date-fns'` |
| `DateCalendar/YearMonthPicker/YearMonthPicker.js` | 4 → `import { addMonths, addYears, subMonths, subYears } from 'date-fns'` |
| `DatePicker/DatePicker.js` | 6 → `import { endOfDay, format, isDate, isValid, parse, startOfDay } from 'date-fns'` |
| `DateCalendar/DateCalendar.js` | 12 → `import { addMonths, differenceInCalendarDays, ... } from 'date-fns'` |
| `DatePicker/__tests__/DatePicker.test.js` | `dateFnsLocale['en-US']` → `dateFnsLocale['enUS']` (v4 locale key) |
| `date-calendar/usage.js` (docs) | Code sample updated to v4 named import style |
| `date-picker/usage.js` (docs) | Code sample updated to v4 named import style |

## Breaking Change in date-fns v4

Subpath default imports no longer export the function directly:

```js
// Before (v2) — broken in v4
import addDays from 'date-fns/addDays'; // returns { addDays: fn }, not fn

// After (v4)
import { addDays } from 'date-fns';
```

Locale keys also changed from dash-case to camelCase (`'en-US'` → `'enUS'`, `'zh-TW'` → `'zhTW'`).

## Migration

If you use the `formatDate` prop with date-fns, update your imports:

```js
// Before
import format from 'date-fns/format';
import enLocale from 'date-fns/locale/en-US';

// After
import { format } from 'date-fns';
import { enUS as enLocale } from 'date-fns/locale';
```