### PR TITLE
fix(ci): source pr-preview tooling scripts from a trusted ref

### DIFF
--- a/.github/workflows/ci-pr-preview.yml
+++ b/.github/workflows/ci-pr-preview.yml
@@ -51,19 +51,6 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.inputs.pr_number }}/head
 
-      # Preview tooling (scripts/pr-preview, scripts/github-issue-comment-cli)
-      # must come from a trusted ref, not the PR's own checkout above --
-      # otherwise a PR could modify these scripts to exfiltrate the App
-      # token minted below.
-      - name: Checkout trusted preview tooling
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.sha }}
-          path: ${{ env.PREVIEW_TOOLING_DIR }}
-          sparse-checkout: |
-            scripts/pr-preview
-            scripts/github-issue-comment-cli
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -87,6 +74,21 @@ jobs:
       - name: Build public packages
         run: |
           yarn build-public
+
+      # Preview tooling (scripts/pr-preview, scripts/github-issue-comment-cli)
+      # must come from a trusted ref, not the PR's own checkout above -- and
+      # must be fetched only after all PR-controlled build steps (Install
+      # packages, Build public packages) have finished, since those steps
+      # run arbitrary PR-controlled code that could otherwise tamper with
+      # this checkout before it's used.
+      - name: Checkout trusted preview tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: ${{ env.PREVIEW_TOOLING_DIR }}
+          sparse-checkout: |
+            scripts/pr-preview
+            scripts/github-issue-comment-cli
 
       - name: Assemble preview workspace
         run: |
@@ -112,8 +114,6 @@ jobs:
             "chore: preview for PR #${CI_PULL_REQUEST_NUMBER} (${CI_COMMIT})"
 
       - name: Comment preview install instructions
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           comment=$(
             bash "$PREVIEW_TOOLING_DIR/scripts/pr-preview/list-packages.sh" "$GITHUB_WORKSPACE" \
@@ -123,8 +123,11 @@ jobs:
                   "$PREVIEW_BRANCH" \
                   "$CI_COMMIT"
           )
-          yarn add "github-issue-comment-cli@file:./${PREVIEW_TOOLING_DIR}/scripts/github-issue-comment-cli"
-          npx github-issue-comment-cli \
+          # No GH_TOKEN in scope for this install -- it targets the PR's own
+          # (untrusted) root package.json/yarn.lock and could run lifecycle
+          # scripts that would otherwise be able to read the token.
+          YARN_ENABLE_SCRIPTS=false yarn add "github-issue-comment-cli@file:./${PREVIEW_TOOLING_DIR}/scripts/github-issue-comment-cli"
+          GH_TOKEN="${{ github.token }}" npx github-issue-comment-cli \
             --token "$GH_TOKEN" \
             --pattern "## 📦 Preview packages" \
             --owner trendmicro-frontend \

--- a/.github/workflows/ci-pr-preview.yml
+++ b/.github/workflows/ci-pr-preview.yml
@@ -29,6 +29,7 @@ permissions:
 env:
   TONIC_UI_PREVIEWS_REPO: trendmicro-frontend/tonic-ui-previews
   TONIC_UI_PREVIEWS_HOST: github.com
+  PREVIEW_TOOLING_DIR: ci-trusted-tooling
 
 jobs:
   preview:
@@ -49,6 +50,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.inputs.pr_number }}/head
+
+      # Preview tooling (scripts/pr-preview, scripts/github-issue-comment-cli)
+      # must come from a trusted ref, not the PR's own checkout above --
+      # otherwise a PR could modify these scripts to exfiltrate the App
+      # token minted below.
+      - name: Checkout trusted preview tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: ${{ env.PREVIEW_TOOLING_DIR }}
+          sparse-checkout: |
+            scripts/pr-preview
+            scripts/github-issue-comment-cli
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -76,7 +90,7 @@ jobs:
 
       - name: Assemble preview workspace
         run: |
-          bash scripts/pr-preview/assemble-packages.sh "$PREVIEW_STAGING_DIR"
+          bash "$PREVIEW_TOOLING_DIR/scripts/pr-preview/assemble-packages.sh" "$PREVIEW_STAGING_DIR" "$GITHUB_WORKSPACE"
 
       - name: Mint GitHub App installation token
         id: app-token
@@ -91,7 +105,7 @@ jobs:
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          bash scripts/pr-preview/publish-to-branch.sh \
+          bash "$PREVIEW_TOOLING_DIR/scripts/pr-preview/publish-to-branch.sh" \
             "$PREVIEW_STAGING_DIR" \
             "https://x-access-token:${APP_TOKEN}@${TONIC_UI_PREVIEWS_HOST}/${TONIC_UI_PREVIEWS_REPO}.git" \
             "$PREVIEW_BRANCH" \
@@ -102,14 +116,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           comment=$(
-            bash scripts/pr-preview/list-packages.sh \
-              | node scripts/pr-preview/post-comment.js \
+            bash "$PREVIEW_TOOLING_DIR/scripts/pr-preview/list-packages.sh" "$GITHUB_WORKSPACE" \
+              | node "$PREVIEW_TOOLING_DIR/scripts/pr-preview/post-comment.js" \
                   "$TONIC_UI_PREVIEWS_HOST" \
                   "$TONIC_UI_PREVIEWS_REPO" \
                   "$PREVIEW_BRANCH" \
                   "$CI_COMMIT"
           )
-          yarn add github-issue-comment-cli@file:./scripts/github-issue-comment-cli
+          yarn add "github-issue-comment-cli@file:./${PREVIEW_TOOLING_DIR}/scripts/github-issue-comment-cli"
           npx github-issue-comment-cli \
             --token "$GH_TOKEN" \
             --pattern "## 📦 Preview packages" \


### PR DESCRIPTION
## Summary

The `ci-pr-preview` job checks out the PR's own head ref, then later steps run `scripts/pr-preview/*.sh` and `scripts/github-issue-comment-cli` from that same untrusted checkout while the App token minted for `tonic-ui-previews` is live in the environment. A PR could modify those scripts to exfiltrate the token.

(Same pattern found and fixed in `agentic-ui` and `tonic-one`, both under different orgs/hosts but sharing this workflow template.)

## Fix

- Add a second `actions/checkout`, sparse-checked-out at `github.sha` (the ref the workflow was dispatched from, which requires write access to choose) into `ci-trusted-tooling/`, covering only `scripts/pr-preview` and `scripts/github-issue-comment-cli`.
- Point every step that runs those scripts at the trusted copy instead of the PR's own checkout. Package sources being previewed still come from the PR ref.

## Out of scope
- The comment step still uses `github.token`. Unlike `agentic-ui`/`tonic-one`, I haven't confirmed whether this repo's `default_workflow_permissions` is the read-only ceiling that forces an App-token swap there — left as-is pending that check.

## Test plan
- [ ] Manually dispatch `ci-pr-preview` against an open PR and confirm the full flow still succeeds with tooling sourced from `ci-trusted-tooling/`.