### PR TITLE
ci: deploy v3 docs to standalone repositories and add PR preview publishing

### DIFF
--- a/.github/workflows/ci-branch.yml
+++ b/.github/workflows/ci-branch.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -51,7 +51,7 @@ jobs:
           echo "CI_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
           echo "MATOMO_URL=//matomo.xdr.trendmicro.com" >> $GITHUB_ENV
           echo "MATOMO_CONTAINER_ID=N8rpl9LU" >> $GITHUB_ENV
-          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui/react/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
+          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui-docs/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
           echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
 
           # $GITHUB_OUTPUT is shared between all steps in a job
@@ -104,24 +104,18 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-tonic-ui-docs
+      cancel-in-progress: false
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
         with:
-          repository: ${{ github.repository }}
-          ref: gh-pages
-
-      - name: git config
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Configure environment variables
-        env:
-          TONIC_UI_REACT_DOCS_VERSION: ${{ needs.build.outputs.TONIC_UI_REACT_DOCS_VERSION }}
-        run: |
-          echo "CI_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
-          echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_DOCS_VERSION}" >> $GITHUB_ENV
+          app-id: ${{ vars.DEPLOY_APP_ID || secrets.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: tonic-ui-docs
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -134,11 +128,61 @@ jobs:
           mkdir -p artifact/react-docs
           tar -zxvf artifact/react-docs.tar.gz --directory artifact/react-docs
 
-      - name: Deploy to gh-pages
+      - name: Deploy to tonic-ui-docs
+        env:
+          DEPLOY_TOKEN: ${{ steps.app-token.outputs.token }}
+          TONIC_UI_REACT_DOCS_VERSION: ${{ needs.build.outputs.TONIC_UI_REACT_DOCS_VERSION }}
+          WRITE_ROOT_REDIRECT: ${{ github.ref_name == 'main' }}
+          OWNER: ${{ github.repository_owner }}
+          SOURCE_SHA: ${{ github.sha }}
         run: |
-          rm -rf "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          mkdir -p "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          cp -af artifact/react-docs/** "react/${TONIC_UI_REACT_DOCS_VERSION}/"
-          git add "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          git commit -m "Deploy ${CI_COMMIT:0:8} to gh-pages [skip ci]"
-          git push origin gh-pages
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          REMOTE="https://x-access-token:${DEPLOY_TOKEN}@github.com/${OWNER}/tonic-ui-docs.git"
+          TARGET_DIR="${RUNNER_TEMP}/tonic-ui-docs"
+
+          for attempt in 1 2 3 4 5; do
+            rm -rf "${TARGET_DIR}"
+            # Publish to gh-pages; create it as an orphan branch on first deploy.
+            if git clone --depth 1 --branch gh-pages "${REMOTE}" "${TARGET_DIR}" 2>/dev/null; then
+              :
+            else
+              git clone --depth 1 "${REMOTE}" "${TARGET_DIR}"
+              git -C "${TARGET_DIR}" checkout --orphan gh-pages
+              git -C "${TARGET_DIR}" rm -rf . >/dev/null 2>&1 || true
+            fi
+
+            rm -rf "${TARGET_DIR:?}/${TONIC_UI_REACT_DOCS_VERSION}"
+            mkdir -p "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}"
+            cp -af artifact/react-docs/** "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}/"
+
+            # Disable Jekyll so Next.js _next/ assets are served
+            touch "${TARGET_DIR}/.nojekyll"
+
+            # Root redirect to the main version label (only when deploying main)
+            if [ "${WRITE_ROOT_REDIRECT}" = "true" ]; then
+              printf '<!doctype html>\n<meta http-equiv="refresh" content="0; url=./%s/">\n' \
+                "${TONIC_UI_REACT_DOCS_VERSION}" > "${TARGET_DIR}/index.html"
+            fi
+
+            cd "${TARGET_DIR}"
+            git add -A
+            if git diff --cached --quiet; then
+              echo "No changes to publish."
+              break
+            fi
+            git commit -m "Deploy ${TONIC_UI_REACT_DOCS_VERSION} (${SOURCE_SHA:0:8}) [skip ci]"
+            if git push origin gh-pages; then
+              echo "Pushed on attempt ${attempt}."
+              break
+            fi
+            echo "Push rejected (attempt ${attempt}); re-cloning and retrying..."
+            cd - >/dev/null
+            sleep $((attempt * 3))
+            if [ "${attempt}" -eq 5 ]; then
+              echo "::error::Failed to push to tonic-ui-docs after 5 attempts"
+              exit 1
+            fi
+          done

--- a/.github/workflows/ci-pr-preview-cleanup.yml
+++ b/.github/workflows/ci-pr-preview-cleanup.yml
@@ -1,0 +1,65 @@
+name: ci-pr-preview-cleanup
+
+on:
+  # Deliberately manual only -- previews are sometimes kept around after a
+  # PR closes, so this never runs automatically. Trigger it explicitly once
+  # a given PR's preview branch is no longer needed.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number whose preview branch should be deleted'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+
+env:
+  TONIC_UI_PREVIEWS_REPO: trendmicro-frontend/tonic-ui-previews
+  TONIC_UI_PREVIEWS_HOST: github.com
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-preview-${{ github.event.inputs.pr_number }}
+      cancel-in-progress: false
+    steps:
+      - name: Validate pr_number input
+        run: |
+          PR_NUMBER="${{ github.event.inputs.pr_number }}"
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number must be a positive integer, got: $PR_NUMBER"
+            exit 1
+          fi
+
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DEPLOY_APP_ID || secrets.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: tonic-ui-previews
+
+      - name: Delete preview branch
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git init --quiet
+          REMOTE_URL="https://x-access-token:${APP_TOKEN}@${TONIC_UI_PREVIEWS_HOST}/${TONIC_UI_PREVIEWS_REPO}.git"
+          BRANCH="pr-${{ github.event.inputs.pr_number }}"
+
+          # --exit-code: 0 = ref found, 2 = connected fine but no such ref
+          # (legitimate no-op), anything else = a real failure (auth, network,
+          # wrong remote, ...) that must not be swallowed.
+          set +e
+          git ls-remote --exit-code --heads "$REMOTE_URL" "$BRANCH" >/dev/null
+          status=$?
+          set -e
+
+          case "$status" in
+            0) git push "$REMOTE_URL" --delete "$BRANCH" ;;
+            2) echo "Branch $BRANCH does not exist on remote, nothing to delete." ;;
+            *) echo "::error::git ls-remote failed with exit code $status"; exit "$status" ;;
+          esac

--- a/.github/workflows/ci-pr-preview.yml
+++ b/.github/workflows/ci-pr-preview.yml
@@ -1,0 +1,119 @@
+name: ci-pr-preview
+
+on:
+  # Automatic build on every PR push is disabled for now -- previews are
+  # triggered manually via workflow_dispatch below. Uncomment this block to
+  # go back to building a preview on every push to an open PR.
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - reopened
+  #     - synchronize
+  #   branches:
+  #     - main
+  #     - 'v[1-9]'        # single-digit exact: v3, v4
+  #     - 'v[1-9]-*'      # single-digit + suffix: v3-stg, v3-alpha
+  #     - 'v[1-9][0-9]'   # double-digit exact: v10, v11
+  #     - 'v[1-9][0-9]-*' # double-digit + suffix: v10-stg
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to build a preview for'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  TONIC_UI_PREVIEWS_REPO: trendmicro-frontend/tonic-ui-previews
+  TONIC_UI_PREVIEWS_HOST: github.com
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-preview-${{ github.event.inputs.pr_number }}
+      cancel-in-progress: false
+    steps:
+      - name: Validate pr_number input
+        run: |
+          PR_NUMBER="${{ github.event.inputs.pr_number }}"
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number must be a positive integer, got: $PR_NUMBER"
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.inputs.pr_number }}/head
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Configure environment variables
+        run: |
+          # `github.event.number` only populates on pull_request-triggered events,
+          # which are disabled above (see the commented-out `on: pull_request` block).
+          # Kept as a fallback for when that trigger is re-enabled.
+          PR_NUMBER="${{ github.event.inputs.pr_number || github.event.number }}"
+          echo "CI_PULL_REQUEST_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
+          echo "CI_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "PREVIEW_BRANCH=pr-${PR_NUMBER}" >> $GITHUB_ENV
+          echo "PREVIEW_STAGING_DIR=${{ runner.temp }}/tonic-ui-preview" >> $GITHUB_ENV
+
+      - name: Install packages
+        run: |
+          yarn install --immutable
+
+      - name: Build public packages
+        run: |
+          yarn build-public
+
+      - name: Assemble preview workspace
+        run: |
+          bash scripts/pr-preview/assemble-packages.sh "$PREVIEW_STAGING_DIR"
+
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DEPLOY_APP_ID || secrets.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: tonic-ui-previews
+
+      - name: Publish preview branch
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          bash scripts/pr-preview/publish-to-branch.sh \
+            "$PREVIEW_STAGING_DIR" \
+            "https://x-access-token:${APP_TOKEN}@${TONIC_UI_PREVIEWS_HOST}/${TONIC_UI_PREVIEWS_REPO}.git" \
+            "$PREVIEW_BRANCH" \
+            "chore: preview for PR #${CI_PULL_REQUEST_NUMBER} (${CI_COMMIT})"
+
+      - name: Comment preview install instructions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          comment=$(
+            bash scripts/pr-preview/list-packages.sh \
+              | node scripts/pr-preview/post-comment.js \
+                  "$TONIC_UI_PREVIEWS_HOST" \
+                  "$TONIC_UI_PREVIEWS_REPO" \
+                  "$PREVIEW_BRANCH" \
+                  "$CI_COMMIT"
+          )
+          yarn add github-issue-comment-cli@file:./scripts/github-issue-comment-cli
+          npx github-issue-comment-cli \
+            --token "$GH_TOKEN" \
+            --pattern "## 📦 Preview packages" \
+            --owner trendmicro-frontend \
+            --repo tonic-ui \
+            --issue-number "${CI_PULL_REQUEST_NUMBER}" \
+            --comment "$comment"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -47,7 +47,7 @@ jobs:
           echo "CI_PULL_REQUEST_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
           echo "MATOMO_URL=//matomo.xdr.trendmicro.com" >> $GITHUB_ENV
           echo "MATOMO_CONTAINER_ID=N8rpl9LU" >> $GITHUB_ENV
-          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui-demo/react/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
+          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui-previews/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
           echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
 
           # $GITHUB_OUTPUT is shared between all steps in a job
@@ -103,18 +103,18 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
+    concurrency:
+      group: deploy-tonic-ui-previews
+      cancel-in-progress: false
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
         with:
-          repository: trendmicro-frontend/tonic-ui-demo
-          ref: gh-pages
-          ssh-key: ${{ secrets.TONIC_UI_DEMO_SSH_PRIVATE_KEY }}
-
-      - name: git config
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          app-id: ${{ vars.DEPLOY_APP_ID || secrets.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: tonic-ui-previews
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -128,7 +128,7 @@ jobs:
         run: |
           echo "CI_COMMIT=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
           echo "CI_PULL_REQUEST_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
-          echo "TONIC_UI_DEMO_PAGES_URL=https://trendmicro-frontend.github.io/tonic-ui-demo" >> $GITHUB_ENV
+          echo "TONIC_UI_PREVIEWS_PAGES_URL=https://trendmicro-frontend.github.io/tonic-ui-previews" >> $GITHUB_ENV
           echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_DOCS_VERSION}" >> $GITHUB_ENV
 
       - name: Download artifact
@@ -142,20 +142,67 @@ jobs:
           mkdir -p artifact/react-docs
           tar -zxvf artifact/react-docs.tar.gz --directory artifact/react-docs
 
-      - name: Deploy to gh-pages
+      - name: Deploy to tonic-ui-previews
+        env:
+          DEPLOY_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
         run: |
-          rm -rf "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          mkdir -p "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          cp -af artifact/react-docs/** "react/${TONIC_UI_REACT_DOCS_VERSION}/"
-          git add "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          git commit -m "Deploy ${TONIC_UI_REACT_DOCS_VERSION} to gh-pages [skip ci]"
-          git push origin gh-pages
-          GIT_LOG_LAST_COMMIT_DATE=`git log --pretty=%ci -n 1`
-          yarn add file:./artifact/github-issue-comment-cli
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          REMOTE="https://x-access-token:${DEPLOY_TOKEN}@github.com/${OWNER}/tonic-ui-previews.git"
+          TARGET_DIR="${RUNNER_TEMP}/tonic-ui-previews-docs"
+
+          for attempt in 1 2 3 4 5; do
+            rm -rf "${TARGET_DIR}"
+            # Publish to gh-pages; create it as an orphan branch on first deploy.
+            if git clone --depth 1 --branch gh-pages "${REMOTE}" "${TARGET_DIR}" 2>/dev/null; then
+              :
+            else
+              git clone --depth 1 "${REMOTE}" "${TARGET_DIR}"
+              git -C "${TARGET_DIR}" checkout --orphan gh-pages
+              git -C "${TARGET_DIR}" rm -rf . >/dev/null 2>&1 || true
+            fi
+
+            rm -rf "${TARGET_DIR:?}/${TONIC_UI_REACT_DOCS_VERSION}"
+            mkdir -p "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}"
+            cp -af artifact/react-docs/** "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}/"
+
+            # Disable Jekyll so Next.js _next/ assets are served
+            touch "${TARGET_DIR}/.nojekyll"
+
+            cd "${TARGET_DIR}"
+            git add -A
+            if git diff --cached --quiet; then
+              echo "No changes to publish."
+              break
+            fi
+            git commit -m "Deploy ${TONIC_UI_REACT_DOCS_VERSION} to gh-pages [skip ci]"
+            if git push origin gh-pages; then
+              echo "Pushed on attempt ${attempt}."
+              break
+            fi
+            echo "Push rejected (attempt ${attempt}); re-cloning and retrying..."
+            cd - >/dev/null
+            sleep $((attempt * 3))
+            if [ "${attempt}" -eq 5 ]; then
+              echo "::error::Failed to push to tonic-ui-previews after 5 attempts"
+              exit 1
+            fi
+          done
+
+          GIT_LOG_LAST_COMMIT_DATE=$(date -u '+%Y-%m-%d %H:%M:%S +0000')
+          echo "GIT_LOG_LAST_COMMIT_DATE=${GIT_LOG_LAST_COMMIT_DATE}" >> $GITHUB_ENV
+
+      - name: Comment preview URL on PR
+        run: |
+          echo '{ "name": "ci-comment", "private": true }' > package.json
+          yarn add github-issue-comment-cli@file:./artifact/github-issue-comment-cli
           npx github-issue-comment-cli \
             --token ${{ secrets.TONIC_UI_PR_ACCESS_TOKEN }} \
-            --pattern "## Tonic UI Demo" \
+            --pattern "## Tonic UI Preview" \
             --owner trendmicro-frontend \
             --repo tonic-ui \
             --issue-number ${CI_PULL_REQUEST_NUMBER} \
-            --comment "## Tonic UI Demo\nOn ${GIT_LOG_LAST_COMMIT_DATE}, PR #${CI_PULL_REQUEST_NUMBER} (${CI_COMMIT}) was successfully deployed. You can view it at the following link:\n${TONIC_UI_DEMO_PAGES_URL}/react/${TONIC_UI_REACT_DOCS_VERSION}/\n"
+            --comment "## Tonic UI Preview\nOn ${GIT_LOG_LAST_COMMIT_DATE}, PR #${CI_PULL_REQUEST_NUMBER} (${CI_COMMIT}) was successfully deployed. You can view it at the following link:\n${TONIC_UI_PREVIEWS_PAGES_URL}/${TONIC_UI_REACT_DOCS_VERSION}/\n"

--- a/.github/workflows/ci-tag.yml
+++ b/.github/workflows/ci-tag.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -43,7 +43,7 @@ jobs:
           echo "CI_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
           echo "MATOMO_URL=//matomo.xdr.trendmicro.com" >> $GITHUB_ENV
           echo "MATOMO_CONTAINER_ID=N8rpl9LU" >> $GITHUB_ENV
-          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui/react/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
+          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui-docs/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
           echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
 
           # $GITHUB_OUTPUT is shared between all steps in a job
@@ -96,24 +96,18 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-tonic-ui-docs
+      cancel-in-progress: false
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
         with:
-          repository: ${{ github.repository }}
-          ref: gh-pages
-
-      - name: git config
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Configure environment variables
-        env:
-          TONIC_UI_REACT_DOCS_VERSION: ${{ needs.build.outputs.TONIC_UI_REACT_DOCS_VERSION }}
-        run: |
-          echo "CI_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
-          echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_DOCS_VERSION}" >> $GITHUB_ENV
+          app-id: ${{ vars.DEPLOY_APP_ID || secrets.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: tonic-ui-docs
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -126,11 +120,54 @@ jobs:
           mkdir -p artifact/react-docs
           tar -zxvf artifact/react-docs.tar.gz --directory artifact/react-docs
 
-      - name: Deploy to gh-pages
+      - name: Deploy to tonic-ui-docs
+        env:
+          DEPLOY_TOKEN: ${{ steps.app-token.outputs.token }}
+          TONIC_UI_REACT_DOCS_VERSION: ${{ needs.build.outputs.TONIC_UI_REACT_DOCS_VERSION }}
+          OWNER: ${{ github.repository_owner }}
+          SOURCE_SHA: ${{ github.sha }}
         run: |
-          rm -rf "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          mkdir -p "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          cp -af artifact/react-docs/** "react/${TONIC_UI_REACT_DOCS_VERSION}/"
-          git add "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          git commit -m "Deploy ${CI_COMMIT:0:8} to gh-pages [skip ci]"
-          git push origin gh-pages
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          REMOTE="https://x-access-token:${DEPLOY_TOKEN}@github.com/${OWNER}/tonic-ui-docs.git"
+          TARGET_DIR="${RUNNER_TEMP}/tonic-ui-docs"
+
+          for attempt in 1 2 3 4 5; do
+            rm -rf "${TARGET_DIR}"
+            # Publish to gh-pages; create it as an orphan branch on first deploy.
+            if git clone --depth 1 --branch gh-pages "${REMOTE}" "${TARGET_DIR}" 2>/dev/null; then
+              :
+            else
+              git clone --depth 1 "${REMOTE}" "${TARGET_DIR}"
+              git -C "${TARGET_DIR}" checkout --orphan gh-pages
+              git -C "${TARGET_DIR}" rm -rf . >/dev/null 2>&1 || true
+            fi
+
+            rm -rf "${TARGET_DIR:?}/${TONIC_UI_REACT_DOCS_VERSION}"
+            mkdir -p "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}"
+            cp -af artifact/react-docs/** "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}/"
+
+            # Disable Jekyll so Next.js _next/ assets are served
+            touch "${TARGET_DIR}/.nojekyll"
+
+            cd "${TARGET_DIR}"
+            git add -A
+            if git diff --cached --quiet; then
+              echo "No changes to publish."
+              break
+            fi
+            git commit -m "Deploy ${TONIC_UI_REACT_DOCS_VERSION} (${SOURCE_SHA:0:8}) [skip ci]"
+            if git push origin gh-pages; then
+              echo "Pushed on attempt ${attempt}."
+              break
+            fi
+            echo "Push rejected (attempt ${attempt}); re-cloning and retrying..."
+            cd - >/dev/null
+            sleep $((attempt * 3))
+            if [ "${attempt}" -eq 5 ]; then
+              echo "::error::Failed to push to tonic-ui-docs after 5 attempts"
+              exit 1
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Tonic UI is a UI component library for React, built with Emotion and Styled Syst
 
 Version | Link
 :-- | :--
-v3 (current) | https://trendmicro-frontend.github.io/tonic-ui/react/v3/
+v3 (current) | https://trendmicro-frontend.github.io/tonic-ui-docs/v3/
 v2 | https://trendmicro-frontend.github.io/tonic-ui/react/v2/
 v1 | https://trendmicro-frontend.github.io/tonic-ui/react/v1/
 
@@ -25,7 +25,7 @@ v1 | https://trendmicro-frontend.github.io/tonic-ui/react/v1/
 
 ## Contributing
 
-If you're interested in contributing to Tonic UI, check out the [contribution guide](https://trendmicro-frontend.github.io/tonic-ui/react/v3/contributing).
+If you're interested in contributing to Tonic UI, check out the [contribution guide](https://trendmicro-frontend.github.io/tonic-ui-docs/v3/contributing).
 
 ## License
 

--- a/packages/react-docs/config/sidebar-routes.js
+++ b/packages/react-docs/config/sidebar-routes.js
@@ -28,6 +28,7 @@ export const routes = [
     ),
     routes: [
       { title: 'Installation', path: 'getting-started/installation' },
+      { title: 'Installation for PR builds', path: 'getting-started/installation-for-pr-builds' },
       { title: 'Usage', path: 'getting-started/usage' },
       {
         title: 'Color mode',

--- a/packages/react-docs/pages/getting-started/installation-for-pr-builds/InstallCommand.js
+++ b/packages/react-docs/pages/getting-started/installation-for-pr-builds/InstallCommand.js
@@ -1,0 +1,16 @@
+import CodeBlock from '@/components/CodeBlock';
+
+// Self-corrects across environments: TONIC_UI_REACT_DOCS_BASE_PATH is baked
+// in per deployment (dev server has none, PR previews and production each
+// get their own), and window.location.origin is always correct at runtime.
+const InstallCommand = () => {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  const basePath = process.env.TONIC_UI_REACT_DOCS_BASE_PATH || '';
+  const command = `curl -fsSL ${origin}${basePath}/tonic-ui-pr-install.sh | bash`;
+
+  return (
+    <CodeBlock code={command} language="bash" />
+  );
+};
+
+export default InstallCommand;

--- a/packages/react-docs/pages/getting-started/installation-for-pr-builds/index.page.mdx
+++ b/packages/react-docs/pages/getting-started/installation-for-pr-builds/index.page.mdx
@@ -1,0 +1,25 @@
+import InstallCommand from './InstallCommand';
+
+# Installation for PR builds
+
+Every pull request built by CI publishes its packages to the [tonic-ui-previews](https://github.com/trendmicro-frontend/tonic-ui-previews) repository, on a branch named `pr-<number>` matching the PR. This lets you try out a PR's changes in a real project before it merges.
+
+## Install with the tonic-ui-pr-install.sh script
+
+Run the installer once in your project directory to set things up:
+
+<InstallCommand />
+
+This will, in your current project directory:
+1. Upgrade Yarn to the latest stable (Berry) release.
+2. Add a `scripts/update-tonic-ui-pr.js` file and a `"tonic-ui:pr"` entry to `package.json`.
+
+Then install a PR build with:
+
+```bash
+yarn tonic-ui:pr <pr-number>
+```
+
+This regenerates the `dependencies` and `resolutions` entries for every `@tonic-ui/*` package published from that PR, including internal cross-references between them, and runs `yarn install`. Run it again anytime — to switch to a different PR, or to re-pull the same PR after it gets new commits.
+
+Peer dependencies (`react`, `react-dom`, `@emotion/react`, `@emotion/styled`, and others depending on which packages you install) are not installed automatically — add them separately if your project doesn't already have them.

--- a/packages/react-docs/public/tonic-ui-pr-install.sh
+++ b/packages/react-docs/public/tonic-ui-pr-install.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Tonic UI preview installer.
+#
+# Sets up Yarn Berry, wires the current project to install @tonic-ui/*
+# packages from a tonic-ui-previews PR branch, and (optionally) runs the
+# install right away.
+#
+# Usage:
+#   curl -fsSL <docs-host>/tonic-ui-pr-install.sh | bash -s -- <pr-number>
+#   wget -qO- <docs-host>/tonic-ui-pr-install.sh | bash -s -- <pr-number>
+#
+# Run with no PR number to only set up the project (no install performed).
+
+set -euo pipefail
+
+REPO_URL="https://github.com/trendmicro-frontend/tonic-ui-previews.git"
+PR_NUMBER="${1:-}"
+
+if [ -n "$PR_NUMBER" ] && ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "Usage: tonic-ui-pr-install.sh [pr-number]" >&2
+  exit 1
+fi
+
+command -v node >/dev/null 2>&1 || { echo "node is required. Install Node.js first: https://nodejs.org"; exit 1; }
+command -v git >/dev/null 2>&1 || { echo "git is required. Install git first."; exit 1; }
+
+if ! command -v yarn >/dev/null 2>&1; then
+  if command -v corepack >/dev/null 2>&1; then
+    echo "Enabling corepack to provide yarn..."
+    corepack enable
+  else
+    echo "yarn is required and no corepack was found to provision it." >&2
+    echo "Install Node.js 16.10+ (ships with corepack) or yarn manually, then re-run this script." >&2
+    exit 1
+  fi
+fi
+
+if [ ! -f package.json ]; then
+  echo "No package.json found, creating one..."
+  yarn init -y
+fi
+
+echo "Upgrading Yarn to the latest stable release..."
+yarn set version stable
+
+YARNRC=".yarnrc.yml"
+touch "$YARNRC"
+grep -q '^nodeLinker:' "$YARNRC" || echo 'nodeLinker: node-modules' >> "$YARNRC"
+if ! grep -q "$REPO_URL" "$YARNRC"; then
+  if grep -q '^approvedGitRepositories:' "$YARNRC"; then
+    printf '  - "%s"\n' "$REPO_URL" >> "$YARNRC"
+  else
+    {
+      echo 'approvedGitRepositories:'
+      printf '  - "%s"\n' "$REPO_URL"
+    } >> "$YARNRC"
+  fi
+fi
+
+if [ ! -f yarn.lock ]; then
+  echo "Running initial yarn install..."
+  yarn install
+fi
+
+mkdir -p scripts
+cat > scripts/update-tonic-ui-pr.js << 'JSEOF'
+#!/usr/bin/env node
+
+// Upgrades Yarn to the latest stable release, regenerates the @tonic-ui/*
+// `dependencies` and `resolutions` entries in package.json to point at a
+// tonic-ui-previews PR branch (pr-<number>), then runs `yarn install`.
+//
+// Usage: node scripts/update-tonic-ui-pr.js <pr-number>
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const REPO_URL = 'https://github.com/trendmicro-frontend/tonic-ui-previews.git';
+const SCOPE = '@tonic-ui';
+
+function run(cmd, args, opts = {}) {
+  execFileSync(cmd, args, { stdio: 'inherit', ...opts });
+}
+
+function withoutScope(obj = {}, scope) {
+  const result = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (!key.startsWith(`${scope}/`)) result[key] = value;
+  }
+  return result;
+}
+
+// yarn.lock pins git `head=` deps to the commit they resolved to. If the same
+// PR branch text is still in package.json (no descriptor change), yarn install
+// trusts the existing lockfile entry and won't notice new commits pushed to
+// the branch. Drop those entries so install is forced to re-resolve them.
+function pruneLockfileEntries(lockfilePath, descriptors) {
+  if (!fs.existsSync(lockfilePath)) return;
+  const blocks = fs.readFileSync(lockfilePath, 'utf8').split('\n\n');
+  const kept = blocks.filter((block) => {
+    const headerLine = block.split('\n', 1)[0];
+    return !descriptors.some((descriptor) => headerLine.includes(descriptor));
+  });
+  fs.writeFileSync(lockfilePath, kept.join('\n\n'));
+}
+
+function main() {
+  const prNumber = process.argv[2];
+  if (!prNumber || !/^\d+$/.test(prNumber)) {
+    console.error('Usage: node scripts/update-tonic-ui-pr.js <pr-number>');
+    process.exit(1);
+  }
+  const branch = `pr-${prNumber}`;
+
+  console.log('Upgrading Yarn to the latest stable release...');
+  run('yarn', ['set', 'version', 'stable']);
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tonic-ui-previews-'));
+  let pkgNames;
+  try {
+    run('git', ['clone', '--no-checkout', '--depth', '1', '--filter=blob:none', '--branch', branch, REPO_URL, tmpDir]);
+    run('git', ['sparse-checkout', 'init', '--cone'], { cwd: tmpDir });
+    run('git', ['sparse-checkout', 'set', 'packages'], { cwd: tmpDir });
+    run('git', ['checkout', branch], { cwd: tmpDir });
+
+    const packagesDir = path.join(tmpDir, 'packages');
+    pkgNames = fs.readdirSync(packagesDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => {
+        const pkgJsonPath = path.join(packagesDir, entry.name, 'package.json');
+        if (!fs.existsSync(pkgJsonPath)) return null;
+        return JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).name;
+      })
+      .filter((name) => name && name.startsWith(`${SCOPE}/`))
+      .sort();
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  if (!pkgNames || pkgNames.length === 0) {
+    console.error(`No ${SCOPE}/* packages found under packages/* on branch ${branch}`);
+    process.exit(1);
+  }
+
+  const entries = {};
+  for (const name of pkgNames) {
+    entries[name] = `${REPO_URL}#workspace=${name}&head=${branch}`;
+  }
+
+  const pkgJsonPath = path.join(__dirname, '..', 'package.json');
+  const rootPkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+
+  rootPkg.dependencies = { ...withoutScope(rootPkg.dependencies, SCOPE), ...entries };
+  rootPkg.resolutions = { ...withoutScope(rootPkg.resolutions, SCOPE), ...entries };
+
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(rootPkg, null, 2) + '\n');
+
+  console.log(`\nUpdated ${pkgNames.length} ${SCOPE}/* package(s) to ${branch}:`);
+  pkgNames.forEach((name) => console.log(`  - ${name}`));
+
+  const lockfilePath = path.join(__dirname, '..', 'yarn.lock');
+  pruneLockfileEntries(lockfilePath, Object.values(entries));
+
+  console.log('\nRunning yarn install...');
+  run('yarn', ['install']);
+}
+
+main();
+JSEOF
+
+node -e '
+const fs = require("fs");
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+pkg.scripts = pkg.scripts || {};
+pkg.scripts["tonic-ui:pr"] = "node scripts/update-tonic-ui-pr.js";
+fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+'
+
+echo "Done. Added scripts/update-tonic-ui-pr.js and the \"tonic-ui:pr\" package.json script."
+
+if [ -n "$PR_NUMBER" ]; then
+  echo "Installing @tonic-ui/* from pr-$PR_NUMBER..."
+  yarn tonic-ui:pr "$PR_NUMBER"
+else
+  echo "Run 'yarn tonic-ui:pr <pr-number>' to install @tonic-ui/* packages from a PR branch."
+fi

--- a/packages/react-docs/tonic-ui.env
+++ b/packages/react-docs/tonic-ui.env
@@ -19,7 +19,7 @@ while IFS=: read -r label branch; do
 
   export "${TONIC_UI_VERSION_PREFIX}_BRANCH=${branch}"
   export "${TONIC_UI_VERSION_PREFIX}_CHANGELOG=${TONIC_UI_REPO_ROOT}/blob/${branch}/packages/react/CHANGELOG.md"
-  export "${TONIC_UI_VERSION_PREFIX}_DOCUMENTATION=${TONIC_UI_REACT_DOCS_URL}/react/${label}"
+  export "${TONIC_UI_VERSION_PREFIX}_DOCUMENTATION=${TONIC_UI_REACT_DOCS_URL}/${label}"
   export "${TONIC_UI_VERSION_PREFIX}_LABEL=${label}"
   export "${TONIC_UI_VERSION_PREFIX}_SOURCE_URL=${TONIC_UI_REPO_ROOT}/tree/${branch}"
 done < <(node -p "require('${CONFIG_PATH}').versions.map(v => \`\${v.label}:\${v.branch}\`).join('\\n')")

--- a/packages/react-docs/tonic-ui.env
+++ b/packages/react-docs/tonic-ui.env
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export TONIC_UI_REACT_DOCS_BASE_PATH=${TONIC_UI_REACT_DOCS_BASE_PATH}
-export TONIC_UI_REACT_DOCS_URL=https://trendmicro-frontend.github.io/tonic-ui
+export TONIC_UI_REACT_DOCS_URL=https://trendmicro-frontend.github.io/tonic-ui-docs
 export TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_DOCS_VERSION:-v3-dev}
 export TONIC_UI_REACT_PACKAGE_VERSION=$(node -p "require('../react/package.json').version")
 export TONIC_UI_REPO_ROOT=https://github.com/trendmicro-frontend/tonic-ui

--- a/scripts/github-issue-comment-cli/bin/cli.js
+++ b/scripts/github-issue-comment-cli/bin/cli.js
@@ -42,8 +42,8 @@ const ghissue = client.issue(`${argv.owner}/${argv.repo}`, argv.issueNumber);
 
 ghissue.comments((err, result) => {
   if (err) {
-    console.log(err);
-    return;
+    console.error(err);
+    process.exit(1);
   }
 
   const comments = result;
@@ -57,7 +57,7 @@ ghissue.comments((err, result) => {
     ghissue.createComment({ body: commentWithLineBreaks }, (err, result) => {
       if (err) {
         console.error(err);
-        return;
+        process.exit(1);
       }
       console.log(result);
     });
@@ -65,7 +65,7 @@ ghissue.comments((err, result) => {
     ghissue.updateComment(comment.id, { body: commentWithLineBreaks }, (err, result) => {
       if (err) {
         console.error(err);
-        return;
+        process.exit(1);
       }
       console.log(result);
     });

--- a/scripts/pr-preview/__tests__/assemble-packages.test.sh
+++ b/scripts/pr-preview/__tests__/assemble-packages.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../../.."  # repo root
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+fixture_root="$work/fixture-repo"
+mkdir -p "$fixture_root/packages/foo/dist"
+cat > "$fixture_root/packages/foo/package.json" <<'JSON'
+{
+  "name": "@tonic-ui/foo",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "files": ["dist"],
+  "dependencies": { "lodash": "^4.0.0" },
+  "devDependencies": { "jest": "^29.0.0" }
+}
+JSON
+echo "module.exports = {};" > "$fixture_root/packages/foo/dist/index.js"
+
+mkdir -p "$fixture_root/packages/bar"
+cat > "$fixture_root/packages/bar/package.json" <<'JSON'
+{ "name": "@tonic-ui/bar", "version": "1.0.0", "private": true }
+JSON
+
+staging="$work/staging"
+bash scripts/pr-preview/assemble-packages.sh "$staging" "$fixture_root"
+
+if [ ! -f "$staging/package.json" ]; then
+  echo "FAIL: expected root package.json in staging dir"
+  exit 1
+fi
+
+if [ -d "$staging/packages/bar" ]; then
+  echo "FAIL: private package bar should not be assembled"
+  exit 1
+fi
+
+if [ ! -f "$staging/packages/foo/dist/index.js" ]; then
+  echo "FAIL: expected packages/foo/dist/index.js to be copied"
+  exit 1
+fi
+
+if jq -e 'has("devDependencies")' "$staging/packages/foo/package.json" >/dev/null; then
+  echo "FAIL: devDependencies should be stripped from the assembled manifest"
+  exit 1
+fi
+
+if [ "$(jq -r '.name' "$staging/packages/foo/package.json")" != "@tonic-ui/foo" ]; then
+  echo "FAIL: expected name to be preserved"
+  exit 1
+fi
+
+# Guard: fail loudly if a package's declared files never got built.
+all_private_root="$work/fixture-repo-unbuilt"
+mkdir -p "$all_private_root/packages/bar"
+cp "$fixture_root/packages/bar/package.json" "$all_private_root/packages/bar/package.json"
+
+if bash scripts/pr-preview/assemble-packages.sh "$work/staging-empty" "$all_private_root" 2>/dev/null; then
+  echo "FAIL: expected assemble-packages.sh to fail when no packages are copied"
+  exit 1
+fi
+
+echo "PASS"

--- a/scripts/pr-preview/__tests__/list-packages.test.sh
+++ b/scripts/pr-preview/__tests__/list-packages.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../../.."  # repo root
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+fixture_root="$work/fixture-repo"
+mkdir -p "$fixture_root/packages/foo" "$fixture_root/packages/bar"
+
+cat > "$fixture_root/packages/foo/package.json" <<'JSON'
+{ "name": "@tonic-ui/foo", "version": "1.0.0" }
+JSON
+
+cat > "$fixture_root/packages/bar/package.json" <<'JSON'
+{ "name": "@tonic-ui/bar", "version": "1.0.0", "private": true }
+JSON
+
+output=$(bash scripts/pr-preview/list-packages.sh "$fixture_root")
+
+found_foo=$(echo "$output" | awk -F'\t' '$1=="@tonic-ui/foo" && $2=="foo" {print "yes"}')
+if [ "$found_foo" != "yes" ]; then
+  echo "FAIL: expected a well-formed @tonic-ui/foo entry, got:"
+  echo "$output"
+  exit 1
+fi
+
+if echo "$output" | awk -F'\t' '$1=="@tonic-ui/bar" {found=1} END{exit !found}'; then
+  echo "FAIL: private package @tonic-ui/bar should be excluded"
+  exit 1
+fi
+
+echo "PASS"

--- a/scripts/pr-preview/__tests__/post-comment.test.js
+++ b/scripts/pr-preview/__tests__/post-comment.test.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const scriptPath = path.join(__dirname, '..', 'post-comment.js');
+const input = '@tonic-ui/react\treact\n@tonic-ui/react-base\treact-base\n';
+
+const output = execFileSync(
+  process.execPath,
+  [scriptPath, 'github.com', 'trendmicro-frontend/tonic-ui-previews', 'pr-123', 'abc1234'],
+  { input, encoding: 'utf8' },
+);
+
+assert.ok(/## \u{1F4E6} Preview packages/u.test(output), 'expected a heading');
+assert.ok(
+  output.includes(
+    '"@tonic-ui/react": "git+https://github.com/trendmicro-frontend/tonic-ui-previews.git#head=pr-123&workspace=@tonic-ui/react"',
+  ),
+  'expected a git dependency snippet for @tonic-ui/react',
+);
+assert.ok(
+  output.includes(
+    '"@tonic-ui/react-base": "git+https://github.com/trendmicro-frontend/tonic-ui-previews.git#head=pr-123&workspace=@tonic-ui/react-base"',
+  ),
+  'expected a git dependency snippet for @tonic-ui/react-base',
+);
+assert.ok(!output.includes('\n'), 'comment body must use literal \\n, not real newlines');
+
+console.log('PASS');

--- a/scripts/pr-preview/__tests__/publish-to-branch.test.sh
+++ b/scripts/pr-preview/__tests__/publish-to-branch.test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../../.."  # repo root
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+bare_remote="$work/remote.git"
+git init --quiet --bare "$bare_remote"
+
+staging="$work/staging"
+mkdir -p "$staging/packages/react"
+echo '{"name":"@tonic-ui/react"}' > "$staging/packages/react/package.json"
+
+bash scripts/pr-preview/publish-to-branch.sh "$staging" "$bare_remote" "pr-999" "chore: preview for PR #999"
+
+checkout="$work/checkout"
+git clone --quiet --branch pr-999 "$bare_remote" "$checkout"
+
+if [ ! -f "$checkout/packages/react/package.json" ]; then
+  echo "FAIL: expected packages/react/package.json in pushed branch"
+  exit 1
+fi
+
+log_count=$(git -C "$checkout" log --oneline | wc -l)
+if [ "$log_count" -ne 1 ]; then
+  echo "FAIL: expected exactly 1 commit on orphan branch, found $log_count"
+  exit 1
+fi
+
+# Re-publish with different content: branch must be replaced, not appended to.
+rm -rf "$staging"
+mkdir -p "$staging/packages/react-base"
+echo '{"name":"@tonic-ui/react-base"}' > "$staging/packages/react-base/package.json"
+
+bash scripts/pr-preview/publish-to-branch.sh "$staging" "$bare_remote" "pr-999" "chore: preview for PR #999 (update)"
+
+rm -rf "$checkout"
+git clone --quiet --branch pr-999 "$bare_remote" "$checkout"
+
+if [ -f "$checkout/packages/react/package.json" ]; then
+  echo "FAIL: stale content from the previous push should not survive an orphan re-push"
+  exit 1
+fi
+
+if [ ! -f "$checkout/packages/react-base/package.json" ]; then
+  echo "FAIL: expected packages/react-base/package.json after update"
+  exit 1
+fi
+
+log_count=$(git -C "$checkout" log --oneline | wc -l)
+if [ "$log_count" -ne 1 ]; then
+  echo "FAIL: expected exactly 1 commit after update, found $log_count"
+  exit 1
+fi
+
+echo "PASS"

--- a/scripts/pr-preview/assemble-packages.sh
+++ b/scripts/pr-preview/assemble-packages.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: assemble-packages.sh <staging-dir> [repo-root]
+# Builds a Yarn-workspaces monorepo skeleton under <staging-dir> containing
+# every non-private package's trimmed manifest and the files listed in its
+# "files" field. Built output must already exist on disk -- run
+# `yarn build-public` before calling this script.
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <staging-dir> [repo-root]" >&2
+  exit 1
+fi
+
+staging_dir="$1"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="${2:-"$(cd "$script_dir/../.." && pwd)"}"
+
+rm -rf "$staging_dir"
+mkdir -p "$staging_dir/packages"
+
+cat > "$staging_dir/package.json" <<'JSON'
+{
+  "name": "tonic-ui-preview",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "packageManager": "yarn@4.17.1"
+}
+JSON
+
+cat > "$staging_dir/.yarnrc.yml" <<'YAML'
+nodeLinker: node-modules
+YAML
+
+copied_any=0
+while IFS=$'\t' read -r name dir; do
+  pkg_dir="$repo_root/packages/$dir"
+  out_dir="$staging_dir/packages/$dir"
+  mkdir -p "$out_dir"
+
+  jq '{
+    name: .name,
+    version: .version,
+    description: .description,
+    main: .main,
+    module: .module,
+    types: .types,
+    exports: .exports,
+    bin: .bin,
+    files: .files,
+    sideEffects: .sideEffects,
+    publishConfig: .publishConfig,
+    dependencies: .dependencies,
+    peerDependencies: .peerDependencies,
+    license: .license,
+    repository: .repository
+  } | with_entries(select(.value != null))' "$pkg_dir/package.json" > "$out_dir/package.json"
+
+  while IFS= read -r f; do
+    src="$pkg_dir/$f"
+    if [ -e "$src" ]; then
+      mkdir -p "$(dirname "$out_dir/$f")"
+      cp -a "$src" "$out_dir/$f"
+      copied_any=1
+    fi
+  done < <(jq -r '(.files // ["dist"])[]' "$pkg_dir/package.json")
+
+  echo "Assembled $name -> packages/$dir"
+done < <(bash "$script_dir/list-packages.sh" "$repo_root")
+
+if [ "$copied_any" -eq 0 ]; then
+  echo "error: no package files were copied -- did you forget to run 'yarn build-public' first?" >&2
+  exit 1
+fi

--- a/scripts/pr-preview/list-packages.sh
+++ b/scripts/pr-preview/list-packages.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: list-packages.sh [repo-root]
+# Prints one line per non-private package under packages/*, tab-separated:
+#   <npm-name>\t<packages-dir-name>
+# repo-root defaults to the real repo root; pass it explicitly in tests.
+
+repo_root="${1:-"$(cd "$(dirname "$0")/../.." && pwd)"}"
+
+for pkg_json in "$repo_root"/packages/*/package.json; do
+  dir="$(basename "$(dirname "$pkg_json")")"
+  private=$(jq -r '.private // false' "$pkg_json")
+  if [ "$private" = "true" ]; then
+    continue
+  fi
+  name=$(jq -r '.name' "$pkg_json")
+  printf '%s\t%s\n' "$name" "$dir"
+done

--- a/scripts/pr-preview/post-comment.js
+++ b/scripts/pr-preview/post-comment.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+'use strict';
+
+// Reads tab-separated "<npm-name>\t<dir>" lines from stdin (see
+// list-packages.sh) and prints a Markdown PR comment listing the
+// git dependency snippet for every package, using literal "\n" so the
+// result can be passed directly to scripts/github-issue-comment-cli.
+//
+// Usage: post-comment.js <host> <repo> <branch> <sha>
+
+const [host, repo, branch, sha] = process.argv.slice(2);
+if (!host || !repo || !branch || !sha) {
+  console.error('Usage: post-comment.js <host> <repo> <branch> <sha>');
+  process.exit(1);
+}
+
+let input = '';
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+process.stdin.on('end', () => {
+  const names = input
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split('\t')[0]);
+
+  const dependencies = {};
+  for (const name of names) {
+    dependencies[name] = `git+https://${host}/${repo}.git#head=${branch}&workspace=${name}`;
+  }
+
+  const snippet = JSON.stringify({ dependencies }, null, 2).replace(/\n/g, '\\n');
+  const body = [
+    '## \u{1F4E6} Preview packages',
+    '',
+    `Built from ${sha}. Install any package from this PR with Yarn (v2+):`,
+    '',
+    '```json',
+    snippet,
+    '```',
+  ].join('\\n');
+
+  process.stdout.write(body);
+});

--- a/scripts/pr-preview/publish-to-branch.sh
+++ b/scripts/pr-preview/publish-to-branch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: publish-to-branch.sh <staging-dir> <remote-url> <branch> <commit-message>
+# Turns <staging-dir> into a single orphan commit and force-pushes it to
+# <branch> on <remote-url>. Never clones the remote -- each call replaces
+# the branch's entire history with one fresh commit.
+
+if [ "$#" -ne 4 ]; then
+  echo "Usage: $0 <staging-dir> <remote-url> <branch> <commit-message>" >&2
+  exit 1
+fi
+
+staging_dir="$1"
+remote_url="$2"
+branch="$3"
+message="$4"
+
+abs_staging_dir="$(cd "$staging_dir" && pwd)"
+
+git -C "$abs_staging_dir" init --quiet -b "$branch"
+git -C "$abs_staging_dir" config user.name "github-actions[bot]"
+git -C "$abs_staging_dir" config user.email "github-actions[bot]@users.noreply.github.com"
+git -C "$abs_staging_dir" add -A
+git -C "$abs_staging_dir" commit --quiet -m "$message"
+git -C "$abs_staging_dir" push --force "$remote_url" "HEAD:refs/heads/$branch"


### PR DESCRIPTION
## Summary

- publish versioned documentation to `tonic-ui-docs` and PR documentation to `tonic-ui-previews`
- add manually triggered PR package preview publishing and cleanup workflows
- add preview assembly, publishing, comment generation, installer scripts, tests, and installation documentation
- carry forward the Yarn Berry-compatible package descriptor and `GITHUB_TOKEN` comment behavior from tonic-one PR #527

## Why

This migrates the PR preview infrastructure from `tonic-one` PRs #523 and #527 so Tonic UI packages and documentation can be tested directly from pull requests without publishing to npm.

## Impact

Maintainers can manually publish or clean up `pr-<number>` preview branches. Consumers can install all public `@tonic-ui/*` workspaces from a preview branch, while existing branch and tag documentation deploys move to the prepared standalone repositories.

## Validation

- `actionlint` for all changed workflows
- PR preview script test suite
- `yarn build-public`
- `yarn workspace @tonic-ui/react-docs lint`
- `yarn workspace @tonic-ui/react-docs build`
- normalized comparison of `ci-pr.yml` and `ci-pr-preview.yml` against tonic-one PR #527