### PR TITLE
feat(react/portal): `Portal` now supports Shadow DOM by resolving its default container from the mounted root instead of `document.body`.

### DIFF
--- a/.changeset/tonic-ui-pr-1166.md
+++ b/.changeset/tonic-ui-pr-1166.md
@@ -2,4 +2,4 @@
 "@tonic-ui/react": patch
 ---
 
-feat(react): `Portal` now supports Shadow DOM by resolving its default container from the mounted root instead of `document.body`.
+feat(react/portal): `Portal` now supports Shadow DOM by resolving its default container from the mounted root instead of `document.body`.

--- a/.changeset/tonic-ui-pr-1166.md
+++ b/.changeset/tonic-ui-pr-1166.md
@@ -1,0 +1,5 @@
+---
+"@tonic-ui/react": patch
+---
+
+`Portal` now resolves its default container from the root node of the tree it is mounted in (via the native `Node.getRootNode()`) instead of always using `document.body`. Portal-based components (`Modal`, `Drawer`, `Popper`, `PortalManager`, `ToastManager`) render inside a shadow root automatically when the app is mounted there. The iframe and normal-page behavior is unchanged, and an explicit `containerRef` still overrides the default.

--- a/.changeset/tonic-ui-pr-1166.md
+++ b/.changeset/tonic-ui-pr-1166.md
@@ -2,4 +2,4 @@
 "@tonic-ui/react": patch
 ---
 
-`Portal` now resolves its default container from the root node of the tree it is mounted in (via the native `Node.getRootNode()`) instead of always using `document.body`. Portal-based components (`Modal`, `Drawer`, `Popper`, `PortalManager`, `ToastManager`) render inside a shadow root automatically when the app is mounted there. The iframe and normal-page behavior is unchanged, and an explicit `containerRef` still overrides the default.
+feat(react): `Portal` now supports Shadow DOM by resolving its default container from the mounted root instead of `document.body`.

--- a/packages/react-docs/config/sidebar-routes.js
+++ b/packages/react-docs/config/sidebar-routes.js
@@ -8,6 +8,7 @@ import {
   ColorIcon,
   FileImageOIcon,
   HookIcon,
+  LinkIcon,
   MigrateSuccessIcon,
   RocketIcon,
   SearchOIcon,
@@ -37,8 +38,20 @@ export const routes = [
           </Tag>
         ),
       },
-      { title: 'Color mode', path: 'getting-started/color-mode' },
-      { title: 'Color style', path: 'getting-started/color-style' },
+      {
+        title: 'Color mode',
+        path: 'components/color-mode',
+        render: () => (
+          <LinkIcon />
+        ),
+      },
+      {
+        title: 'Color style',
+        path: 'components/color-style',
+        render: () => (
+          <LinkIcon />
+        ),
+      },
       { title: 'Icons', path: 'getting-started/icons' },
       { title: 'The sx prop', path: 'getting-started/the-sx-prop' },
       { title: 'Versions', path: 'getting-started/versions' },

--- a/packages/react-docs/config/sidebar-routes.js
+++ b/packages/react-docs/config/sidebar-routes.js
@@ -30,15 +30,6 @@ export const routes = [
       { title: 'Installation', path: 'getting-started/installation' },
       { title: 'Usage', path: 'getting-started/usage' },
       {
-        title: 'AI assistant with MCP',
-        path: 'getting-started/mcp',
-        render: () => (
-          <Tag variant="outline" borderColor="yellow:50" color="yellow:50" size="sm">
-            NEW
-          </Tag>
-        ),
-      },
-      {
         title: 'Color mode',
         path: 'components/color-mode',
         render: () => (
@@ -52,7 +43,21 @@ export const routes = [
           <LinkIcon />
         ),
       },
-      { title: 'Icons', path: 'getting-started/icons' },
+      {
+        title: 'Environment',
+        path: 'components/environment',
+        render: () => (
+          <LinkIcon />
+        ),
+      },
+      {
+        title: 'Icons',
+        path: 'icons',
+        render: () => (
+          <LinkIcon />
+        ),
+      },
+      { title: 'AI assistant with MCP', path: 'getting-started/mcp' },
       { title: 'The sx prop', path: 'getting-started/the-sx-prop' },
       { title: 'Versions', path: 'getting-started/versions' },
     ],

--- a/packages/react-docs/pages/components/environment/index.page.mdx
+++ b/packages/react-docs/pages/components/environment/index.page.mdx
@@ -58,21 +58,80 @@ The above setup is equivalent to:
 
 **Note:** Use a function `() => rootNode` when the root node might change or isn't available during initial render.
 
-## Examples
+## Iframe vs Shadow DOM
+
+Both contexts require an `environment` config. Shadow DOM also needs extra setup for CSS-in-JS scoping and CSS variables.
+
+| | Iframe | Shadow DOM |
+| :--- | :----- | :--------- |
+| `environment` value | `iframe.contentDocument` | shadow root (`ShadowRoot`) |
+| Emotion cache `container` | `iframe.contentDocument.head` | shadow root |
+| CSS variables root | not needed (defaults to `:root`) | `':host'` — scopes CSS variables to the shadow host |
+| Full setup guide | — | [Shadow DOM](../../customization/shadow-dom) |
 
 ### Usage with Shadow DOM
 
-To render components inside a Shadow DOM, configure the `environment` prop with the shadow root. This ensures modals and other portal-based components render within the shadow DOM boundary:
+Set `environment` to the shadow root. Portal-based components then render within the shadow DOM boundary. See [Shadow DOM](../../customization/shadow-dom) for the complete setup, including `createShadowDOM`, cache, and theme configuration.
+
+```jsx
+const cache = createCache({
+  key: 'tonic-ui-css',
+  nonce: 'your-nonce-value',
+  prepend: true,
+  container: shadowRoot,
+});
+
+const shadowTheme = createTheme({
+  cssVariables: {
+    prefix: 'tonic-ui',
+    rootSelector: ':host',
+  },
+});
+
+<CacheProvider value={cache}>
+  <TonicProvider
+    environment={{ value: shadowRoot }}
+    theme={shadowTheme}
+  >
+    <App />
+  </TonicProvider>
+</CacheProvider>
+```
 
 {render('./usage-in-shadow-dom')}
 
 ### Usage with iframe
 
-To render components inside an iframe, configure the `environment` prop with the iframe's document. This ensures modals and other portal-based components render within the iframe context:
+Set `environment` to the iframe's document. Portal-based components then render within the iframe context.
+
+```jsx
+const cache = createCache({
+  key: 'tonic-ui-css',
+  nonce: 'your-nonce-value',
+  prepend: true,
+  container: iframe.contentDocument.head,
+});
+
+const theme = createTheme({
+  cssVariables: {
+    prefix: 'tonic-ui',
+    rootSelector: ':root', // ':root' works correctly in the iframe's own document
+  },
+});
+
+<CacheProvider value={cache}>
+  <TonicProvider
+    environment={{ value: iframe.contentDocument }}
+    theme={theme}
+  >
+    <App />
+  </TonicProvider>
+</CacheProvider>
+```
 
 {render('./usage-in-iframe')}
 
-### Why the environment matters in an iframe
+## Why the environment matters in an iframe
 
 An iframe is a separate realm: its `document` and `window` are different objects from the page's global `document` and `window`. Since Tonic UI components render into the iframe from the parent page's JavaScript, the global `document`/`window` point at the parent page — the wrong realm. Configuring the `environment` lets `useEnvironment()` resolve to the iframe's own `document` and `window`. The example below renders the same probe twice — without the environment config (falls back to the global document/window) and with it (resolves to the iframe's):
 
