### PR TITLE
ci: deploy v1 docs to standalone repositories

### DIFF
--- a/.github/workflows/ci-branch.yml
+++ b/.github/workflows/ci-branch.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -58,7 +58,7 @@ jobs:
           echo "CI_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
           echo "MATOMO_URL=//matomo.xdr.trendmicro.com" >> $GITHUB_ENV
           echo "MATOMO_CONTAINER_ID=N8rpl9LU" >> $GITHUB_ENV
-          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui/react/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
+          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui-docs/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
           echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
 
           # $GITHUB_OUTPUT is shared between all steps in a job
@@ -106,24 +106,18 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-tonic-ui-docs
+      cancel-in-progress: false
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
         with:
-          repository: ${{ github.repository }}
-          ref: gh-pages
-
-      - name: git config
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Configure environment variables
-        env:
-          TONIC_UI_REACT_DOCS_VERSION: ${{ needs.build.outputs.TONIC_UI_REACT_DOCS_VERSION }}
-        run: |
-          echo "CI_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
-          echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_DOCS_VERSION}" >> $GITHUB_ENV
+          app-id: ${{ vars.DEPLOY_APP_ID || secrets.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: tonic-ui-docs
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -136,11 +130,54 @@ jobs:
           mkdir -p artifact/react-docs
           tar -zxvf artifact/react-docs.tar.gz --directory artifact/react-docs
 
-      - name: Deploy to gh-pages
+      - name: Deploy to tonic-ui-docs
+        env:
+          DEPLOY_TOKEN: ${{ steps.app-token.outputs.token }}
+          TONIC_UI_REACT_DOCS_VERSION: ${{ needs.build.outputs.TONIC_UI_REACT_DOCS_VERSION }}
+          OWNER: ${{ github.repository_owner }}
+          SOURCE_SHA: ${{ github.sha }}
         run: |
-          rm -rf "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          mkdir -p "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          cp -af artifact/react-docs/** "react/${TONIC_UI_REACT_DOCS_VERSION}/"
-          git add "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          git commit -m "Deploy ${CI_COMMIT:0:8} to gh-pages [skip ci]"
-          git push origin gh-pages
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          REMOTE="https://x-access-token:${DEPLOY_TOKEN}@github.com/${OWNER}/tonic-ui-docs.git"
+          TARGET_DIR="${RUNNER_TEMP}/tonic-ui-docs"
+
+          for attempt in 1 2 3 4 5; do
+            rm -rf "${TARGET_DIR}"
+            # Publish to gh-pages; create it as an orphan branch on first deploy.
+            if git clone --depth 1 --branch gh-pages "${REMOTE}" "${TARGET_DIR}" 2>/dev/null; then
+              :
+            else
+              git clone --depth 1 "${REMOTE}" "${TARGET_DIR}"
+              git -C "${TARGET_DIR}" checkout --orphan gh-pages
+              git -C "${TARGET_DIR}" rm -rf . >/dev/null 2>&1 || true
+            fi
+
+            rm -rf "${TARGET_DIR:?}/${TONIC_UI_REACT_DOCS_VERSION}"
+            mkdir -p "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}"
+            cp -af artifact/react-docs/** "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}/"
+
+            # Disable Jekyll so Next.js _next/ assets are served
+            touch "${TARGET_DIR}/.nojekyll"
+
+            cd "${TARGET_DIR}"
+            git add -A
+            if git diff --cached --quiet; then
+              echo "No changes to publish."
+              break
+            fi
+            git commit -m "Deploy ${TONIC_UI_REACT_DOCS_VERSION} (${SOURCE_SHA:0:8}) [skip ci]"
+            if git push origin gh-pages; then
+              echo "Pushed on attempt ${attempt}."
+              break
+            fi
+            echo "Push rejected (attempt ${attempt}); re-cloning and retrying..."
+            cd - >/dev/null
+            sleep $((attempt * 3))
+            if [ "${attempt}" -eq 5 ]; then
+              echo "::error::Failed to push to tonic-ui-docs after 5 attempts"
+              exit 1
+            fi
+          done

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -47,7 +47,7 @@ jobs:
           echo "CI_PULL_REQUEST_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
           echo "MATOMO_URL=//matomo.xdr.trendmicro.com" >> $GITHUB_ENV
           echo "MATOMO_CONTAINER_ID=N8rpl9LU" >> $GITHUB_ENV
-          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui-demo/react/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
+          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui-previews/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
           echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
 
           # $GITHUB_OUTPUT is shared between all steps in a job
@@ -97,18 +97,18 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-tonic-ui-previews
+      cancel-in-progress: false
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
         with:
-          repository: trendmicro-frontend/tonic-ui-demo
-          ref: gh-pages
-          ssh-key: ${{ secrets.TONIC_UI_DEMO_SSH_PRIVATE_KEY }}
-
-      - name: git config
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          app-id: ${{ vars.DEPLOY_APP_ID || secrets.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: tonic-ui-previews
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -122,7 +122,7 @@ jobs:
         run: |
           echo "CI_COMMIT=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
           echo "CI_PULL_REQUEST_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
-          echo "TONIC_UI_DEMO_PAGES_URL=https://trendmicro-frontend.github.io/tonic-ui-demo" >> $GITHUB_ENV
+          echo "TONIC_UI_PREVIEWS_PAGES_URL=https://trendmicro-frontend.github.io/tonic-ui-previews" >> $GITHUB_ENV
           echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_DOCS_VERSION}" >> $GITHUB_ENV
 
       - name: Download artifact
@@ -136,20 +136,67 @@ jobs:
           mkdir -p artifact/react-docs
           tar -zxvf artifact/react-docs.tar.gz --directory artifact/react-docs
 
-      - name: Deploy to gh-pages
+      - name: Deploy to tonic-ui-previews
+        env:
+          DEPLOY_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
         run: |
-          rm -rf "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          mkdir -p "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          cp -af artifact/react-docs/** "react/${TONIC_UI_REACT_DOCS_VERSION}/"
-          git add "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          git commit -m "Deploy ${TONIC_UI_REACT_DOCS_VERSION} to gh-pages [skip ci]"
-          git push origin gh-pages
-          GIT_LOG_LAST_COMMIT_DATE=`git log --pretty=%ci -n 1`
-          yarn add file:./artifact/github-issue-comment-cli
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          REMOTE="https://x-access-token:${DEPLOY_TOKEN}@github.com/${OWNER}/tonic-ui-previews.git"
+          TARGET_DIR="${RUNNER_TEMP}/tonic-ui-previews-docs"
+
+          for attempt in 1 2 3 4 5; do
+            rm -rf "${TARGET_DIR}"
+            # Publish to gh-pages; create it as an orphan branch on first deploy.
+            if git clone --depth 1 --branch gh-pages "${REMOTE}" "${TARGET_DIR}" 2>/dev/null; then
+              :
+            else
+              git clone --depth 1 "${REMOTE}" "${TARGET_DIR}"
+              git -C "${TARGET_DIR}" checkout --orphan gh-pages
+              git -C "${TARGET_DIR}" rm -rf . >/dev/null 2>&1 || true
+            fi
+
+            rm -rf "${TARGET_DIR:?}/${TONIC_UI_REACT_DOCS_VERSION}"
+            mkdir -p "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}"
+            cp -af artifact/react-docs/** "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}/"
+
+            # Disable Jekyll so Next.js _next/ assets are served
+            touch "${TARGET_DIR}/.nojekyll"
+
+            cd "${TARGET_DIR}"
+            git add -A
+            if git diff --cached --quiet; then
+              echo "No changes to publish."
+              break
+            fi
+            git commit -m "Deploy ${TONIC_UI_REACT_DOCS_VERSION} to gh-pages [skip ci]"
+            if git push origin gh-pages; then
+              echo "Pushed on attempt ${attempt}."
+              break
+            fi
+            echo "Push rejected (attempt ${attempt}); re-cloning and retrying..."
+            cd - >/dev/null
+            sleep $((attempt * 3))
+            if [ "${attempt}" -eq 5 ]; then
+              echo "::error::Failed to push to tonic-ui-previews after 5 attempts"
+              exit 1
+            fi
+          done
+
+          GIT_LOG_LAST_COMMIT_DATE=$(date -u '+%Y-%m-%d %H:%M:%S +0000')
+          echo "GIT_LOG_LAST_COMMIT_DATE=${GIT_LOG_LAST_COMMIT_DATE}" >> $GITHUB_ENV
+
+      - name: Comment preview URL on PR
+        run: |
+          echo '{ "name": "ci-comment", "private": true }' > package.json
+          yarn add github-issue-comment-cli@file:./artifact/github-issue-comment-cli
           npx github-issue-comment-cli \
             --token ${{ secrets.TONIC_UI_PR_ACCESS_TOKEN }} \
-            --pattern "## Tonic UI Demo" \
+            --pattern "## Tonic UI Preview" \
             --owner trendmicro-frontend \
             --repo tonic-ui \
             --issue-number ${CI_PULL_REQUEST_NUMBER} \
-            --comment "## Tonic UI Demo\nOn ${GIT_LOG_LAST_COMMIT_DATE}, PR #${CI_PULL_REQUEST_NUMBER} (${CI_COMMIT}) was successfully deployed. You can view it at the following link:\n${TONIC_UI_DEMO_PAGES_URL}/react/${TONIC_UI_REACT_DOCS_VERSION}/\n"
+            --comment "## Tonic UI Preview\nOn ${GIT_LOG_LAST_COMMIT_DATE}, PR #${CI_PULL_REQUEST_NUMBER} (${CI_COMMIT}) was successfully deployed. You can view it at the following link:\n${TONIC_UI_PREVIEWS_PAGES_URL}/${TONIC_UI_REACT_DOCS_VERSION}/\n"

--- a/.github/workflows/ci-tag.yml
+++ b/.github/workflows/ci-tag.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -43,7 +43,7 @@ jobs:
           echo "CI_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
           echo "MATOMO_URL=//matomo.xdr.trendmicro.com" >> $GITHUB_ENV
           echo "MATOMO_CONTAINER_ID=N8rpl9LU" >> $GITHUB_ENV
-          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui/react/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
+          echo "TONIC_UI_REACT_DOCS_BASE_PATH=/tonic-ui-docs/${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
           echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_VERSION}" >> $GITHUB_ENV
 
           # $GITHUB_OUTPUT is shared between all steps in a job
@@ -91,24 +91,18 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-tonic-ui-docs
+      cancel-in-progress: false
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
         with:
-          repository: ${{ github.repository }}
-          ref: gh-pages
-
-      - name: git config
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Configure environment variables
-        env:
-          TONIC_UI_REACT_DOCS_VERSION: ${{ needs.build.outputs.TONIC_UI_REACT_DOCS_VERSION }}
-        run: |
-          echo "CI_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
-          echo "TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_DOCS_VERSION}" >> $GITHUB_ENV
+          app-id: ${{ vars.DEPLOY_APP_ID || secrets.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: tonic-ui-docs
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -121,11 +115,54 @@ jobs:
           mkdir -p artifact/react-docs
           tar -zxvf artifact/react-docs.tar.gz --directory artifact/react-docs
 
-      - name: Deploy to gh-pages
+      - name: Deploy to tonic-ui-docs
+        env:
+          DEPLOY_TOKEN: ${{ steps.app-token.outputs.token }}
+          TONIC_UI_REACT_DOCS_VERSION: ${{ needs.build.outputs.TONIC_UI_REACT_DOCS_VERSION }}
+          OWNER: ${{ github.repository_owner }}
+          SOURCE_SHA: ${{ github.sha }}
         run: |
-          rm -rf "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          mkdir -p "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          cp -af artifact/react-docs/** "react/${TONIC_UI_REACT_DOCS_VERSION}/"
-          git add "react/${TONIC_UI_REACT_DOCS_VERSION}"
-          git commit -m "Deploy ${CI_COMMIT:0:8} to gh-pages [skip ci]"
-          git push origin gh-pages
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          REMOTE="https://x-access-token:${DEPLOY_TOKEN}@github.com/${OWNER}/tonic-ui-docs.git"
+          TARGET_DIR="${RUNNER_TEMP}/tonic-ui-docs"
+
+          for attempt in 1 2 3 4 5; do
+            rm -rf "${TARGET_DIR}"
+            # Publish to gh-pages; create it as an orphan branch on first deploy.
+            if git clone --depth 1 --branch gh-pages "${REMOTE}" "${TARGET_DIR}" 2>/dev/null; then
+              :
+            else
+              git clone --depth 1 "${REMOTE}" "${TARGET_DIR}"
+              git -C "${TARGET_DIR}" checkout --orphan gh-pages
+              git -C "${TARGET_DIR}" rm -rf . >/dev/null 2>&1 || true
+            fi
+
+            rm -rf "${TARGET_DIR:?}/${TONIC_UI_REACT_DOCS_VERSION}"
+            mkdir -p "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}"
+            cp -af artifact/react-docs/** "${TARGET_DIR}/${TONIC_UI_REACT_DOCS_VERSION}/"
+
+            # Disable Jekyll so Next.js _next/ assets are served
+            touch "${TARGET_DIR}/.nojekyll"
+
+            cd "${TARGET_DIR}"
+            git add -A
+            if git diff --cached --quiet; then
+              echo "No changes to publish."
+              break
+            fi
+            git commit -m "Deploy ${TONIC_UI_REACT_DOCS_VERSION} (${SOURCE_SHA:0:8}) [skip ci]"
+            if git push origin gh-pages; then
+              echo "Pushed on attempt ${attempt}."
+              break
+            fi
+            echo "Push rejected (attempt ${attempt}); re-cloning and retrying..."
+            cd - >/dev/null
+            sleep $((attempt * 3))
+            if [ "${attempt}" -eq 5 ]; then
+              echo "::error::Failed to push to tonic-ui-docs after 5 attempts"
+              exit 1
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Tonic UI is a UI component library for React, built with Emotion and Styled Syst
 
 Version | Link
 :-- | :--
-v1 (current) | https://trendmicro-frontend.github.io/tonic-ui/react/v1/
-v0 | https://trendmicro-frontend.github.io/tonic-ui/react/v0/
+v1 (current) | https://trendmicro-frontend.github.io/tonic-ui-docs/v1/
 
 ## Features
 
@@ -24,9 +23,8 @@ v0 | https://trendmicro-frontend.github.io/tonic-ui/react/v0/
 
 ## Contributing
 
-If you're interested in contributing to Tonic UI, check out the [contribution guide](https://trendmicro-frontend.github.io/tonic-ui/react/v1/getting-started/contributing).
+If you're interested in contributing to Tonic UI, check out the [contribution guide](https://trendmicro-frontend.github.io/tonic-ui-docs/v1/getting-started/contributing).
 
 ## License
 
 MIT
-

--- a/packages/react-docs/components/Header.js
+++ b/packages/react-docs/components/Header.js
@@ -50,7 +50,7 @@ const versionMap = Object.fromEntries(
     versionLabel,
     {
       label: versionLabel,
-      url: `${TONIC_UI_REACT_DOCS_URL}/react/${versionLabel}`,
+      url: `${TONIC_UI_REACT_DOCS_URL}/${versionLabel}`,
     },
   ])
 );

--- a/packages/react-docs/tonic-ui.env
+++ b/packages/react-docs/tonic-ui.env
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export TONIC_UI_REACT_DOCS_BASE_PATH=${TONIC_UI_REACT_DOCS_BASE_PATH}
-export TONIC_UI_REACT_DOCS_URL=https://trendmicro-frontend.github.io/tonic-ui
+export TONIC_UI_REACT_DOCS_URL=https://trendmicro-frontend.github.io/tonic-ui-docs
 export TONIC_UI_REACT_DOCS_VERSION=${TONIC_UI_REACT_DOCS_VERSION:-v1-dev}
 export TONIC_UI_REACT_PACKAGE_VERSION=$(node -p "require('../react/package.json').version")
 export TONIC_UI_REPO_ROOT=https://github.com/trendmicro-frontend/tonic-ui
@@ -19,7 +19,7 @@ while IFS=: read -r label branch; do
 
   export "${TONIC_UI_VERSION_PREFIX}_BRANCH=${branch}"
   export "${TONIC_UI_VERSION_PREFIX}_CHANGELOG=${TONIC_UI_REPO_ROOT}/blob/${branch}/packages/react/CHANGELOG.md"
-  export "${TONIC_UI_VERSION_PREFIX}_DOCUMENTATION=${TONIC_UI_REACT_DOCS_URL}/react/${label}"
+  export "${TONIC_UI_VERSION_PREFIX}_DOCUMENTATION=${TONIC_UI_REACT_DOCS_URL}/${label}"
   export "${TONIC_UI_VERSION_PREFIX}_LABEL=${label}"
   export "${TONIC_UI_VERSION_PREFIX}_SOURCE_URL=${TONIC_UI_REPO_ROOT}/tree/${branch}"
 done < <(node -p "require('${CONFIG_PATH}').versions.map(v => \`\${v.label}:\${v.branch}\`).join('\\n')")

--- a/scripts/github-issue-comment-cli/bin/cli.js
+++ b/scripts/github-issue-comment-cli/bin/cli.js
@@ -42,8 +42,8 @@ const ghissue = client.issue(`${argv.owner}/${argv.repo}`, argv.issueNumber);
 
 ghissue.comments((err, result) => {
   if (err) {
-    console.log(err);
-    return;
+    console.error(err);
+    process.exit(1);
   }
 
   const comments = result;
@@ -57,7 +57,7 @@ ghissue.comments((err, result) => {
     ghissue.createComment({ body: commentWithLineBreaks }, (err, result) => {
       if (err) {
         console.error(err);
-        return;
+        process.exit(1);
       }
       console.log(result);
     });
@@ -65,7 +65,7 @@ ghissue.comments((err, result) => {
     ghissue.updateComment(comment.id, { body: commentWithLineBreaks }, (err, result) => {
       if (err) {
         console.error(err);
-        return;
+        process.exit(1);
       }
       console.log(result);
     });


### PR DESCRIPTION
## Summary

- deploy branch and tag documentation to `tonic-ui-docs`
- deploy existing PR documentation builds to `tonic-ui-previews`
- authenticate deployments with the prepared GitHub App credentials
- update v1 documentation links and remove the v0 README entry
- make PR comment failures fail the workflow

This intentionally does not add package preview generation, `ci-pr-preview.yml`, or `ci-pr-preview-cleanup.yml`.

## Validation

- `actionlint .github/workflows/ci-branch.yml .github/workflows/ci-pr.yml .github/workflows/ci-tag.yml`
- `bash -n packages/react-docs/tonic-ui.env`
- `node --check scripts/github-issue-comment-cli/bin/cli.js`
- `git diff --check`