### PR TITLE
fix: PR preview install script bugs (yarnrc insertion, hydration mismatch)

### DIFF
--- a/packages/react-docs/pages/getting-started/installation-for-pr-builds/InstallCommand.js
+++ b/packages/react-docs/pages/getting-started/installation-for-pr-builds/InstallCommand.js
@@ -1,10 +1,18 @@
+import { useEffect, useState } from 'react';
 import CodeBlock from '@/components/CodeBlock';
 
 // Self-corrects across environments: TONIC_UI_REACT_DOCS_BASE_PATH is baked
 // in per deployment (dev server has none, PR previews and production each
 // get their own), and window.location.origin is always correct at runtime.
 const InstallCommand = () => {
-  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  // Start empty so the client's initial render matches the server-rendered
+  // HTML, then fill in the origin post-mount to avoid a hydration mismatch.
+  const [origin, setOrigin] = useState('');
+
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
+
   const basePath = process.env.TONIC_UI_REACT_DOCS_BASE_PATH || '';
   const command = `curl -fsSL ${origin}${basePath}/tonic-ui-pr-install.sh | bash`;
 

--- a/packages/react-docs/public/tonic-ui-pr-install.sh
+++ b/packages/react-docs/public/tonic-ui-pr-install.sh
@@ -46,9 +46,15 @@ yarn set version stable
 YARNRC=".yarnrc.yml"
 touch "$YARNRC"
 grep -q '^nodeLinker:' "$YARNRC" || echo 'nodeLinker: node-modules' >> "$YARNRC"
-if ! grep -q "$REPO_URL" "$YARNRC"; then
+if ! grep -qF -- "$REPO_URL" "$YARNRC"; then
   if grep -q '^approvedGitRepositories:' "$YARNRC"; then
-    printf '  - "%s"\n' "$REPO_URL" >> "$YARNRC"
+    # Insert right after the key line so the new item stays nested under
+    # approvedGitRepositories even if other top-level keys follow it later
+    # in the file -- appending to EOF would land under whichever key is last.
+    awk -v line="  - \"$REPO_URL\"" '
+      { print }
+      /^approvedGitRepositories:/ && !done { print line; done=1 }
+    ' "$YARNRC" > "$YARNRC.tmp" && mv "$YARNRC.tmp" "$YARNRC"
   else
     {
       echo 'approvedGitRepositories:'


### PR DESCRIPTION
## Summary

Two bugs found while backporting this repo's PR #1180 package-preview feature (tonic-ui-pr-install.sh / InstallCommand.js) to a downstream fork:

- `tonic-ui-pr-install.sh`: appending a new `approvedGitRepositories` entry to EOF when the key already exists — with other top-level keys after it — can nest the new item under the wrong key, producing incorrect YAML. Now inserts the entry immediately after the `approvedGitRepositories:` line instead, which is always safe for a YAML block sequence. Also switched to fixed-string `grep -qF` so the repo URL isn't parsed as a regex.
- `InstallCommand.js`: `window.location.origin` differs between SSR (empty) and the client's first render, causing a hydration mismatch inside `CodeBlock`'s `LiveEditor`. Now computed in a `useEffect` so the client's initial render matches the server-rendered HTML.

## Why

Correctness fix for the PR-preview installer flow; the YAML bug can silently corrupt a consumer's `.yarnrc.yml`, and the hydration mismatch produces a React warning (and a visible flash) on the docs site.

## Test plan

- [x] Reproduced the YAML-nesting bug against a fixture `.yarnrc.yml` with a trailing unrelated key, confirmed the fix keeps the new entry nested correctly (validated with `yaml.safe_load`)
- [ ] Manual smoke: run `tonic-ui-pr-install.sh` against a project with an existing `.yarnrc.yml` that already has `approvedGitRepositories` followed by another key
- [ ] Manual smoke: load `installation-for-pr-builds` docs page and confirm no hydration warning in the browser console