@@ -84,16 +143,13 @@ The [useEnvironment](./useEnvironment) hook provides access to the correct `docu
 
 ```jsx
 const { getRootNode, getDocument, getWindow } = useEnvironment();
-
-const doc = getDocument();
-const win = getWindow();
-
-// Query elements in the correct context
-const element = doc.querySelector('#my-element');
-
-// Get computed styles from the correct window
-const styles = win.getComputedStyle(element);
 ```
+
+| | Standard browser | Shadow DOM | iframe |
+| :-- | :-- | :-- | :-- |
+| `getRootNode()` | `document` | `ShadowRoot` | `iframe.contentDocument` |
+| `getDocument()` | `document` | `shadowRoot.ownerDocument` | `iframe.contentDocument` |
+| `getWindow()` | `window` | `shadowRoot.ownerDocument.defaultView` | `iframe.contentWindow` |
 
 ## Props
 
@@ -110,11 +166,12 @@ The `useEnvironment` hook returns an object with the following methods:
 
 | Method | Return Type | Description |
 | :----- | :---------- | :---------- |
-| getRootNode | () => RootNode | Returns the root node of the current environment. |
-| getDocument | () => Document | Returns the document object for the current environment. |
-| getWindow | () => Window | Returns the window object for the current environment. |
+| getRootNode | () => RootNode | Returns the configured root node — `document` in a standard browser, `ShadowRoot` in a shadow DOM, or `iframe.contentDocument` in an iframe. |
+| getDocument | () => Document | Returns the `Document` for the current environment — `document` in a standard browser, `shadowRoot.ownerDocument` in a shadow DOM, or `iframe.contentDocument` in an iframe. |
+| getWindow | () => Window | Returns the `Window` for the current environment — `window` in a standard browser, `shadowRoot.ownerDocument.defaultView` in a shadow DOM, or `iframe.contentWindow` in an iframe. |
 
 ## See also
 
+- [Getting started › Micro frontend](../../getting-started/micro-frontend) — Module Federation and Wujie demos with live comparison
 - [Customization › Shadow DOM](../../customization/shadow-dom)
 - [useEnvironment](./useEnvironment)

--- a/packages/react-docs/pages/components/environment/index.page.mdx
+++ b/packages/react-docs/pages/components/environment/index.page.mdx
@@ -172,6 +172,5 @@ The `useEnvironment` hook returns an object with the following methods:
 
 ## See also
 
-- [Getting started › Micro frontend](../../getting-started/micro-frontend) — Module Federation and Wujie demos with live comparison
 - [Customization › Shadow DOM](../../customization/shadow-dom)
 - [useEnvironment](./useEnvironment)

--- a/packages/react-docs/pages/components/environment/usage-in-iframe-environment.js
+++ b/packages/react-docs/pages/components/environment/usage-in-iframe-environment.js
@@ -38,7 +38,7 @@ const IFrame = ({ children, ...rest }) => {
       border="none"
       {...rest}
     >
-      {mountNode && createPortal(children({ document: mountNode.ownerDocument }), mountNode)}
+      {!!mountNode && createPortal(children({ document: mountNode.ownerDocument }), mountNode)}
     </Box>
   );
 };
@@ -47,7 +47,16 @@ const IFrame = ({ children, ...rest }) => {
 // resolve to the iframe's own realm or to the global (top-level) one.
 const EnvironmentProbe = ({ frameDocument, title, description }) => {
   const [colorStyle] = useColorStyle();
-  const { getDocument, getWindow } = useEnvironment();
+  const { getRootNode, getDocument, getWindow } = useEnvironment();
+
+  useEffect(() => {
+    console.log('useEnvironment', {
+      getRootNode: getRootNode(),
+      getDocument: getDocument(),
+      getWindow: getWindow(),
+    });
+  }, [getRootNode, getDocument, getWindow]);
+
   const isIframeDocument = getDocument() === frameDocument;
   const isIframeWindow = getWindow() === frameDocument.defaultView;
 

--- a/packages/react-docs/pages/components/environment/usage-in-iframe.js
+++ b/packages/react-docs/pages/components/environment/usage-in-iframe.js
@@ -51,7 +51,7 @@ const IFrame = ({ children, ...rest }) => {
       {...styleProps}
       {...rest}
     >
-      {mountNode && createPortal(children({ document: mountNode.ownerDocument }), mountNode)}
+      {!!mountNode && createPortal(children({ document: mountNode.ownerDocument }), mountNode)}
     </Box>
   );
 };

--- a/packages/react-docs/pages/components/environment/usage-in-shadow-dom.js
+++ b/packages/react-docs/pages/components/environment/usage-in-shadow-dom.js
@@ -21,12 +21,40 @@ import {
   useColorStyle,
   usePortalManager,
 } from '@tonic-ui/react';
-import { useEffect, useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import BorderedBox from '@/components/BorderedBox';
 
 const NONCE = process.env.NONCE ?? '';
+
+const createShadowDOM = (container) => {
+  if (!(container instanceof Element)) {
+    throw new Error('createShadowDOM: container must be a DOM Element');
+  }
+
+  const shadowRoot = container.shadowRoot ?? container.attachShadow({ mode: 'open' });
+
+  shadowRoot.replaceChildren();
+  const mountElement = document.createElement('div');
+  mountElement.setAttribute('data-shadow-root', 'true');
+  mountElement.style.display = 'contents';
+  shadowRoot.appendChild(mountElement);
+
+  const root = createRoot(mountElement);
+
+  return {
+    shadowRoot,
+    render: (children) => root.render(children),
+    unmount: () => root.unmount(),
+  };
+};
+
+const useLayoutUnmount = (fn) => {
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+  useLayoutEffect(() => () => fnRef.current(), []);
+};
 
 const ModalComponent = ({ onClose }) => {
   return (
@@ -95,99 +123,56 @@ const ShadowDOMContent = () => {
 };
 
 const ShadowDOMContainer = ({ children, colorMode }) => {
-  const hostRef = useRef(null);
-  const shadowRootElementRef = useRef(null);
-  const rootRef = useRef(null);
+  const containerRef = useRef();
+  const shadowDOMRef = useRef();
+  const cacheRef = useRef();
+  const themeRef = useRef();
 
-  useEffect(() => {
-    const host = hostRef.current;
-    if (!host) {
+  // Re-runs on [children, colorMode] change — re-renders the shadow tree (reconcile)
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
       return;
     }
 
-    const shadowRoot = host.shadowRoot ?? host.attachShadow({ mode: 'open' });
-    const shadowRootElement = document.createElement('div');
-    shadowRoot.appendChild(shadowRootElement);
-    shadowRootElementRef.current = shadowRootElement;
-    rootRef.current = createRoot(shadowRootElement);
-
-    return () => {
-      setTimeout(() => {
-        rootRef.current?.unmount();
-        rootRef.current = null;
-        shadowRootElementRef.current = null;
-        shadowRoot.replaceChildren();
-      }, 0);
-    };
-  }, []);
-
-  useEffect(() => {
-    const shadowRootElement = shadowRootElementRef.current;
-    if (!(shadowRootElement instanceof HTMLElement)) {
-      return;
+    if (!shadowDOMRef.current) {
+      shadowDOMRef.current = createShadowDOM(container);
     }
-    const shadowRoot = shadowRootElement.parentNode;
 
-    // Create Emotion cache with shadow root as container
-    const cache = createCache({
-      key: 'css',
-      nonce: NONCE,
-      prepend: true,
-      container: shadowRoot,
-    });
+    if (!cacheRef.current) {
+      cacheRef.current = createCache({
+        key: 'tonic-ui-css',
+        nonce: NONCE,
+        prepend: true,
+        container: shadowDOMRef.current.shadowRoot,
+      });
+    }
 
-    // Create theme with CSS variables scoped to :host
-    const shadowTheme = createTheme({
-      cssVariables: {
-        prefix: 'tonic',
-        rootSelector: ':host',
-      },
-      components: {
-        Drawer: {
-          defaultProps: {
-            portalProps: {
-              containerRef: shadowRootElementRef,
-            },
-          },
+    // Create theme with CSS variables scoped to :container. Portal-based components
+    // (Modal, Drawer, Popper, ToastManager, PortalManager) resolve their portal
+    // container from the DOM tree they are mounted in (the shadow root), so they render
+    // inside the shadow root automatically — no per-component `containerRef` is needed.
+    // The `environment` config below is for resolving `getDocument()`/`getWindow()`
+    // to the correct realm, not for portal placement.
+    if (!themeRef.current) {
+      themeRef.current = createTheme({
+        cssVariables: {
+          prefix: 'tonic-ui',
+          rootSelector: ':host',
         },
-        Modal: {
-          defaultProps: {
-            portalProps: {
-              containerRef: shadowRootElementRef,
-            },
-          },
-        },
-        Popper: {
-          defaultProps: {
-            portalProps: {
-              containerRef: shadowRootElementRef,
-            },
-          },
-        },
-        PortalManager: {
-          defaultProps: {
-            containerRef: shadowRootElementRef,
-          },
-        },
-        ToastManager: {
-          defaultProps: {
-            containerRef: shadowRootElementRef,
-          },
-        },
-      },
-    });
+      });
+    }
 
-    const root = rootRef.current;
-    root.render(
-      <CacheProvider value={cache}>
+    shadowDOMRef.current.render(
+      <CacheProvider value={cacheRef.current}>
         <TonicProvider
           colorMode={{
             value: colorMode,
           }}
           environment={{
-            value: shadowRoot,
+            value: shadowDOMRef.current.shadowRoot,
           }}
-          theme={shadowTheme}
+          theme={themeRef.current}
         >
           <ToastManager>
             <PortalManager>
@@ -199,7 +184,15 @@ const ShadowDOMContainer = ({ children, colorMode }) => {
     );
   }, [children, colorMode]);
 
-  return <Box ref={hostRef} />;
+  // Cleanup runs only on unmount — destroys the shadow tree
+  useLayoutUnmount(() => {
+    shadowDOMRef.current?.unmount();
+    shadowDOMRef.current = null;
+    cacheRef.current = null;
+    themeRef.current = null;
+  });
+
+  return <Box ref={containerRef} />;
 };
 
 const App = () => {

--- a/packages/react-docs/pages/components/environment/useEnvironment/index.page.mdx
+++ b/packages/react-docs/pages/components/environment/useEnvironment/index.page.mdx
@@ -21,15 +21,22 @@ import { useEnvironment } from '@tonic-ui/react';
 const { getRootNode, getDocument, getWindow } = useEnvironment();
 ```
 
+| | Standard browser | Shadow DOM | iframe |
+| :-- | :-- | :-- | :-- |
+| `getRootNode()` | `document` | `ShadowRoot` | `iframe.contentDocument` |
+| `getDocument()` | `document` | `shadowRoot.ownerDocument` | `iframe.contentDocument` |
+| `getWindow()` | `window` | `shadowRoot.ownerDocument.defaultView` | `iframe.contentWindow` |
+
+
 ### Returns
 
 The hook returns an object with the following methods:
 
 | Method | Return Type | Description |
 | :----- | :---------- | :---------- |
-| getRootNode | () => RootNode | Returns the root node of the current environment (Document, ShadowRoot, or Node). |
-| getDocument | () => Document | Returns the document object for the current environment. |
-| getWindow | () => Window | Returns the window object for the current environment. |
+| getRootNode | () => RootNode | Returns the configured root node — `document` in a standard browser, `ShadowRoot` in a shadow DOM, or `iframe.contentDocument` in an iframe. |
+| getDocument | () => Document | Returns the `Document` for the current environment — `document` in a standard browser, `shadowRoot.ownerDocument` in a shadow DOM, or `iframe.contentDocument` in an iframe. |
+| getWindow | () => Window | Returns the `Window` for the current environment — `window` in a standard browser, `shadowRoot.ownerDocument.defaultView` in a shadow DOM, or `iframe.contentWindow` in an iframe. |
 
 ## Demos
 

--- a/packages/react-docs/pages/components/environment/useEnvironment/viewport-size.js
+++ b/packages/react-docs/pages/components/environment/useEnvironment/viewport-size.js
@@ -2,10 +2,16 @@ import { Box, Text, useEnvironment } from '@tonic-ui/react';
 import { useEffect, useState } from 'react';
 
 const App = () => {
-  const { getWindow } = useEnvironment();
+  const { getRootNode, getDocument, getWindow } = useEnvironment();
   const [size, setSize] = useState({ width: 0, height: 0 });
 
   useEffect(() => {
+    console.log('useEnvironment', {
+      getRootNode: getRootNode(),
+      getDocument: getDocument(),
+      getWindow: getWindow(),
+    });
+
     const win = getWindow();
 
     const updateSize = () => {
@@ -19,7 +25,7 @@ const App = () => {
     win.addEventListener('resize', updateSize);
 
     return () => win.removeEventListener('resize', updateSize);
-  }, [getWindow]);
+  }, [getRootNode, getDocument, getWindow]);
 
   return (
     <Box>

--- a/packages/react-docs/pages/customization/shadow-dom/index.page.mdx
+++ b/packages/react-docs/pages/customization/shadow-dom/index.page.mdx
@@ -1,134 +1,42 @@
 # Shadow DOM
 
-The shadow DOM allows you to encapsulate parts of your application, isolating them from global styles and preventing interference with the regular DOM tree.
+The shadow DOM encapsulates parts of your application, isolating them from global styles and preventing interference with the regular DOM tree.
 
-## Getting started
+This page covers two setup patterns, depending on where you mount your app.
 
-To enable styling within the shadow DOM, start by importing `createCache` and `CacheProvider`:
+## Global root
 
-```js
+Use this pattern when mounting outside a React tree — for example in an MFE entry point, a web component lifecycle callback, or any `main.js`-style entry point.
+
+```jsx
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
-```
+import { TonicProvider, ToastManager, PortalManager, createTheme } from '@tonic-ui/react';
 
-### 1. Applying styles inside the shadow DOM
+const container = document.getElementById('root');
+const shadowDOM = createShadowDOM(container);
 
-The shadow DOM creates an isolated DOM tree attached to a host element, helping prevent style conflicts across components. Below is an example of how to create and style a shadow DOM:
-
-```js
-const container = document.querySelector('#root');
-const shadowContainer = container.shadowRoot || container.attachShadow({ mode: 'open' });
-const shadowRootElement = document.createElement('div');
-shadowContainer.appendChild(shadowRootElement);
-
-// If you're using a functional component, you might want to use `useRef` to store the `shadowRootElement`.
-const shadowRootElementRef = {
-  current: shadowRootElement,
-};
-
-// https://emotion.sh/docs/@emotion/cache
 const cache = createCache({
   key: 'tonic-css',
   prepend: true,
-  container: shadowContainer,
-  nonce: process.env.CSP_NONCE || 'your-nonce-string', // [optional] to comply with Content Security Policy (CSP) for inline execution
+  container: shadowDOM.shadowRoot,
 });
-```
 
-### 2. Theming components inside the shadow DOM
-
-`PortalManager`, `ToastManager`, and components such as `Drawer`, `Modal`, and `Popper` render outside the main DOM hierarchy through a `Portal`, which defaults to `document.body`. To maintain consistent theming inside the shadow DOM, proper configuration is needed.
-
-Below is an example configuration using a custom theme:
-
-```js
-const shadowTheme = createTheme({
-  components: {
-    Drawer: {
-      defaultProps: {
-        portalProps: {
-          containerRef: shadowRootElementRef,
-        },
-      },
-    },
-    Modal: {
-      defaultProps: {
-        portalProps: {
-          containerRef: shadowRootElementRef,
-        },
-      },
-    },
-    Popper: {
-      defaultProps: {
-        portalProps: {
-          containerRef: shadowRootElementRef,
-        },
-      },
-    },
-    PortalManager: {
-      defaultProps: {
-        containerRef: shadowRootElementRef,
-      },
-    },
-    ToastManager: {
-      defaultProps: {
-        containerRef: shadowRootElementRef,
-      },
-    },
-  },
-});
-```
-
-### 3. Using CSS theme variables (optional)
-
-To use CSS theme variables within the shadow DOM, specify the root selector for generating the CSS variables:
-
-```js
-const shadowTheme = createTheme({
+const theme = createTheme({
   cssVariables: {
     prefix: 'tonic',
     rootSelector: ':host',
   },
-  components: {
-    // Same as the above step
-  },
 });
-```
 
-### 4. Rendering components inside the shadow DOM
-
-The following code snippet demonstrates how to render components inside the shadow DOM:
-
-```jsx
-ReactDOM.createRoot(shadowRootElement).render(
+shadowDOM.render(
   <CacheProvider value={cache}>
     <TonicProvider
-      colorMode={{
-        value: colorMode,
-      }}
-      theme={shadowTheme}
+      colorMode={{ value: 'light' }}
+      environment={{ value: shadowDOM.shadowRoot }}
+      theme={theme}
     >
-      <ToastManager
-        // Ensure that `ToastManager` is positioned above `PortalManager` to allow toast notifications to be displayed within a portal.
-        slotProps={{
-          transition: {
-            sx: {
-              '[data-toast-placement^="top"] > &:first-of-type': {
-                mt: '4x', // the space to the top edge of the screen
-              },
-              '[data-toast-placement^="bottom"] > &:last-of-type': {
-                mb: '4x', // the space to the bottom edge of the screen
-              },
-              '[data-toast-placement$="left"] > &': {
-                ml: '4x', // the space to the left edge of the screen
-              },
-              '[data-toast-placement$="right"] > &': {
-                mr: '4x', // the space to the right edge of the screen
-              },
-            },
-          },
-        }}
-      >
+      <ToastManager>
         <PortalManager>
           <App />
         </PortalManager>
@@ -138,9 +46,140 @@ ReactDOM.createRoot(shadowRootElement).render(
 );
 ```
 
+**What each piece does:**
+
+| Piece | Purpose |
+| :---- | :------ |
+| `createCache({ container: shadowRoot })` | Injects Emotion `<style>` tags into the shadow root instead of `<head>`, keeping styles scoped inside the shadow boundary |
+| `createTheme({ rootSelector: ':host' })` | Emits CSS variables on the shadow host element (`:host`) so they are visible inside the shadow tree |
+| `environment={{ value: shadowRoot }}` | Tells portal-based components (`Modal`, `Drawer`, `Tooltip`, `ToastManager`) to resolve their portal container from the shadow root instead of `document` |
+
+### `createShadowDOM` helper
+
+Copy this helper into your project. It attaches a shadow root to a host element, creates a React root inside it, and returns a `{ shadowRoot, render, unmount }` object modelled after React's own `createRoot` API.
+
+```js
+import { createRoot } from 'react-dom/client';
+
+const createShadowDOM = (container) => {
+  if (!(container instanceof Element)) {
+    throw new Error('createShadowDOM: container must be a DOM Element');
+  }
+
+  const shadowRoot = container.shadowRoot ?? container.attachShadow({ mode: 'open' });
+
+  shadowRoot.replaceChildren();
+  const mountElement = document.createElement('div');
+  mountElement.setAttribute('data-shadow-root', 'true');
+  mountElement.style.display = 'contents';
+  shadowRoot.appendChild(mountElement);
+
+  const root = createRoot(mountElement);
+
+  return {
+    shadowRoot,
+    render: (children) => root.render(children),
+    unmount: () => root.unmount(),
+  };
+};
+```
+
+## React component wrapper
+
+Use this pattern when your shadow DOM host lives inside an existing React tree — for example in a docs site, a dashboard embedding a widget, or anywhere you control the host element's lifecycle via React.
+
+```jsx
+import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
+import { TonicProvider, ToastManager, PortalManager, createTheme } from '@tonic-ui/react';
+import { useLayoutEffect, useRef } from 'react';
+
+const ShadowDOMContainer = ({ children, colorMode, ...rest }) => {
+  const containerRef = useRef();
+  const shadowDOMRef = useRef();
+  const cacheRef = useRef();
+  const themeRef = useRef();
+
+  // Re-runs on [children, colorMode] change — re-renders the shadow tree (reconcile)
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    if (!shadowDOMRef.current) {
+      shadowDOMRef.current = createShadowDOM(container);
+    }
+
+    if (!cacheRef.current) {
+      cacheRef.current = createCache({
+        key: 'tonic-css',
+        prepend: true,
+        container: shadowDOMRef.current.shadowRoot,
+      });
+    }
+
+    if (!themeRef.current) {
+      themeRef.current = createTheme({
+        cssVariables: {
+          prefix: 'tonic',
+          rootSelector: ':host',
+        },
+      });
+    }
+
+    shadowDOMRef.current.render(
+      <CacheProvider value={cacheRef.current}>
+        <TonicProvider
+          colorMode={{ value: colorMode }}
+          environment={{ value: shadowDOMRef.current.shadowRoot }}
+          theme={themeRef.current}
+        >
+          <ToastManager>
+            <PortalManager>
+              {children}
+            </PortalManager>
+          </ToastManager>
+        </TonicProvider>
+      </CacheProvider>
+    );
+  }, [children, colorMode]);
+
+  // Cleanup runs only on unmount — destroys the shadow tree
+  useLayoutUnmount(() => {
+    shadowDOMRef.current?.unmount();
+    shadowDOMRef.current = null;
+    cacheRef.current = null;
+    themeRef.current = null;
+  });
+
+  return <div ref={containerRef} {...rest} />;
+};
+```
+
+**Why two separate layout effects:**
+
+The first `useLayoutEffect` re-renders the shadow tree on every `[children, colorMode]` change via React reconciliation — the root stays alive. The `useLayoutUnmount` cleanup runs only on component unmount, destroying the root exactly once.
+
+Putting `unmount()` in the first effect's cleanup would destroy and recreate the shadow tree on every prop change, losing all component state inside and causing visual flashes.
+
+### `useLayoutUnmount` helper
+
+A semantic wrapper for the cleanup-only `useLayoutEffect` pattern. It uses `useLayoutEffect` (not `useEffect`) so inner layout-effect cleanups inside the shadow tree run synchronously during the same commit phase.
+
+```js
+import { useLayoutEffect, useRef } from 'react';
+
+const useLayoutUnmount = (fn) => {
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+  useLayoutEffect(() => () => fnRef.current(), []);
+};
+```
+
 ## Demo
 
-This example applies a global button style. The button outside the shadow DOM inherits the global styling, while the button inside the shadow DOM remains unaffected:
+This example applies a global button style. The button outside the shadow DOM inherits it; the button inside the shadow DOM stays unaffected:
 
 ```jsx
 sx={{

--- a/packages/react-docs/pages/customization/shadow-dom/shadow-dom.js
+++ b/packages/react-docs/pages/customization/shadow-dom/shadow-dom.js
@@ -34,10 +34,38 @@ import {
   useToggle,
 } from '@tonic-ui/react-hooks';
 import BorderedBox from '@/components/BorderedBox';
-import { useEffect, useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 
 const NONCE = process.env.NONCE ?? '';
+
+const createShadowDOM = (container) => {
+  if (!(container instanceof Element)) {
+    throw new Error('createShadowDOM: container must be a DOM Element');
+  }
+
+  const shadowRoot = container.shadowRoot ?? container.attachShadow({ mode: 'open' });
+
+  shadowRoot.replaceChildren();
+  const mountElement = document.createElement('div');
+  mountElement.setAttribute('data-shadow-root', 'true');
+  mountElement.style.display = 'contents';
+  shadowRoot.appendChild(mountElement);
+
+  const root = createRoot(mountElement);
+
+  return {
+    shadowRoot,
+    render: (children) => root.render(children),
+    unmount: () => root.unmount(),
+  };
+};
+
+const useLayoutUnmount = (fn) => {
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+  useLayoutEffect(() => () => fnRef.current(), []);
+};
 
 const DrawerComponent = ({ isOpen, onClose }) => {
   return (
@@ -122,98 +150,49 @@ const ModalComponent = ({ isOpen, onClose }) => {
 
 const ShadowDOMContainer = ({ children, colorMode, ...rest }) => {
   const containerRef = useRef();
-  const shadowRootElementRef = useRef();
-  const rootRef = useRef();
+  const shadowDOMRef = useRef();
+  const cacheRef = useRef();
+  const themeRef = useRef();
 
-  useEffect(() => {
+  // Re-runs on [children, colorMode] change — re-renders the shadow tree (reconcile)
+  useLayoutEffect(() => {
     const container = containerRef.current;
     if (!container) {
-      return () => {};
-    }
-
-    const shadowContainer = container.shadowRoot ?? container.attachShadow({ mode: 'open' });
-    const shadowRootElement = document.createElement('div');
-    shadowContainer.appendChild(shadowRootElement);
-    shadowRootElementRef.current = shadowRootElement;
-    rootRef.current = createRoot(shadowRootElement);
-
-    return () => {
-      setTimeout(() => {
-        rootRef.current.unmount(); // Clean up React state
-        rootRef.current = null;
-        shadowRootElementRef.current = null; // Clear the reference
-        shadowContainer.replaceChildren(); // Clear the shadow DOM content
-      }, 0);
-    };
-  }, []); // Run only once on mount
-
-  useEffect(() => {
-    const shadowRootElement = shadowRootElementRef.current;
-    if (!(shadowRootElement instanceof HTMLElement)) {
-      console.error('The shadow root element is not an HTMLElement.');
       return;
     }
-    const shadowContainer = shadowRootElement.parentNode;
 
-    // https://emotion.sh/docs/@emotion/cache
-    const cache = createCache({
-      key: 'tonic-css',
-      nonce: NONCE, // Needed to comply with Content Security Policy (CSP) for inline execution
-      prepend: true,
-      container: shadowContainer,
-    });
+    if (!shadowDOMRef.current) {
+      shadowDOMRef.current = createShadowDOM(container);
+    }
 
-    const shadowTheme = createTheme({
-      cssVariables: {
-        prefix: 'tonic',
-        rootSelector: ':host',
-      },
-      components: {
-        Drawer: {
-          defaultProps: {
-            portalProps: {
-              containerRef: shadowRootElementRef,
-            },
-          },
-        },
-        Modal: {
-          defaultProps: {
-            portalProps: {
-              containerRef: shadowRootElementRef,
-            },
-          },
-        },
-        Popper: {
-          defaultProps: {
-            portalProps: {
-              containerRef: shadowRootElementRef,
-            },
-          },
-        },
-        PortalManager: {
-          defaultProps: {
-            containerRef: shadowRootElementRef,
-          },
-        },
-        ToastManager: {
-          defaultProps: {
-            containerRef: shadowRootElementRef,
-          },
-        },
-      },
-    });
+    if (!cacheRef.current) {
+      cacheRef.current = createCache({
+        key: 'tonic-css',
+        nonce: NONCE,
+        prepend: true,
+        container: shadowDOMRef.current.shadowRoot,
+      });
+    }
 
-    const root = rootRef.current;
-    root.render(
-      <CacheProvider value={cache}>
+    if (!themeRef.current) {
+      themeRef.current = createTheme({
+        cssVariables: {
+          prefix: 'tonic',
+          rootSelector: ':host',
+        },
+      });
+    }
+
+    shadowDOMRef.current.render(
+      <CacheProvider value={cacheRef.current}>
         <TonicProvider
           colorMode={{
             value: colorMode,
           }}
           environment={{
-            value: () => shadowContainer.getRootNode(),
+            value: shadowDOMRef.current.shadowRoot,
           }}
-          theme={shadowTheme}
+          theme={themeRef.current}
         >
           <ToastManager
             slotProps={{
@@ -244,8 +223,16 @@ const ShadowDOMContainer = ({ children, colorMode, ...rest }) => {
     );
   }, [children, colorMode]);
 
+  // Cleanup runs only on unmount — destroys the shadow tree
+  useLayoutUnmount(() => {
+    shadowDOMRef.current?.unmount();
+    shadowDOMRef.current = null;
+    cacheRef.current = null;
+    themeRef.current = null;
+  });
+
   return (
-    <div ref={containerRef} {...rest} />
+    <Box ref={containerRef} {...rest} />
   );
 };
 
@@ -253,6 +240,7 @@ const InsideShadowDOMComponent = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useToggle(false);
   const [isModalOpen, setIsModalOpen] = useToggle(false);
   const toast = useToastManager();
+
   const handleOpenDrawer = () => {
     setIsDrawerOpen(true);
   };
@@ -336,6 +324,7 @@ const OutsideShadowDOMComponent = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useToggle(false);
   const [isModalOpen, setIsModalOpen] = useToggle(false);
   const toast = useToastManager();
+
   const handleOpenDrawer = () => {
     setIsDrawerOpen(true);
   };
@@ -400,10 +389,7 @@ const OutsideShadowDOMComponent = () => {
         >
           Show Toast Notification
         </Button>
-        <Tooltip
-          portalled
-          label="This is a tooltip"
-        >
+        <Tooltip label="This is a tooltip">
           <Button variant="secondary">
             Display Tooltip on Hover
           </Button>
@@ -419,20 +405,12 @@ const App = () => {
   const [colorMode] = useColorMode();
 
   return (
-    <Box
-      sx={{
-        'button': {
-          opacity: '.65 !important',
-        },
-      }}
-    >
-      <Stack spacing="4x">
-        <ShadowDOMContainer colorMode={colorMode}>
-          <InsideShadowDOMComponent />
-        </ShadowDOMContainer>
-        <OutsideShadowDOMComponent />
-      </Stack>
-    </Box>
+    <>
+      <OutsideShadowDOMComponent />
+      <ShadowDOMContainer colorMode={colorMode}>
+        <InsideShadowDOMComponent />
+      </ShadowDOMContainer>
+    </>
   );
 };
 

--- a/packages/react-docs/pages/getting-started/color-mode/index.page.mdx
+++ b/packages/react-docs/pages/getting-started/color-mode/index.page.mdx
@@ -1,4 +1,0 @@
-import ColorMode from '../../components/color-mode/index.page.mdx';
-
-<ColorMode />
-

--- a/packages/react-docs/pages/getting-started/color-style/index.page.mdx
+++ b/packages/react-docs/pages/getting-started/color-style/index.page.mdx
@@ -1,4 +1,0 @@
-import ColorStyle from '../../components/color-style/index.page.mdx';
-
-<ColorStyle />
-

--- a/packages/react-docs/pages/llms.txt
+++ b/packages/react-docs/pages/llms.txt
@@ -6,13 +6,15 @@
 
 [Usage]({{PAGE_BASE}}/getting-started/usage/): <classification>LLM should read this page when starting to use Tonic UI components, setting up the theme provider, or implementing basic component usage patterns in your application.</classification>
 
+[Color mode]({{PAGE_BASE}}/components/color-mode/): <classification>LLM should read this page when implementing dark/light mode switching, understanding color mode context, or configuring theme-aware components that respond to color mode changes.</classification>
+
+[Color style]({{PAGE_BASE}}/components/color-style/): <classification>LLM should read this page when working with color styling approaches, implementing custom color schemes, or using color tokens and semantic color naming conventions.</classification>
+
+[Environment]({{PAGE_BASE}}/components/environment/): <classification>LLM should read this page when rendering Tonic One components inside non-standard DOM environments such as iframes or shadow DOM, configuring the EnvironmentProvider and the TonicProvider environment prop, or resolving the correct document/window for portals, focus tracking, and event listeners across realms.</classification>
+
+[Icons]({{PAGE_BASE}}/icons/): <classification>LLM should read this page when using icons in Tonic One, implementing custom icon components, or working with the Icon and SVGIcon components for displaying iconography.</classification>
+
 [AI assistant with MCP]({{PAGE_BASE}}/getting-started/mcp/): <classification>LLM should read this page when accessing the Model Context Protocol (MCP) server for Tonic UI documentation and resources.</classification>
-
-[Color mode]({{PAGE_BASE}}/getting-started/color-mode/): <classification>LLM should read this page when implementing dark/light mode switching, understanding color mode context, or configuring theme-aware components that respond to color mode changes.</classification>
-
-[Color style]({{PAGE_BASE}}/getting-started/color-style/): <classification>LLM should read this page when working with color styling approaches, implementing custom color schemes, or using color tokens and semantic color naming conventions.</classification>
-
-[Icons]({{PAGE_BASE}}/getting-started/icons/): <classification>LLM should read this page when using icons in Tonic UI, implementing custom icon components, or working with the Icon and SVGIcon components for displaying iconography.</classification>
 
 [The sx prop]({{PAGE_BASE}}/getting-started/the-sx-prop/): <classification>LLM should read this page when using the sx prop for custom styling, applying theme-aware styles, or implementing responsive styling patterns across components.</classification>
 
@@ -212,6 +214,8 @@
 
 [Image]({{PAGE_BASE}}/components/image/): <classification>LLM should read this page when using the Image component as a replacement for the HTML img tag, displaying static images, or working with inline SVG content. The Image component provides a simple wrapper for image display with proper alt text support and src path specification.</classification>
 
+[SVGIcon]({{PAGE_BASE}}/components/svg-icon/): <classification>LLM should read this page when using the SVGIcon component for custom SVG icons, creating accessible SVG icons with automatic scaling, implementing custom icon components with createSVGIcon utility, or working with external SVG files using the as prop with svgr loaders.</classification>
+
 ### Navigation
 
 [Link]({{PAGE_BASE}}/components/link/): <classification>LLM should read this page when using the Link component for navigation and hyperlinks, implementing accessible link functionality, or creating both internal and external navigation with proper styling. Related to ButtonLink and LinkButton components.</classification>
@@ -268,13 +272,13 @@
 
 [PortalManager]({{PAGE_BASE}}/components/portal-manager/): <classification>LLM should read this page when setting up portal management in applications, creating and managing multiple portals programmatically, or implementing modal systems that require centralized portal control and lifecycle management.</classification>
 
-[usePortalManager]({{PAGE_BASE}}/components/portal-manager/usePortalManager/): <classification>LLM should read this page when using the usePortalManager hook to create, remove, and manage portals programmatically, implementing dynamic modal creation, or building custom overlay components that need portal functionality with lifecycle control.</classification>
-
 [ResizeHandle]({{PAGE_BASE}}/components/resize-handle/): <classification>LLM should read this page when implementing resizable UI elements, adding resize functionality to tables, tree views, or panels, or creating interactive resize handles withdrag-and-drop behavior and visual feedback.</classification>
 
 [Scrollbar]({{PAGE_BASE}}/components/scrollbar/): <classification>LLM should read this page when implementing custom scrollbars with consistent cross-platform appearance, creating scrollable content areas with custom styling, controlling scroll behavior, or integrating with virtualization libraries like React Virtuoso.</classification>
 
 [VisuallyHidden]({{PAGE_BASE}}/components/visually-hidden/): <classification>LLM should read this page when implementing accessibility features that hide content visually but keep it available to screen readers, creating accessible form labels, or providing screen reader-only content for better accessibility compliance.</classification>
+
+[usePortalManager]({{PAGE_BASE}}/components/portal-manager/usePortalManager/): <classification>LLM should read this page when using the usePortalManager hook to create, remove, and manage portals programmatically, implementing dynamic modal creation, or building custom overlay components that need portal functionality with lifecycle control.</classification>
 
 [useSlot]({{PAGE_BASE}}/components/slot/useSlot/): <classification>LLM should read this page when building Tonic UI components that expose a slots/slotProps API, swapping out a component's internal elements, forwarding props to internal slots, or customizing component structure without forking the component.</classification>
 

--- a/packages/react/src/portal/Portal.js
+++ b/packages/react/src/portal/Portal.js
@@ -17,6 +17,7 @@ const Portal = (inProps) => {
     containerRef,
   } = useDefaultProps({ props: inProps, name: 'Portal' });
   const [doc, setDoc] = useState(null);
+  const [rootNode, setRootNode] = useState(null);
   const portalRef = useRef(null);
   const parentPortal = useContext(PortalContext);
 
@@ -36,11 +37,36 @@ const Portal = (inProps) => {
         return containerEl;
       }
 
-      if (appendToParentPortal) {
-        return parentPortal ?? doc.body;
+      // Default host resolution. `rootNode` is the native `Node.getRootNode()` of the
+      // probe node — the root of the tree the portal is actually mounted in — so portals
+      // land in the correct DOM context instead of always falling back to `document.body`:
+      //
+      //   where Portal is mounted | rootNode (node.getRootNode()) | host
+      //   ----------------------- | ----------------------------- | ----------------------
+      //   Shadow DOM              | ShadowRoot                    | the ShadowRoot
+      //   iframe                  | the iframe's Document         | doc.body (iframe body)
+      //   normal page             | Document                      | doc.body
+      //
+      // A `ShadowRoot` is the only root we portal into directly, and it is the only root
+      // whose `.host` is an element (the shadow host). A `Document`, a detached `Element`,
+      // or a plain `DocumentFragment` has no element host (note `<a>`/`<area>` expose a
+      // *string* `.host`), so those fall back to `doc.body` — preserving the iframe and
+      // normal-page behavior and avoiding an off-document host for detached trees.
+      const defaultHost = (rootNode && rootNode.host?.nodeType === Node.ELEMENT_NODE)
+        ? rootNode
+        : doc.body;
+
+      // `appendToParentPortal` nests inside the enclosing portal — but only when that portal
+      // lives in the same document we render into. With no parent, or a parent from another
+      // realm (e.g. an outer page's Portal whose React context crossed an iframe boundary, so
+      // `parentPortal` belongs to the parent document while `doc` is the iframe's), fall back
+      // to the default host so the portal stays in the correct document / shadow root instead
+      // of being appended cross-document.
+      if (appendToParentPortal && parentPortal?.ownerDocument === doc) {
+        return parentPortal;
       }
 
-      return doc.body;
+      return defaultHost;
     })();
 
     if (!host) {
@@ -60,15 +86,15 @@ const Portal = (inProps) => {
         host.removeChild(portalNode);
       }
     };
-  }, [doc]);
+  }, [doc, rootNode]);
 
   if (!portalRef.current) {
     return (
       <Box
         ref={(node) => {
           if (node) {
-            const ownerDocument = getOwnerDocument(node);
-            setDoc(ownerDocument);
+            setDoc(getOwnerDocument(node));
+            setRootNode(node.getRootNode());
           }
         }}
       />

--- a/packages/react/src/portal/__tests__/Portal.test.js
+++ b/packages/react/src/portal/__tests__/Portal.test.js
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { screen } from '@testing-library/react';
 import { render } from '@tonic-ui/react/test-utils/render';
 import { Portal } from '@tonic-ui/react/src';
+import { PortalContext } from '@tonic-ui/react/src/portal/context';
 
 describe('Portal', () => {
   it('should render correctly', () => {
@@ -68,5 +69,101 @@ describe('Portal', () => {
     const content = screen.getByTestId('content');
     const container = screen.getByTestId('container');
     expect(container).toContainElement(content);
+  });
+
+  it('should render into document.body by default', () => {
+    render(
+      <Portal>
+        <div data-testid="content">Hello world</div>
+      </Portal>
+    );
+
+    // Key off the content's own portal — the wrapper's ToastManager/PortalManager also
+    // render `.tonic-ui-portal` nodes into document.body, so a first-match query is ambiguous.
+    const content = screen.getByTestId('content');
+    const portalEl = content.closest(Portal.selector);
+    expect(portalEl).not.toBeNull();
+    expect(document.body).toContainElement(portalEl);
+  });
+
+  it('should render into the shadow root when mounted inside one', () => {
+    // Mount the Portal's tree inside a shadow root so the probe node's native
+    // `getRootNode()` resolves to the ShadowRoot — the portal must land there,
+    // not in the host document's body. The host stays detached so the test leaves
+    // nothing behind in document.body even if an assertion throws.
+    const host = document.createElement('div');
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    const container = document.createElement('div');
+    shadowRoot.appendChild(container);
+
+    render(
+      <Portal>
+        <div data-testid="shadow-content">Hello shadow</div>
+      </Portal>,
+      { container }
+    );
+
+    const content = shadowRoot.querySelector('[data-testid="shadow-content"]');
+    const portalEl = shadowRoot.querySelector(Portal.selector);
+    expect(portalEl).not.toBeNull();
+    expect(portalEl).toContainElement(content);
+    // It must NOT leak into the host document's body.
+    expect(document.body.querySelector('[data-testid="shadow-content"]')).toBeNull();
+  });
+
+  it('should fall back to document.body when mounted in a detached fragment', () => {
+    // A detached DocumentFragment is not a ShadowRoot (it has no `host`), so the portal
+    // must fall back to document.body instead of being appended into the off-document fragment.
+    const fragment = document.createDocumentFragment();
+
+    render(
+      <Portal>
+        <div data-testid="fragment-content">Hello fragment</div>
+      </Portal>,
+      { container: fragment }
+    );
+
+    expect(document.body.querySelector('[data-testid="fragment-content"]')).not.toBeNull();
+    expect(fragment.querySelector('[data-testid="fragment-content"]')).toBeNull();
+  });
+
+  it('should fall back to the shadow root for a top-level appendToParentPortal portal', () => {
+    // With no enclosing portal, `appendToParentPortal` must fall back to the same default
+    // host as a normal portal — the shadow root — not escape to the host document's body.
+    const host = document.createElement('div');
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    const container = document.createElement('div');
+    shadowRoot.appendChild(container);
+
+    render(
+      <Portal appendToParentPortal>
+        <div data-testid="append-content">Hello shadow</div>
+      </Portal>,
+      { container }
+    );
+
+    expect(shadowRoot.querySelector('[data-testid="append-content"]')).not.toBeNull();
+    expect(document.body.querySelector('[data-testid="append-content"]')).toBeNull();
+  });
+
+  it('should not nest into a parent portal from a different document (appendToParentPortal)', () => {
+    // React PortalContext propagates through a `createPortal` iframe boundary, so an outer
+    // page's portal can become `parentPortal` while this portal mounts in another document.
+    // appendToParentPortal must NOT append cross-document; it falls back to the local host.
+    const otherDoc = document.implementation.createHTMLDocument('other');
+    const foreignParent = otherDoc.createElement('div');
+    otherDoc.body.appendChild(foreignParent);
+
+    render(
+      <PortalContext.Provider value={foreignParent}>
+        <Portal appendToParentPortal>
+          <div data-testid="xdoc-content">Hello</div>
+        </Portal>
+      </PortalContext.Provider>
+    );
+
+    // Must NOT be appended into the foreign-document parent; stays in the local document.body.
+    expect(foreignParent.querySelector('[data-testid="xdoc-content"]')).toBeNull();
+    expect(document.body.querySelector('[data-testid="xdoc-content"]')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Phase 1 of porting the Tonic One `EnvironmentProvider` work to Tonic UI v2. The `EnvironmentProvider` / `useEnvironment` core already landed in `v2` (#1088); this PR adds the remaining environment-related change and brings the docs up to date.

### Changes
- **`Portal` resolves its default container via `Node.getRootNode()`** — portal-based components (Modal, Drawer, Popper, PortalManager, ToastManager) now render inside a shadow root automatically when the app is mounted there. Falls back to `document.body` for iframe / normal page / detached fragments; an explicit `containerRef` still overrides.
- **Docs sync** — environment usage docs (iframe, shadow DOM, `useEnvironment`) and the shadow-dom customization page updated to the latest content (`createShadowDOM` pattern, `useLayoutUnmount`). Color mode / color style getting-started pages become sidebar redirects to their component pages.

### Test plan
- `packages/react`: Portal tests 11/11 green; environment test suites 32/32 green
- `next build` of the docs site succeeds (165 pages)
- lint clean

> Note: the micro-frontend examples and the styled-system engine work are intentionally **not** in this PR — they depend on the new theming engine and ship in the follow-up Phase 2 PR.
